### PR TITLE
Fix mobile css caching

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=2">
 
     
   </head>

--- a/analytics.html
+++ b/analytics.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Attendance Analytics</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=2">
 
 </head>
 <body>

--- a/createEvent.html
+++ b/createEvent.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Create Poker Night</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=2">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
 
 </head>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>BroTime Poker CRM</title>
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="styles.css?v=2" />
   </head>
   <body>
     <div class="home-container">
@@ -19,6 +19,14 @@
         <a href="viewEvents.html" class="home-button">📖 View Events</a>
         <a href="analytics.html" class="home-button">📊 Analytics</a>
       </div>
+      <div class="mobile-only">Mobile breakpoint active</div>
     </div>
+    <script>
+      const mobileDiv = document.querySelector('.mobile-only');
+      const divStyle = window.getComputedStyle(mobileDiv);
+      if (divStyle.display !== 'none') {
+        console.log('Mobile-only element is visible');
+      }
+    </script>
   </body>
 </html>

--- a/playerAdd.html
+++ b/playerAdd.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>BroTime CRM - Add Player</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=2">
 
 </head>
 <body>

--- a/players_list.html
+++ b/players_list.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Players List</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=2">
 
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,10 @@ body {
   overflow-x: hidden;
 }
 
+.mobile-only {
+  display: none;
+}
+
 h1,
 h2,
 .page-title {
@@ -460,5 +464,9 @@ button {
     flex-direction: column;
     align-items: center;
     gap: 0.75rem;
+  }
+
+  .mobile-only {
+    display: block;
   }
 }

--- a/viewEvents.html
+++ b/viewEvents.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>View Events</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=2">
 
 
 </head>


### PR DESCRIPTION
## Summary
- add `?v=2` cache-busting query param when linking `styles.css`
- create `.mobile-only` helper class and media query rule
- embed small script in index page to log when the mobile breakpoint is active

## Testing
- `npx prettier --check index.html 404.html analytics.html createEvent.html playerAdd.html players_list.html viewEvents.html styles.css` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_685101cccff083309158b45605bf1851