### PR TITLE
Store player ID for analytics mapping

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -165,6 +165,7 @@
               playersSnap.forEach((d) => {
                 const data = d.data();
                 playerInfo[d.id] = {
+                  id: d.id,
                   name: data.name,
                   firstName: data.firstName || (data.name || "").split(" ")[0],
                   role: data.role,
@@ -193,7 +194,7 @@
                 averageAttendance;
 
               const players = Object.values(playerInfo).map((p) => ({
-                id: p.id, // Add player ID
+                id: p.id,
                 name: p.name,
                 firstName: p.firstName,
                 role: p.role,


### PR DESCRIPTION
## Summary
- include `id` field when collecting player info
- build the players list using that stored id

## Testing
- `npm test` *(fails: no test specified)*
- `pip install pre-commit` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_685b661cb67c83309045fc575e958e12