### PR TITLE
Improve Firestore error feedback

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -77,6 +77,11 @@
 
           const app = initializeApp(firebaseConfig);
           const db = getFirestore(app);
+          const errorEl = document.getElementById("noDataMessage");
+
+          function displayError(msg) {
+            if (errorEl) errorEl.textContent = msg;
+          }
 
           function filterValidEarnings(history) {
             return (history || []).filter(
@@ -349,16 +354,14 @@
               msgEl.textContent = "";
             } catch (err) {
               console.error("Failed to load analytics", err);
-              document.getElementById("noDataMessage").textContent =
-                "Error loading analytics. See console.";
+              displayError("Error loading analytics. See console.");
             }
           }
 
           await buildAnalytics();
         } catch (err) {
           console.error("Failed to initialize analytics", err);
-          document.getElementById("noDataMessage").textContent =
-            "Error loading analytics. See console.";
+          displayError("Error loading analytics. See console.");
         }
       });
     </script>

--- a/createEvent.html
+++ b/createEvent.html
@@ -14,6 +14,7 @@
     <div id="navbar-placeholder"></div>
     <main class="page-content">
       <div id="liveEvents"></div>
+      <p id="errorMessage" class="error-message"></p>
 
       <div class="container">
         <div class="page-header mobile-offset">
@@ -94,30 +95,40 @@
       let choices;
       const coreIds = [];
       let players = [];
+      const errorEl = document.getElementById("errorMessage");
+
+      function displayError(msg) {
+        if (errorEl) errorEl.textContent = msg;
+      }
 
       function uniq(arr) {
         return Array.from(new Set(arr));
       }
 
       async function loadPlayers() {
-        const snapshot = await getDocs(collection(db, "players"));
-        snapshot.forEach((docSnap) => {
-          const data = docSnap.data();
-          players.push({ id: docSnap.id, name: data.name, role: data.role });
-          if (data.role === "core") {
-            coreIds.push(docSnap.id);
-            return;
-          }
-          const option = document.createElement("option");
-          option.value = docSnap.id;
-          option.textContent = data.name;
-          inviteesSelect.appendChild(option);
-        });
-        choices = new Choices(inviteesSelect, {
-          removeItemButton: true,
-          searchResultLimit: 50,
-          shouldSort: true,
-        });
+        try {
+          const snapshot = await getDocs(collection(db, "players"));
+          snapshot.forEach((docSnap) => {
+            const data = docSnap.data();
+            players.push({ id: docSnap.id, name: data.name, role: data.role });
+            if (data.role === "core") {
+              coreIds.push(docSnap.id);
+              return;
+            }
+            const option = document.createElement("option");
+            option.value = docSnap.id;
+            option.textContent = data.name;
+            inviteesSelect.appendChild(option);
+          });
+          choices = new Choices(inviteesSelect, {
+            removeItemButton: true,
+            searchResultLimit: 50,
+            shouldSort: true,
+          });
+        } catch (err) {
+          console.error("Failed to load players", err);
+          displayError("Failed to load players. Please try again.");
+        }
       }
 
       loadPlayers();
@@ -244,22 +255,33 @@
               earnings: earnMap[id] || 0,
             }));
 
-            await updateDoc(doc(db, "events", id), {
-              date: Timestamp.fromDate(
-                new Date(card.querySelector(".date-input").value),
-              ),
-              host: card.querySelector(".host-input").value.trim(),
-              notes: card.querySelector(".notes-input").value.trim(),
-              invited: uniq([...coreIds, ...invitedValues]),
-              attended: attendedData,
-            });
+            try {
+              await updateDoc(doc(db, "events", id), {
+                date: Timestamp.fromDate(
+                  new Date(card.querySelector(".date-input").value),
+                ),
+                host: card.querySelector(".host-input").value.trim(),
+                notes: card.querySelector(".notes-input").value.trim(),
+                invited: uniq([...coreIds, ...invitedValues]),
+                attended: attendedData,
+              });
+              displayError("");
+            } catch (err) {
+              console.error("Failed to save event", err);
+              displayError("Failed to save event.");
+            }
           });
 
           const lockBtn = document.createElement("button");
           lockBtn.textContent = "Lock Event";
           lockBtn.style.marginLeft = "0.5rem";
           lockBtn.addEventListener("click", async () => {
-            await updateDoc(doc(db, "events", id), { locked: true });
+            try {
+              await updateDoc(doc(db, "events", id), { locked: true });
+            } catch (err) {
+              console.error("Failed to lock event", err);
+              displayError("Failed to lock event.");
+            }
           });
 
           card.appendChild(saveBtn);
