### PR TITLE
Improve chart diagnostics

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -217,6 +217,12 @@
             console.error("attendanceChart element not found");
             return;
           }
+          const rect = chartRoot.getBoundingClientRect();
+          console.log("attendanceChart size:", rect);
+          if (rect.height === 0) {
+            msgEl.textContent =
+              "Chart container has zero height. Adjust layout to display data.";
+          }
           chartRoot.innerHTML = "";
 
           const allNames = Object.values(playerInfo)


### PR DESCRIPTION
## Summary
- log the size of the attendance chart container
- show a helpful message if the chart container has zero height

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858c44e40cc833090736082c0b8a6dc