### PR TITLE
Implement sortable players table on admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -39,7 +39,28 @@
             <input type="text" id="pInvited" placeholder="Invited By" />
             <button type="submit">Add Player</button>
           </form>
-          <div id="playersList"></div>
+          <div class="players-table-wrapper">
+            <table id="playersTable">
+              <thead>
+                <tr>
+                  <th data-field="name">
+                    Name <span class="sort-indicator"></span>
+                  </th>
+                  <th data-field="attendance">
+                    🎟 Attendance <span class="sort-indicator"></span>
+                  </th>
+                  <th data-field="invitedBy">
+                    Invited By <span class="sort-indicator"></span>
+                  </th>
+                  <th data-field="email">
+                    Email <span class="sort-indicator"></span>
+                  </th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="playersTableBody"></tbody>
+            </table>
+          </div>
         </section>
 
         <section id="eventsSection" class="section">
@@ -100,7 +121,7 @@
       const statsEarnings = document.getElementById("statEarnings");
       const statsUpdated = document.getElementById("statUpdated");
 
-      const playersList = document.getElementById("playersList");
+      const playersTableBody = document.getElementById("playersTableBody");
       const eventsList = document.getElementById("eventsList");
       const attendeesSelect = document.getElementById("eAttendees");
       const earningsPlayerSelect = document.getElementById("earningsPlayer");
@@ -130,100 +151,168 @@
         statsUpdated.textContent = new Date().toLocaleString();
       }
 