@@ -271,8 +293,15 @@
 
       onSnapshot(
         query(collection(db, "events"), where("locked", "==", false)),
-        (snap) => {
-          renderLiveEvents(snap.docs);
+        {
+          next: (snap) => {
+            renderLiveEvents(snap.docs);
+            displayError("");
+          },
+          error: (err) => {
+            console.error("Failed to load events", err);
+            displayError("Failed to load events.");
+          },
         },
       );
 
@@ -298,9 +327,10 @@
           });
 
           form.reset();
+          displayError("");
         } catch (error) {
           console.error("Error creating event:", error);
-          alert("Something went wrong.");
+          displayError("Failed to create event.");
         }
       });
     </script>

--- a/playerAdd.html
+++ b/playerAdd.html
@@ -38,6 +38,7 @@
         <input type="text" id="invitedBy" placeholder="Invited By" />
         <button type="submit">Add Player</button>
       </form>
+      <p id="errorMessage" class="error-message"></p>
     </main>
 
     <script type="module">
@@ -60,6 +61,11 @@
 
       const app = initializeApp(firebaseConfig);
       const db = getFirestore(app);
+      const errorEl = document.getElementById("errorMessage");
+
+      function displayError(msg) {
+        if (errorEl) errorEl.textContent = msg;
+      }
 
       const form = document.getElementById("playerForm");
       form.addEventListener("submit", async (e) => {
@@ -86,9 +92,10 @@
           });
           alert("Player added!");
           form.reset();
+          displayError("");
         } catch (error) {
           console.error("Error adding document: ", error);
-          alert("Something went wrong.");
+          displayError("Failed to add player.");
         }
       });
     </script>

--- a/players_list.html
+++ b/players_list.html
@@ -19,6 +19,7 @@
         <div id="otherSection" class="section">
           <div id="otherPlayers" class="players-grid"></div>
         </div>
+        <p id="errorMessage" class="error-message"></p>
       </div>
     </main>
 
@@ -43,6 +44,11 @@
 
       const app = initializeApp(firebaseConfig);
       const db = getFirestore(app);
+      const errorEl = document.getElementById("errorMessage");
+
+      function displayError(msg) {
+        if (errorEl) errorEl.textContent = msg;
+      }
 
       function sortContainer(container) {
         const cards = Array.from(container.children);
@@ -130,9 +136,10 @@
             refreshCard(card, player);
             alert("Player updated!");
             form.remove();
+            displayError("");
           } catch (err) {
             console.error(err);
-            alert("Update failed.");
+            displayError("Failed to update player.");
           }
         });
 
@@ -166,30 +173,36 @@
       }
 
       async function renderPlayers() {
-        const snapshot = await getDocs(collection(db, "players"));
-        const players = [];
-        snapshot.forEach((docSnap) => {
-          players.push({ id: docSnap.id, ...docSnap.data() });
-        });
+        try {
+          const snapshot = await getDocs(collection(db, "players"));
+          const players = [];
+          snapshot.forEach((docSnap) => {
+            players.push({ id: docSnap.id, ...docSnap.data() });
+          });
 
-        players.sort((a, b) => a.name.localeCompare(b.name));
+          players.sort((a, b) => a.name.localeCompare(b.name));
 
-        const coreContainer = document.getElementById("corePlayers");
-        const otherContainer = document.getElementById("otherPlayers");
-        coreContainer.innerHTML = "";
-        otherContainer.innerHTML = "";
+          const coreContainer = document.getElementById("corePlayers");
+          const otherContainer = document.getElementById("otherPlayers");
+          coreContainer.innerHTML = "";
+          otherContainer.innerHTML = "";
 
-        players.forEach((player) => {
-          const card = createCard(player);
-          if (player.role === "core") {
-            coreContainer.appendChild(card);
-          } else {
-            otherContainer.appendChild(card);
-          }
-        });
+          players.forEach((player) => {
+            const card = createCard(player);
+            if (player.role === "core") {
+              coreContainer.appendChild(card);
+            } else {
+              otherContainer.appendChild(card);
+            }
+          });
 
-        sortContainer(coreContainer);
-        sortContainer(otherContainer);
+          sortContainer(coreContainer);
+          sortContainer(otherContainer);
+          displayError("");
+        } catch (err) {
+          console.error("Failed to load players", err);
+          displayError("Failed to load players.");
+        }
       }
 
       renderPlayers();

