### PR TITLE
Centralize Firebase initialization

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -58,25 +58,11 @@
           console.log("React version:", React?.version);
           console.log("Chart modules:", { ResponsiveContainer, BarChart });
 
-          const { initializeApp } = await import(
-            "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js"
-          );
-          const { getFirestore, collection, getDocs, getDoc, doc } =
+          const { app, db } = await import("./firebaseInit.js");
+          const { collection, getDocs, getDoc, doc } =
             await import(
               "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js"
             );
-
-          const firebaseConfig = {
-            apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-            authDomain: "poker-crm.firebaseapp.com",
-            projectId: "poker-crm",
-            storageBucket: "poker-crm.appspot.com",
-            messagingSenderId: "218784808902",
-            appId: "1:218784808902:web:c587bdf584d704f7733107",
-          };
-
-          const app = initializeApp(firebaseConfig);
-          const db = getFirestore(app);
 
           function filterValidEarnings(history) {
             return (history || []).filter(

--- a/createEvent.html
+++ b/createEvent.html
@@ -64,9 +64,8 @@
 
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script type="module">
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+      import { app, db } from "./firebaseInit.js";
       import {
-        getFirestore,
         collection,
         getDocs,
         addDoc,
@@ -77,18 +76,6 @@
         where,
         Timestamp,
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-
-      const firebaseConfig = {
-        apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-        authDomain: "poker-crm.firebaseapp.com",
-        projectId: "poker-crm",
-        storageBucket: "poker-crm.appspot.com",
-        messagingSenderId: "218784808902",
-        appId: "1:218784808902:web:c587bdf584d704f7733107",
-      };
-
-      const app = initializeApp(firebaseConfig);
-      const db = getFirestore(app);
 
       const inviteesSelect = document.getElementById("invitees");
       let choices;

--- a/firebaseInit.js
+++ b/firebaseInit.js
@@ -1,0 +1,15 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
+  authDomain: "poker-crm.firebaseapp.com",
+  projectId: "poker-crm",
+  storageBucket: "poker-crm.appspot.com",
+  messagingSenderId: "218784808902",
+  appId: "1:218784808902:web:c587bdf584d704f7733107",
+};
+
+export const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+

--- a/login.html
+++ b/login.html
@@ -28,30 +28,17 @@
         <button id="loginBtn" style="width: 100%">Log In</button>
       </div>
     </main>
-    <script type="module">
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
-      import {
-        getAuth,
-        signInWithEmailAndPassword,
-        onAuthStateChanged,
-      } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+      <script type="module">
+        import { app } from "./firebaseInit.js";
+        import {
+          getAuth,
+          signInWithEmailAndPassword,
+          onAuthStateChanged,
+          setPersistence,
+          browserLocalPersistence,
+        } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
 
-      const firebaseConfig = {
-        apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-        authDomain: "poker-crm.firebaseapp.com",
-        projectId: "poker-crm",
-        storageBucket: "poker-crm.appspot.com",
-        messagingSenderId: "218784808902",
-        appId: "1:218784808902:web:c587bdf584d704f7733107",
-      };
-
-      const app = initializeApp(firebaseConfig);
-      const auth = getAuth(app);
-
-      import {
-        setPersistence,
-        browserLocalPersistence,
-      } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+        const auth = getAuth(app);
 
       setPersistence(auth, browserLocalPersistence).catch((error) => {
         console.error("Persistence error:", error);

--- a/playerAdd.html
+++ b/playerAdd.html
@@ -41,25 +41,11 @@
     </main>
 
     <script type="module">
-      // Firebase imports
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+      import { app, db } from "./firebaseInit.js";
       import {
-        getFirestore,
         collection,
         addDoc,
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-
-      const firebaseConfig = {
-        apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-        authDomain: "poker-crm.firebaseapp.com",
-        projectId: "poker-crm",
-        storageBucket: "poker-crm.appspot.com",
-        messagingSenderId: "218784808902",
-        appId: "1:218784808902:web:c587bdf584d704f7733107",
-      };
-
-      const app = initializeApp(firebaseConfig);
-      const db = getFirestore(app);
 
       const form = document.getElementById("playerForm");
       form.addEventListener("submit", async (e) => {

--- a/players_list.html
+++ b/players_list.html
@@ -23,26 +23,13 @@
     </main>
 
     <script type="module">
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+      import { app, db } from "./firebaseInit.js";
       import {
-        getFirestore,
         collection,
         getDocs,
         updateDoc,
         doc,
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-
-      const firebaseConfig = {
-        apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-        authDomain: "poker-crm.firebaseapp.com",
-        projectId: "poker-crm",
-        storageBucket: "poker-crm.appspot.com",
-        messagingSenderId: "218784808902",
-        appId: "1:218784808902:web:c587bdf584d704f7733107",
-      };
-
-      const app = initializeApp(firebaseConfig);
-      const db = getFirestore(app);
 
       function sortContainer(container) {
         const cards = Array.from(container.children);

--- a/viewEvents.html
+++ b/viewEvents.html
@@ -18,26 +18,13 @@
     </main>
 
     <script type="module">
-      import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+      import { app, db } from "./firebaseInit.js";
       import {
-        getFirestore,
         collection,
         getDocs,
         getDoc,
         doc,
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-
-      const firebaseConfig = {
-        apiKey: "AIzaSyDqLxlBmdM_O1wmeOPPKyRh8PFnSw-dTH0",
-        authDomain: "poker-crm.firebaseapp.com",
-        projectId: "poker-crm",
-        storageBucket: "poker-crm.appspot.com",
-        messagingSenderId: "218784808902",
-        appId: "1:218784808902:web:c587bdf584d704f7733107",
-      };
-
-      const app = initializeApp(firebaseConfig);
-      const db = getFirestore(app);
       const eventList = document.getElementById("eventList");
 
       async function fetchNames(ids) {


### PR DESCRIPTION
## Summary
- add reusable `firebaseInit.js` with config
- replace inline Firebase setup in HTML pages with imports

## Testing
- `pre-commit run --files firebaseInit.js login.html createEvent.html players_list.html playerAdd.html viewEvents.html analytics.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b661d9d6883308558a163acfbe8d7