-      function renderPlayers() {
-        playersList.innerHTML = "";
+      let sortField = "name";
+      let sortDirection = 1;
+
+      function getFullName(p) {
+        return (p.firstName || "") + (p.lastName ? ` ${p.lastName}` : "");
+      }
+
+      function updateSortIndicators() {
+        document
+          .querySelectorAll("#playersTable th[data-field]")
+          .forEach((th) => {
+            const span = th.querySelector(".sort-indicator");
+            if (!span) return;
+            if (th.dataset.field === sortField) {
+              span.textContent = sortDirection === 1 ? "▲" : "▼";
+            } else {
+              span.textContent = "";
+            }
+          });
+      }
+
+      function renderTable() {
+        playersTableBody.innerHTML = "";
         attendeesSelect.innerHTML = "";
         earningsPlayerSelect.innerHTML =
           '<option value="">Select player</option>';
-        players
-          .sort((a, b) => {
-            const nameA =
-              (a.firstName || "") + (a.lastName ? " " + a.lastName : "");
-            const nameB =
-              (b.firstName || "") + (b.lastName ? " " + b.lastName : "");
-            return nameA.localeCompare(nameB);
-          })
-          .forEach((p) => {
-            const card = document.createElement("div");
-            card.className = "player-card";
-            card.dataset.id = p.id;
-
-            const meta = document.createElement("div");
-            meta.className = "player-meta";
-            const fullName =
-              (p.firstName || "") + (p.lastName ? " " + p.lastName : "");
-            meta.innerHTML = `
-              <span>${fullName}</span>
-              ${p.email ? `<span>${p.email}</span>` : ""}
-              ${
-                p.role === "core"
-                  ? ""
-                  : `<span>Invited by: ${p.invitedBy || "-"}</span>`
-              }
-              <span>🎟 ${(p.earningsHistory || []).length}</span>
-            `;
-
-            const actions = document.createElement("div");
-            actions.className = "player-actions";
-            actions.innerHTML = `
+        players.forEach((p) => {
+          const tr = document.createElement("tr");
+          tr.dataset.id = p.id;
+          tr.innerHTML = `
+            <td>${getFullName(p)}</td>
+            <td>${(p.earningsHistory || []).length}</td>
+            <td>${p.role !== "core" ? p.invitedBy || "—" : "—"}</td>
+            <td>${p.email || ""}</td>
+            <td class="player-actions">
               <button data-id="${p.id}" class="edit-btn" title="Edit">&#9881;</button>
               <button data-id="${p.id}" class="delete-btn" title="Delete">&#10006;</button>
-            `;
+            </td>`;
+          playersTableBody.appendChild(tr);
 
-            card.appendChild(meta);
-            card.appendChild(actions);
-            playersList.appendChild(card);
-
-            const opt = document.createElement("option");
-            opt.value = p.id;
-            opt.textContent = fullName;
-            attendeesSelect.appendChild(opt.cloneNode(true));
+          const opt = document.createElement("option");
+          opt.value = p.id;
+          opt.textContent = getFullName(p);
+          attendeesSelect.appendChild(opt.cloneNode(true));
           earningsPlayerSelect.appendChild(opt);
         });
       }
 
-      function togglePlayerEdit(card, player) {
-        let form = card.querySelector("form.edit-form");
-        if (form) {
-          form.remove();
+      function sortPlayers(field, initial = false) {
+        if (sortField === field && !initial) {
+          sortDirection *= -1;
+        } else {
+          sortField = field;
+          sortDirection = 1;
+        }
+        players.sort((a, b) => {
+          let aVal;
+          let bVal;
+          switch (field) {
+            case "attendance":
+              aVal = (a.earningsHistory || []).length;
+              bVal = (b.earningsHistory || []).length;
+              break;
+            case "invitedBy":
+              aVal = a.role === "core" ? "" : a.invitedBy || "";
+              bVal = b.role === "core" ? "" : b.invitedBy || "";
+              break;
+            case "email":
+              aVal = a.email || "";
+              bVal = b.email || "";
+              break;
+            case "name":
+            default:
+              aVal = getFullName(a).toLowerCase();
+              bVal = getFullName(b).toLowerCase();
+              break;
+          }
+          if (aVal < bVal) return -1 * sortDirection;
+          if (aVal > bVal) return 1 * sortDirection;
+          return 0;
+        });
+        renderTable();
+        updateSortIndicators();
+        updateStats();
+      }
+
+      function togglePlayerEdit(row, player) {
+        const next = row.nextElementSibling;
+        if (next && next.classList.contains("edit-row")) {
+          next.remove();
           return;
         }
-
-        form = document.createElement("form");
-        form.className = "edit-form";
-        form.innerHTML = `
-          <input name="firstName" type="text" value="${player.firstName}" placeholder="First Name" required />
-          <input name="email" type="email" value="${player.email || ''}" placeholder="Email" />
-          <input name="invitedBy" type="text" value="${player.invitedBy || ''}" placeholder="Invited By" />
-          <div class="form-buttons">
-            <button type="submit">Save</button>
-            <button type="button" class="cancel-btn">Cancel</button>
-          </div>
-        `;
-
-        form.querySelector(".cancel-btn").addEventListener("click", () => form.remove());
-
+        const editRow = document.createElement("tr");
+        editRow.className = "edit-row";
+        editRow.innerHTML = `
+          <td colspan="5">
+            <form class="edit-form">
+              <input name="firstName" type="text" value="${
+                player.firstName || getFullName(player)
+              }" placeholder="First Name" required />
+              <input name="lastName" type="text" value="${
+                player.lastName || ""
+              }" placeholder="Last Name" />
+              <input name="email" type="email" value="${
+                player.email || ""
+              }" placeholder="Email" />
+              <input name="invitedBy" type="text" value="${
+                player.invitedBy || ""
+              }" placeholder="Invited By" />
+              ${
+                player.role === "core"
+                  ? ""
+                  : `<select name="role">
+              <option value="regular" ${
+                player.role === "regular" ? "selected" : ""
+              }>Regular</option>
+              <option value="guest" ${
+                player.role === "guest" ? "selected" : ""
+              }>Guest</option>
+            </select>`
+              }
+              <div class="form-buttons">
+                <button type="submit">Save</button>
+                <button type="button" class="cancel-btn">Cancel</button>
+              </div>
+            </form>
+          </td>`;
+        row.parentNode.insertBefore(editRow, row.nextSibling);
+        const form = editRow.querySelector("form");
+        form.querySelector(".cancel-btn").addEventListener("click", () => {
+          editRow.remove();
+        });
         form.addEventListener("submit", async (e) => {
           e.preventDefault();
-          const formData = new FormData(form);
+          const fd = new FormData(form);
           const updated = {
-            firstName: formData.get("firstName").trim(),
-            email: formData.get("email").trim().toLowerCase(),
-            invitedBy: formData.get("invitedBy").trim(),
+            firstName: fd.get("firstName").trim(),
+            lastName: fd.get("lastName").trim(),
+            email: fd.get("email").trim(),
+            invitedBy: fd.get("invitedBy").trim(),
           };
+          if (fd.get("role") !== null) {
+            updated.role = fd.get("role");
+          }
           try {
             await updateDoc(doc(db, "players", player.id), updated);
             Object.assign(player, updated);
-            renderPlayers();
+            editRow.remove();
+            renderTable();
             updateStats();
           } catch (err) {
             console.error(err);
             alert("Update failed.");
           }
         });
-
-        card.appendChild(form);
       }
+
+      document
+        .querySelectorAll("#playersTable th[data-field]")
+        .forEach((th) => {
+          th.addEventListener("click", () => sortPlayers(th.dataset.field));
+        });
 
       function renderEvents() {
         eventsList.innerHTML = "";
@@ -276,7 +365,7 @@
         players = pSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
         events = eSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
         updateStats();
-        renderPlayers();
+        sortPlayers("name", true);
         renderEvents();
       }
 
@@ -304,7 +393,7 @@
               invitedBy,
               earningsHistory: [],
             });
-            renderPlayers();
+            sortPlayers(sortField, true);
             updateStats();
             e.target.reset();
           } catch (err) {
@@ -313,22 +402,21 @@
           }
         });
 
