### PR TITLE
Highlight core members in admin table

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -206,6 +206,15 @@
       let players = [];
       let events = [];
 
+      const coreNames = [
+        "adam",
+        "sterling",
+        "john",
+        "julian",
+        "nathan",
+        "isaiah",
+      ];
+
       function formatDate(ts) {
         const d = ts?.toDate ? ts.toDate() : new Date(ts);
         return d.toISOString().split("T")[0];
@@ -257,6 +266,16 @@
         players.forEach((p) => {
           const tr = document.createElement("tr");
           tr.dataset.id = p.id;
+
+          const firstName = (
+            p.firstName ||
+            (p.name ? p.name.split(" ")[0] : "")
+          ).toLowerCase();
+          if (coreNames.includes(firstName)) {
+            tr.classList.add("core-member-row");
+            tr.setAttribute("title", "Core BroTime Member");
+          }
+
           tr.innerHTML = `
             <td>${getFullName(p)}</td>
             <td>${(p.earningsHistory || []).length}</td>

--- a/styles.css
+++ b/styles.css
@@ -270,6 +270,11 @@ button {
   margin-left: 4px;
 }
 
+/* Highlight for core members on admin page */
+#playersTable tr.core-member-row {
+  background-color: #fdf7e3;
+}
+
 .player-card {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- indicate core BroTime members in Admin player table
- style core member rows with soft gold background

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b90a2ec388330a877a488f6a2eb98