### PR TITLE
Use player IDs for attendance charts

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -165,6 +165,7 @@
               playersSnap.forEach((d) => {
                 const data = d.data();
                 playerInfo[d.id] = {
+                  id: d.id,
                   name: data.name,
                   firstName: data.firstName || (data.name || "").split(" ")[0],
                   role: data.role,
@@ -180,7 +181,7 @@
 
               Object.values(playerInfo).forEach((player) => {
                 const count = getValidAttendanceCount(player);
-                attendanceCounts[player.name] = count;
+                attendanceCounts[player.id] = count;
                 totalAttendees += count;
               });
 
@@ -193,11 +194,11 @@
                 averageAttendance;
 
               const players = Object.values(playerInfo).map((p) => ({
-                id: p.id, // Add player ID
+                id: p.id,
                 name: p.name,
                 firstName: p.firstName,
                 role: p.role,
-                count: attendanceCounts[p.name] || 0,
+                count: attendanceCounts[p.id] || 0,
               }));
 
               const nameMap = {
@@ -229,20 +230,21 @@
               });
 
               const chartData = Object.entries(attendanceCounts)
-                .map(([name, count]) => {
-                  const player = players.find((p) => p.name === name);
-                  const firstName = player?.firstName || name.split(" ")[0]; // Use firstName if available
-                  return { name: firstName, count };
+                .map(([id, count]) => {
+                  const player = players.find((p) => p.id === id);
+                  const firstName =
+                    player?.firstName || (player?.name || "").split(" ")[0];
+                  return { id, name: firstName, count };
                 })
                 .filter((entry) => {
-                  const isCore = corePlayers.some(
-                    (p) => p.firstName === entry.name,
-                  );
+                  const isCore = corePlayers.some((p) => p.id === entry.id);
                   return !isCore;
                 })
                 .sort((a, b) => {
                   if (b.count !== a.count) return b.count - a.count;
-                  return a.name.localeCompare(b.name);
+                  const nameA = playerInfo[a.id]?.name || "";
+                  const nameB = playerInfo[b.id]?.name || "";
+                  return nameA.localeCompare(nameB);
                 });
 
               console.log("chartData:", chartData);


### PR DESCRIPTION
## Summary
- include player IDs in the gathered player data
- compute attendance counts keyed by ID instead of name
- update chart data logic and sorting to use IDs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b661cd0608330b81d937b5cf41b86