-      document
-        .getElementById("playersList")
-        .addEventListener("click", async (e) => {
-          const id = e.target.dataset.id;
-          if (e.target.classList.contains("delete-btn")) {
-            if (!confirm("Are you sure you want to delete this player?")) return;
-            await deleteDoc(doc(db, "players", id));
-            players = players.filter((p) => p.id !== id);
-            renderPlayers();
-            updateStats();
-          } else if (e.target.classList.contains("edit-btn")) {
-            const card = e.target.closest(".player-card");
-            const p = players.find((x) => x.id === id);
-            togglePlayerEdit(card, p);
-          }
-        });
+      playersTableBody.addEventListener("click", async (e) => {
+        const id = e.target.dataset.id;
+        if (!id) return;
+        const row = e.target.closest("tr");
+        const player = players.find((p) => p.id === id);
+        if (e.target.classList.contains("delete-btn")) {
+          if (!confirm("Are you sure you want to delete this player?")) return;
+          await deleteDoc(doc(db, "players", id));
+          players = players.filter((p) => p.id !== id);
+          renderTable();
+          updateStats();
+        } else if (e.target.classList.contains("edit-btn")) {
+          togglePlayerEdit(row, player);
+        }
+      });
 
       document
         .getElementById("addEventForm")

--- a/players_list.html
+++ b/players_list.html
@@ -13,173 +13,221 @@
         <div class="page-header mobile-offset">
           <h1 class="page-title">📇 Player Directory</h1>
         </div>
-        <div id="coreSection" class="section">
-          <div id="corePlayers" class="players-grid"></div>
-        </div>
-        <div id="otherSection" class="section">
-          <div id="otherPlayers" class="players-grid"></div>
+        <div class="players-table-wrapper">
+          <table id="playersTable">
+            <thead>
+              <tr>
+                <th data-field="name">
+                  Name <span class="sort-indicator"></span>
+                </th>
+                <th data-field="attendance">
+                  🎟 Attendance <span class="sort-indicator"></span>
+                </th>
+                <th data-field="invitedBy">
+                  Invited By <span class="sort-indicator"></span>
+                </th>
+                <th data-field="email">
+                  Email <span class="sort-indicator"></span>
+                </th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="playersTableBody"></tbody>
+          </table>
         </div>
       </div>
     </main>
 
     <script type="module">