--- a/styles.css
+++ b/styles.css
@@ -393,6 +393,12 @@ button {
   gap: 0.5rem;
 }
 
+.error-message {
+  color: #ff3333;
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
 .event {
   background-color: rgba(255, 255, 255, 0.9);
   border-radius: 10px;

--- a/viewEvents.html
+++ b/viewEvents.html
@@ -14,6 +14,7 @@
           <h1 class="page-title">🗓️ Poker Night Events</h1>
         </div>
         <div id="eventList"></div>
+        <p id="errorMessage" class="error-message"></p>
       </div>
     </main>
 
@@ -39,6 +40,11 @@
       const app = initializeApp(firebaseConfig);
       const db = getFirestore(app);
       const eventList = document.getElementById("eventList");
+      const errorEl = document.getElementById("errorMessage");
+
+      function displayError(msg) {
+        if (errorEl) errorEl.textContent = msg;
+      }
 
       async function fetchNames(ids) {
         const names = [];
@@ -79,33 +85,34 @@
       }
 
       async function renderEvents() {
-        const snap = await getDocs(collection(db, "events"));
-        const events = [];
-        for (const d of snap.docs) {
-          const data = d.data();
-          const invited = await fetchNames(data.invited || []);
-          const attended = await fetchAttendees(data.attended || []);
+        try {
+          const snap = await getDocs(collection(db, "events"));
+          const events = [];
+          for (const d of snap.docs) {
+            const data = d.data();
+            const invited = await fetchNames(data.invited || []);
+            const attended = await fetchAttendees(data.attended || []);
 
-          const dateObj = data.date?.toDate ? data.date.toDate() : new Date();
+            const dateObj = data.date?.toDate ? data.date.toDate() : new Date();
 
-          events.push({
-            locked: !!data.locked,
-            dateObj,
-            date: dateObj.toLocaleDateString(),
-            host: data.host || "",
-            notes: data.notes || "",
-            invited,
-            attended,
-          });
-        }
+            events.push({
+              locked: !!data.locked,
+              dateObj,
+              date: dateObj.toLocaleDateString(),
+              host: data.host || "",
+              notes: data.notes || "",
+              invited,
+              attended,
+            });
+          }
 
-        eventList.innerHTML = "";
+          eventList.innerHTML = "";
 
-        events.sort((a, b) => b.dateObj - a.dateObj);
-        for (const ev of events) {
-          const div = document.createElement("div");
-          div.className = "event";
-          div.innerHTML = `
+          events.sort((a, b) => b.dateObj - a.dateObj);
+          for (const ev of events) {
+            const div = document.createElement("div");
+            div.className = "event";
+            div.innerHTML = `
         <h2><strong>${ev.locked ? "🔒 " : ""}${ev.date}</strong></h2>
         ${ev.host ? `<p><strong>Host:</strong> ${ev.host}</p>` : ""}
         <p><strong>Notes:</strong> ${ev.notes || "—"}</p>
@@ -127,8 +134,12 @@
           )
           .join("")}</ul></div>
       `;
-
-          eventList.appendChild(div);
+            eventList.appendChild(div);
+          }
+          displayError("");
+        } catch (err) {
+          console.error("Failed to load events", err);
+          displayError("Failed to load events.");
         }
       }
 


### PR DESCRIPTION
## Summary
- add error display elements and styling
- catch Firestore errors when loading players, events and analytics data
- surface friendly error messages in forms and analytics pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b66203d4c8330a6773cc0bd99d55e