### PR TITLE
Fix navbar flex layout on mobile

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -1,5 +1,6 @@
 <header class="navbar">
   <a href="index.html" class="logo">🃏 BroTime CRM</a>
+  <button class="hamburger" id="hamburgerBtn" aria-label="Toggle navigation">☰</button>
   <nav class="nav-links" id="navLinks" role="navigation">
     <a href="playerAdd.html" class="nav-item">➕ Add Player</a>
     <a href="createEvent.html" class="nav-item">🗓️ Create Event</a>
@@ -7,5 +8,4 @@
     <a href="viewEvents.html" class="nav-item">🗃️ View Events</a>
     <a href="analytics.html" class="nav-item">📊 Analytics</a>
   </nav>
-  <button class="hamburger" id="hamburgerBtn" aria-label="Toggle navigation">☰</button>
 </header>

--- a/styles.css
+++ b/styles.css
@@ -478,9 +478,10 @@ button {
   }
 
   .navbar {
+    display: flex;
     flex-direction: row;
-    align-items: center;
     justify-content: space-between;
+    align-items: center;
   }
 
   .nav-links {


### PR DESCRIPTION
## Summary
- reorder hamburger before nav-links
- enforce flexbox rules for mobile navbar

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68523d7ed96483308d2b64f6da9153f8