### PR TITLE
Fix mobile layout padding and navbar overlay

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -11,8 +11,8 @@
  <div id="navbar-placeholder"></div>
 
 
-  <main class="content page-content">
-    <div class="page-header">
+  <main class="page-content">
+    <div class="page-header mobile-offset">
       <h1 class="page-title">📊 Attendance Analytics</h1>
     </div>
     <div class="stats">

--- a/createEvent.html
+++ b/createEvent.html
@@ -15,7 +15,7 @@
    <div id="liveEvents"></div>
 
   <div class="container">
-    <div class="page-header">
+    <div class="page-header mobile-offset">
       <h1 class="page-title">Create New Poker Night Event</h1>
     </div>
     <form id="eventForm">

--- a/playerAdd.html
+++ b/playerAdd.html
@@ -12,7 +12,7 @@
 <main class="page-content">
 
   <div class="container">
-    <div class="page-header">
+    <div class="page-header mobile-offset">
       <h1 class="page-title">Add a New Player</h1>
     </div>
     <form id="playerForm">

--- a/players_list.html
+++ b/players_list.html
@@ -13,7 +13,7 @@
 
 
   <div class="container">
-    <div class="page-header">
+    <div class="page-header mobile-offset">
       <h1 class="page-title">📇 Player Directory</h1>
     </div>
      <div id="coreSection" class="section">

--- a/styles.css
+++ b/styles.css
@@ -58,6 +58,10 @@ h2,
   box-sizing: border-box;
 }
 
+.mobile-offset {
+  margin-top: 1rem;
+}
+
 /* Navbar styling */
 .navbar {
   display: flex;
@@ -362,14 +366,14 @@ button {
 @media (max-width: 768px) {
   .nav-links {
     position: fixed;
-    top: 60px; /* height of navbar */
+    top: 0;
     left: 0;
     width: 100%;
     background-color: #333;
-    z-index: 1000;
+    z-index: 1100;
     display: none;
     flex-direction: column;
-    padding: 10px 0;
+    padding: 70px 0 10px; /* account for navbar height */
   }
 
   .nav-links.show {
@@ -388,13 +392,15 @@ button {
   }
 }
 
-/* Disable fixed navbar on mobile landscape */
+/* Ensure layout works in mobile landscape */
 @media (max-width: 768px) and (orientation: landscape) {
   .navbar {
-    position: static;
+    position: fixed;
+    top: 0;
+    width: 100%;
   }
   .page-content {
-    padding-top: 0;
+    padding-top: 70px;
   }
 }
 
@@ -459,11 +465,11 @@ button {
 
   .nav-links {
     position: fixed;
-    top: 60px;
+    top: 0;
     left: 0;
     width: 100%;
     background-color: #111;
-    z-index: 1000;
+    z-index: 1100;
     display: none;
     flex-direction: column;
     align-items: center;
@@ -472,11 +478,11 @@ button {
   .nav-links.show {
     display: flex;
     position: fixed;
-    top: 60px;
+    top: 0;
     left: 0;
     width: 100%;
     background-color: #111;
-    z-index: 1000;
+    z-index: 1100;
   }
 
   .hamburger {

--- a/viewEvents.html
+++ b/viewEvents.html
@@ -13,7 +13,7 @@
 <main class="page-content">
 
 
-  <div class="page-header">
+  <div class="page-header mobile-offset">
     <h1 class="page-title">🗓️ Poker Night Events</h1>
   </div>
   <div id="eventList"></div>


### PR DESCRIPTION
## Summary
- add `mobile-offset` class and adjust page headers to use it
- unify analytics `<main>` markup
- ensure nav dropdown overlays all content and is positioned at top
- keep navbar fixed in mobile landscape

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee2f3d708330999d0f4542ba9695