### PR TITLE
Add module logging on analytics load

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -116,6 +116,7 @@
       }
 
       async function buildAnalytics() {
+        console.log('React modules:', window.React, window.ReactDOM, window.Recharts);
         try {
           const [playersSnap, eventsSnap] = await Promise.all([
             getDocs(collection(db, "players")),


### PR DESCRIPTION
## Summary
- log the React modules when analytics page loads

## Testing
- `pre-commit run --files analytics.html` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858c44c10c08330a251ac4f1f764f10