-      import { app, db } from "./firebaseInit.js";
+      import { db } from "./firebaseInit.js";
       import {
         collection,
         getDocs,
         updateDoc,
+        deleteDoc,
         doc,
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
-      function sortContainer(container) {
-        const cards = Array.from(container.children);
-        cards.sort((a, b) => a.dataset.name.localeCompare(b.dataset.name));
-        cards.forEach((c) => container.appendChild(c));
-      }
+      let players = [];
+      let sortField = "name";
+      let sortDirection = 1;
 
-      function refreshCard(card, player) {
-        const info = card.querySelector(".player-info");
-        info.innerHTML = `
-        <strong>${player.name}</strong>
-        <span>📧 ${player.email || "No email provided"}</span>
-        <span>📞 ${player.phone || "No phone"}</span>
-        <span>🏷️ ${player.role || "Unassigned"}</span>
-      `;
-        card.dataset.name = player.name.toLowerCase();
-
-        const coreContainer = document.getElementById("corePlayers");
-        const otherContainer = document.getElementById("otherPlayers");
-        const target = player.role === "core" ? coreContainer : otherContainer;
-        if (card.parentElement !== target) {
-          card.remove();
-          target.appendChild(card);
+      function getFullName(p) {
+        if (p.firstName) {
+          return p.firstName + (p.lastName ? ` ${p.lastName}` : "");
         }
-        sortContainer(target);
+        return p.name || "";
       }
 
-      function toggleEdit(card, player) {
-        let form = card.querySelector("form.edit-form");
-        if (form) {
-          form.remove();
+      function updateSortIndicators() {
+        document.querySelectorAll("#playersTable th").forEach((th) => {
+          const span = th.querySelector(".sort-indicator");
+          if (!span) return;
+          if (th.dataset.field === sortField) {
+            span.textContent = sortDirection === 1 ? "▲" : "▼";
+          } else {
+            span.textContent = "";
+          }
+        });
+      }
+
+      function renderTable() {
+        const tbody = document.getElementById("playersTableBody");
+        tbody.innerHTML = "";
+        players.forEach((p) => {
+          const tr = document.createElement("tr");
+          tr.dataset.id = p.id;
+          tr.innerHTML = `
+            <td>${getFullName(p)}</td>
+            <td>${(p.earningsHistory || []).length}</td>
+            <td>${p.role !== "core" ? p.invitedBy || "—" : "—"}</td>
+            <td>${p.email || ""}</td>
+            <td class="player-actions">
+              <button data-id="${p.id}" class="edit-btn" title="Edit">&#9881;</button>
+              <button data-id="${p.id}" class="delete-btn" title="Delete">&#10006;</button>
+            </td>`;
+          tbody.appendChild(tr);
+        });
+      }
+
+      function sortPlayers(field, initial = false) {
+        if (sortField === field && !initial) {
+          sortDirection *= -1;
+        } else {
+          sortField = field;
+          sortDirection = 1;
+        }
+        players.sort((a, b) => {
+          let aVal;
+          let bVal;
+          switch (field) {
+            case "attendance":
+              aVal = (a.earningsHistory || []).length;
+              bVal = (b.earningsHistory || []).length;
+              break;
+            case "invitedBy":
+              aVal = a.role === "core" ? "" : a.invitedBy || "";
+              bVal = b.role === "core" ? "" : b.invitedBy || "";
+              break;
+            case "email":
+              aVal = a.email || "";
+              bVal = b.email || "";
+              break;
+            case "name":
+            default:
+              aVal = getFullName(a).toLowerCase();
+              bVal = getFullName(b).toLowerCase();
+              break;
+          }
+          if (aVal < bVal) return -1 * sortDirection;
+          if (aVal > bVal) return 1 * sortDirection;
+          return 0;
+        });
+        renderTable();
+        updateSortIndicators();
+      }
+
+      function toggleEdit(row, player) {
+        const next = row.nextElementSibling;
+        if (next && next.classList.contains("edit-row")) {
+          next.remove();
           return;
         }
-
-        form = document.createElement("form");
-        form.className = "edit-form";
-        form.innerHTML = `
-        <input name="name" type="text" value="${player.name}" autocomplete="name" placeholder="Full Name" required>
-        <input name="email" type="email" value="${player.email || ""}" autocomplete="email" placeholder="Email">
-        <input name="phone" type="tel" value="${player.phone || ""}" autocomplete="tel" placeholder="Phone">
-        <input name="invitedBy" type="text" value="${player.invitedBy || ""}" autocomplete="off" placeholder="Invited By">
-        ${
-          player.role === "core"
-            ? ""
-            : `
-        <select name="role">
-          <option value="regular" ${player.role === "regular" ? "selected" : ""}>Regular</option>
-          <option value="guest" ${player.role === "guest" ? "selected" : ""}>Guest</option>
-        </select>`
-        }
-        <div class="form-buttons">
-          <button type="submit">Save</button>
-          <button type="button" class="cancel-btn">Cancel</button>
-        </div>
-      `;
-
-        form
-          .querySelector(".cancel-btn")
-          .addEventListener("click", () => form.remove());
-
+        const editRow = document.createElement("tr");
+        editRow.className = "edit-row";
+        editRow.innerHTML = `
+          <td colspan="5">
+            <form class="edit-form">
+              <input name="firstName" type="text" value="${
+                player.firstName || getFullName(player)
+              }" placeholder="First Name" required />
+              <input name="lastName" type="text" value="${
+                player.lastName || ""
+              }" placeholder="Last Name" />
+              <input name="email" type="email" value="${
+                player.email || ""
+              }" placeholder="Email" />
+              <input name="invitedBy" type="text" value="${
+                player.invitedBy || ""
+              }" placeholder="Invited By" />
+              ${
+                player.role === "core"
+                  ? ""
+                  : `<select name="role">
+              <option value="regular" ${
+                player.role === "regular" ? "selected" : ""
+              }>Regular</option>
+              <option value="guest" ${
+                player.role === "guest" ? "selected" : ""
+              }>Guest</option>
+            </select>`
+              }
+              <div class="form-buttons">
+                <button type="submit">Save</button>
+                <button type="button" class="cancel-btn">Cancel</button>
+              </div>
+            </form>
+          </td>`;
+        row.parentNode.insertBefore(editRow, row.nextSibling);
+        const form = editRow.querySelector("form");
+        form.querySelector(".cancel-btn").addEventListener("click", () => {
+          editRow.remove();
+        });
         form.addEventListener("submit", async (e) => {
           e.preventDefault();
-          const formData = new FormData(form);
+          const fd = new FormData(form);
           const updated = {
-            name: formData.get("name").trim(),
-            email: formData.get("email").trim(),
-            phone: formData.get("phone").trim(),
-            invitedBy: formData.get("invitedBy").trim(),
+            firstName: fd.get("firstName").trim(),
+            lastName: fd.get("lastName").trim(),
+            email: fd.get("email").trim(),
+            invitedBy: fd.get("invitedBy").trim(),
           };
-          if (formData.get("role") !== null) {
-            updated.role = formData.get("role");
-          } else {
-            updated.role = player.role;
+          if (fd.get("role") !== null) {
+            updated.role = fd.get("role");
           }
-
-          if (!updated.name) {
-            alert("Name is required");
-            return;
-          }
-
           try {
-            const ref = doc(db, "players", player.id);
-            await updateDoc(ref, updated);
+            await updateDoc(doc(db, "players", player.id), updated);
             Object.assign(player, updated);
-            refreshCard(card, player);
-            alert("Player updated!");
-            form.remove();
+            editRow.remove();
+            renderTable();
           } catch (err) {
             console.error(err);
             alert("Update failed.");
           }
         });
-
-        card.appendChild(form);
       }
 
-      function createCard(player) {
-        const div = document.createElement("div");
-        div.className = "player-card";
-        div.dataset.id = player.id;
-        div.dataset.name = player.name.toLowerCase();
-
-        const info = document.createElement("div");
-        info.className = "player-info";
-        info.innerHTML = `
-        <strong>${player.name}</strong>
-        <span>📧 ${player.email || "No email provided"}</span>
-        <span>📞 ${player.phone || "No phone"}</span>
-        <span>🏷️ ${player.role || "Unassigned"}</span>
-      `;
-
-        const editBtn = document.createElement("button");
-        editBtn.textContent = "Edit";
-        editBtn.type = "button";
-        editBtn.addEventListener("click", () => toggleEdit(div, player));
-
-        div.appendChild(info);
-        div.appendChild(editBtn);
-
-        return div;
-      }
-
-      async function renderPlayers() {
-        const snapshot = await getDocs(collection(db, "players"));
-        const players = [];
-        snapshot.forEach((docSnap) => {
-          players.push({ id: docSnap.id, ...docSnap.data() });
-        });
-
-        players.sort((a, b) => a.name.localeCompare(b.name));
-
-        const coreContainer = document.getElementById("corePlayers");
-        const otherContainer = document.getElementById("otherPlayers");
-        coreContainer.innerHTML = "";
-        otherContainer.innerHTML = "";
-
-        players.forEach((player) => {
-          const card = createCard(player);
-          if (player.role === "core") {
-            coreContainer.appendChild(card);
-          } else {
-            otherContainer.appendChild(card);
+      document
+        .getElementById("playersTableBody")
+        .addEventListener("click", async (e) => {
+          const id = e.target.dataset.id;
+          if (!id) return;
+          const row = e.target.closest("tr");
+          const player = players.find((p) => p.id === id);
+          if (e.target.classList.contains("delete-btn")) {
+            if (!confirm("Are you sure you want to delete this player?"))
+              return;
+            await deleteDoc(doc(db, "players", id));
+            players = players.filter((p) => p.id !== id);
+            renderTable();
+          } else if (e.target.classList.contains("edit-btn")) {
+            toggleEdit(row, player);
           }
         });
 
-        sortContainer(coreContainer);
-        sortContainer(otherContainer);
+      document
+        .querySelectorAll("#playersTable th[data-field]")
+        .forEach((th) => {
+          th.addEventListener("click", () => sortPlayers(th.dataset.field));
+        });
+
+      async function loadPlayers() {
+        const snapshot = await getDocs(collection(db, "players"));
+        players = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+        sortPlayers("name", true);
       }
 
-      renderPlayers();
+      loadPlayers();
     </script>
     <script src="loadNav.js"></script>
     <script type="module">

--- a/styles.css
+++ b/styles.css
@@ -240,6 +240,36 @@ button {
   gap: 1rem;
 }
 
+/* Players table */
+.players-table-wrapper {
+  overflow-x: auto;
+}
+
+#playersTable {
+  width: 100%;
+  min-width: 480px;
+  border-collapse: collapse;
+  background: #ffffff;
+  color: #222;
+}
+
+#playersTable th,
+#playersTable td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #ccc;
+}
+
+#playersTable th {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.sort-indicator {
+  margin-left: 4px;
+}
+
 .player-card {
   display: flex;
   justify-content: space-between;
@@ -551,6 +581,19 @@ button {
   .players-grid {
     grid-template-columns: 1fr;
     gap: 1rem;
+  }
+
+  #playersTable th,
+  #playersTable td {
+    font-size: 0.9rem;
+    padding: 0.4rem;
+  }
+
+  .edit-btn,
+  .delete-btn {
+    width: 24px;
+    height: 24px;
+    font-size: 0.9rem;
   }
 
   .event {


### PR DESCRIPTION
## Summary
- replace admin players list with sortable table
- render full name, attendance, invited by, email, and actions
- enable header-based sorting and inline row editing

## Testing
- `npx prettier -w admin.html players_list.html styles.css`
- `pre-commit run --files admin.html players_list.html styles.css` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b7552540c8330b15bdf1c26785024