### PR TITLE
Upgrade admin players layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -140,22 +140,77 @@
           .forEach((p) => {
             const card = document.createElement("div");
             card.className = "player-card";
-            card.innerHTML = `
-            <strong>${p.firstName}</strong>
-            <span>${p.email || ""}</span>
-            <span>Invited by: ${p.invitedBy || "-"}</span>
-            <span>Attendance: ${(p.earningsHistory || []).length}</span>
-            <button data-id="${p.id}" class="edit-player">Edit</button>
-            <button data-id="${p.id}" class="delete-player">Delete</button>
-          `;
+            card.dataset.id = p.id;
+
+            const meta = document.createElement("div");
+            meta.className = "player-meta";
+            meta.innerHTML = `
+              <span>${p.firstName}</span>
+              ${p.email ? `<span>${p.email}</span>` : ""}
+              <span>Invited by: ${p.invitedBy || "-"}</span>
+              <span>🎟 ${(p.earningsHistory || []).length}</span>
+            `;
+
+            const actions = document.createElement("div");
+            actions.className = "player-actions";
+            actions.innerHTML = `
+              <button data-id="${p.id}" class="edit-btn" title="Edit">&#9881;</button>
+              <button data-id="${p.id}" class="delete-btn" title="Delete">&#10006;</button>
+            `;
+
+            card.appendChild(meta);
+            card.appendChild(actions);
             playersList.appendChild(card);
 
             const opt = document.createElement("option");
             opt.value = p.id;
             opt.textContent = p.firstName;
             attendeesSelect.appendChild(opt.cloneNode(true));
-            earningsPlayerSelect.appendChild(opt);
-          });
+          earningsPlayerSelect.appendChild(opt);
+        });
+      }
+
+      function togglePlayerEdit(card, player) {
+        let form = card.querySelector("form.edit-form");
+        if (form) {
+          form.remove();
+          return;
+        }
+
+        form = document.createElement("form");
+        form.className = "edit-form";
+        form.innerHTML = `
+          <input name="firstName" type="text" value="${player.firstName}" placeholder="First Name" required />
+          <input name="email" type="email" value="${player.email || ''}" placeholder="Email" />
+          <input name="invitedBy" type="text" value="${player.invitedBy || ''}" placeholder="Invited By" />
+          <div class="form-buttons">
+            <button type="submit">Save</button>
+            <button type="button" class="cancel-btn">Cancel</button>
+          </div>
+        `;
+
+        form.querySelector(".cancel-btn").addEventListener("click", () => form.remove());
+
+        form.addEventListener("submit", async (e) => {
+          e.preventDefault();
+          const formData = new FormData(form);
+          const updated = {
+            firstName: formData.get("firstName").trim(),
+            email: formData.get("email").trim().toLowerCase(),
+            invitedBy: formData.get("invitedBy").trim(),
+          };
+          try {
+            await updateDoc(doc(db, "players", player.id), updated);
+            Object.assign(player, updated);
+            renderPlayers();
+            updateStats();
+          } catch (err) {
+            console.error(err);
+            alert("Update failed.");
+          }
+        });
+
+        card.appendChild(form);
       }
 
       function renderEvents() {
@@ -250,25 +305,16 @@
         .getElementById("playersList")
         .addEventListener("click", async (e) => {
           const id = e.target.dataset.id;
-          if (e.target.classList.contains("delete-player")) {
-            if (!confirm("Delete player?")) return;
+          if (e.target.classList.contains("delete-btn")) {
+            if (!confirm("Are you sure you want to delete this player?")) return;
             await deleteDoc(doc(db, "players", id));
             players = players.filter((p) => p.id !== id);
             renderPlayers();
             updateStats();
-          } else if (e.target.classList.contains("edit-player")) {
+          } else if (e.target.classList.contains("edit-btn")) {
+            const card = e.target.closest(".player-card");
             const p = players.find((x) => x.id === id);
-            const firstName = prompt("First Name", p.firstName) || p.firstName;
-            const email = prompt("Email", p.email) || p.email;
-            const invitedBy = prompt("Invited By", p.invitedBy || "") || "";
-            await updateDoc(doc(db, "players", id), {
-              firstName,
-              email: email.toLowerCase(),
-              invitedBy,
-            });
-            Object.assign(p, { firstName, email, invitedBy });
-            renderPlayers();
-            updateStats();
+            togglePlayerEdit(card, p);
           }
         });
 

--- a/styles.css
+++ b/styles.css
@@ -241,21 +241,52 @@ button {
 }
 
 .player-card {
-  border: 1px solid #333;
-  border-radius: 8px;
-  padding: 0.75rem;
-  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
-.player-card strong {
-  display: block;
+.player-meta span {
+  margin-right: 12px;
+  font-size: 0.9rem;
+  color: #222;
+}
+
+.player-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.edit-btn {
+  border: none;
+  background: #444;
+  color: #fff;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.edit-btn:hover {
+  background: #666;
+}
+
+.delete-btn {
+  border: none;
+  background: none;
+  color: #c0392b;
   font-size: 1.1rem;
-  margin-bottom: 0.25rem;
+  cursor: pointer;
 }
 
-.player-card span {
-  display: block;
-  font-size: 0.95rem;
+.delete-btn:hover {
+  color: #e74c3c;
 }
 
 .edit-form {
@@ -481,6 +512,15 @@ button {
   .container {
     margin: 1rem;
     padding: 1rem;
+  }
+
+  .player-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .player-actions {
+    margin-top: 4px;
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor admin player cards to use compact horizontal layout
- add edit and delete icons
- show edit form inline using gear button
- style player cards and action buttons for small UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b7129348c8330a9c48c763eb455a3