### PR TITLE
Ignore placeholder earnings in analytics stats

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -78,8 +78,14 @@
           const app = initializeApp(firebaseConfig);
           const db = getFirestore(app);
 
+          function filterValidEarnings(history) {
+            return (history || []).filter(
+              (e) => typeof e.amount === "number" && e.amount !== 100,
+            );
+          }
+
           function getPlayerEarningsStats(playerDoc) {
-            const history = playerDoc.earningsHistory || [];
+            const history = filterValidEarnings(playerDoc.earningsHistory);
             if (!history.length)
               return {
                 totalEarnings: "N/A",
@@ -100,7 +106,6 @@
             );
 
             for (const { amount } of sorted) {
-              if (typeof amount !== "number") continue;
               total += amount;
               earningsOverTime.push({ earnings: amount });
               if (amount > 0) wins++;

--- a/viewEvents.html
+++ b/viewEvents.html
@@ -114,8 +114,16 @@
           .join("")}</ul></div>
         <div class="attendees"><strong>Attended:</strong><ul>${ev.attended
           .map(
-            (p) =>
-              `<li>${p.name}${p.earnings !== undefined ? " " + "(" + (p.earnings >= 0 ? "+" : "") + Number(p.earnings).toFixed(2) + ")" : ""}</li>`,
+            (p) => {
+              const val = Number(p.earnings);
+              let display = "";
+              if (p.earnings !== undefined) {
+                display = val === 100
+                  ? " (NA)"
+                  : ` (${val >= 0 ? "+" : ""}${val.toFixed(2)})`;
+              }
+              return `<li>${p.name}${display}</li>`;
+            },
           )
           .join("")}</ul></div>
       `;


### PR DESCRIPTION
## Summary
- filter earnings to exclude placeholder `100` values
- use new filter for player stats in analytics
- replace placeholder earnings with `NA` on event view page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2e6b364483309e46c240d7470afa