### PR TITLE
Fix chart not mounting in analytics page

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -55,6 +55,9 @@
     <script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
     <script type="module">
+      const React = window.React;
+      const ReactDOM = window.ReactDOM;
+      const Recharts = window.Recharts;
       import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
       import {
         getFirestore,
@@ -265,22 +268,22 @@
             XAxis,
             YAxis,
             Tooltip,
-          } = window.Recharts;
+          } = Recharts;
 
-          const chartElement = window.React.createElement(
+          const chartElement = React.createElement(
             ResponsiveContainer,
             { width: "100%", height: 300 },
-            window.React.createElement(
+            React.createElement(
               BarChart,
               { data: chartData },
-              window.React.createElement(XAxis, { dataKey: "name" }),
-              window.React.createElement(YAxis, null),
-              window.React.createElement(Tooltip, null),
-              window.React.createElement(Bar, { dataKey: "count", fill: "#00bcd4" })
+              React.createElement(XAxis, { dataKey: "name" }),
+              React.createElement(YAxis, null),
+              React.createElement(Tooltip, null),
+              React.createElement(Bar, { dataKey: "count", fill: "#00bcd4" })
             )
           );
 
-          window.ReactDOM.render(chartElement, chartRoot);
+          ReactDOM.createRoot(chartRoot).render(chartElement);
 
         } catch (err) {
           console.error("Failed to load analytics", err);


### PR DESCRIPTION
## Summary
- ensure React, ReactDOM and Recharts globals are stored in local vars
- create React root with `createRoot` to mount the Recharts bar chart

## Testing
- `pre-commit run --files analytics.html` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563be3a0888330b97f6ae4e51721e6