### PR TITLE
Fix analytics chart label orientation and filter core players

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -206,6 +206,10 @@
               });
 
               const chartData = Object.entries(attendanceCounts)
+                .filter(([name]) => {
+                  const player = players.find((p) => p.name === name);
+                  return !player || player.role !== "core";
+                })
                 .map(([name, count]) => ({ name, count }))
                 .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -282,8 +286,8 @@
                   { data: chartData },
                   React.createElement(XAxis, {
                     dataKey: "name",
-                    angle: -45,
-                    textAnchor: "end",
+                    angle: 45,
+                    textAnchor: "start",
                     interval: 0,
                   }),
                   React.createElement(YAxis, null),


### PR DESCRIPTION
## Summary
- rotate chart labels clockwise to preserve first names
- remove core members from attendance chart data

## Testing
- `pre-commit run --files analytics.html` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685af1a1144c8330a269bc7fa040c4e5