### PR TITLE
Wrap analytics code in DOMContentLoaded

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -52,38 +52,43 @@
     </main>
 
     <script type="module">
-      import React from "https://esm.sh/react";
-      import ReactDOM from "https://esm.sh/react-dom";
-      import {
-        ResponsiveContainer,
-        BarChart,
-        Bar,
-        XAxis,
-        YAxis,
-        Tooltip
-      } from "https://esm.sh/recharts";
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-      import {
-        getFirestore,
-        collection,
-        getDocs,
-        getDoc,
-        doc,
-      } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+      window.addEventListener("DOMContentLoaded", async () => {
+        const React = (await import("https://esm.sh/react")).default;
+        const ReactDOM = (await import("https://esm.sh/react-dom")).default;
+        const {
+          ResponsiveContainer,
+          BarChart,
+          Bar,
+          XAxis,
+          YAxis,
+          Tooltip,
+        } = await import("https://esm.sh/recharts");
+        const { initializeApp } = await import(
+          "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"
+        );
+        const {
+          getFirestore,
+          collection,
+          getDocs,
+          getDoc,
+          doc,
+        } = await import(
+          "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js"
+        );
 
-      const firebaseConfig = {
-        apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-        authDomain: "poker-crm.firebaseapp.com",
-        projectId: "poker-crm",
-        storageBucket: "poker-crm.appspot.com",
-        messagingSenderId: "218784808902",
-        appId: "1:218784808902:web:c587bdf584d704f7733107",
-      };
+        const firebaseConfig = {
+          apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
+          authDomain: "poker-crm.firebaseapp.com",
+          projectId: "poker-crm",
+          storageBucket: "poker-crm.appspot.com",
+          messagingSenderId: "218784808902",
+          appId: "1:218784808902:web:c587bdf584d704f7733107",
+        };
 
-      const app = initializeApp(firebaseConfig);
-      const db = getFirestore(app);
+        const app = initializeApp(firebaseConfig);
+        const db = getFirestore(app);
 
-      function getPlayerEarningsStats(playerName, allEvents) {
+        function getPlayerEarningsStats(playerName, allEvents) {
         const relevant = allEvents.filter((ev) =>
           ev.attendees.some((p) => p.name === playerName)
         );
@@ -286,7 +291,8 @@
         }
       }
 
-      window.addEventListener("DOMContentLoaded", buildAnalytics);
+        await buildAnalytics();
+      });
     </script>
     <script>
       fetch("nav.html")


### PR DESCRIPTION
## Summary
- prevent early execution of analytics code by wrapping logic
- remove old listener and call buildAnalytics after DOM loads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858c44ce19483309c6bcf3b0cb1b3a5