### PR TITLE
Define BroTM Poker v2 product and first workflow

### DIFF
--- a/docs/APPROVAL_CHECKLIST.md
+++ b/docs/APPROVAL_CHECKLIST.md
@@ -1,0 +1,20 @@
+# BroTM Poker v2 approval checklist
+
+Approve or revise these decisions before implementation begins.
+
+- [ ] The product is a private organizer tool, not a general CRM.
+- [ ] The core workflow is plan, invite, run, close, and review.
+- [ ] The MVP supports trusted organizers only.
+- [ ] Players do not need accounts in the MVP.
+- [ ] The app prepares invitation information but does not send email or SMS initially.
+- [ ] Attendance tracking is required.
+- [ ] Money tracking is optional by event.
+- [ ] The first vertical slice excludes money tracking.
+- [ ] Cloudflare Pages hosts the frontend.
+- [ ] Pages Functions provide the API.
+- [ ] D1 is the authoritative database.
+- [ ] Cloudflare Access provides MVP authentication.
+- [ ] Pages Functions validate Access JWTs and organizer status server-side.
+- [ ] Advanced analytics and public leaderboards are later features.
+
+Implementation may begin after Sterling approves this checklist or records specific revisions.

--- a/docs/ARCHITECTURE_NOTES.md
+++ b/docs/ARCHITECTURE_NOTES.md
@@ -1,0 +1,39 @@
+# Cloudflare architecture notes
+
+## Proposed request path
+
+```text
+Browser
+  -> Cloudflare Access
+  -> Cloudflare Pages
+  -> /api/* Pages Function
+  -> Access JWT validation
+  -> organizer authorization
+  -> D1
+```
+
+## Security boundary
+
+Cloudflare Access determines whether a request may reach the application, but API code must still validate the signed Access assertion and resolve the verified email to an active organizer record.
+
+The browser must never choose its own organizer identity.
+
+## Data boundary
+
+The browser communicates only with JSON endpoints under `/api/*`.
+
+D1 bindings remain server-side. No database identifier, SQL statement, or direct database credential is exposed to browser code.
+
+## Environment separation
+
+Use separate D1 databases or bindings for:
+
+- local development
+- preview deployments
+- production
+
+Preview deployments must not write to production data.
+
+## Deferred choices
+
+The exact frontend component implementation, schema indexes, and deployment-variable names may be refined during the first vertical slice. The organizer workflow and single-source-of-truth rules should not be weakened by those refinements.

--- a/docs/DATA_RULES.md
+++ b/docs/DATA_RULES.md
@@ -1,0 +1,12 @@
+# Authoritative data rules
+
+- Attendance exists only on `event_players.attended`.
+- Invitation and RSVP states exist only on `event_players`.
+- Player attendance totals are derived.
+- Last-attended dates are derived.
+- Money movement exists only as immutable ledger entries plus explicit corrections.
+- Player net results are derived.
+- Event balance is derived.
+- Missing data uses `NULL`, never a monetary sentinel.
+- Names may change without rewriting event relationships because relationships use IDs.
+- Completed events are never silently modified.

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -1,0 +1,23 @@
+# BroTM Poker decision log
+
+## 2026-07-21: Hosting reset
+
+- Hosting moved from Firebase Hosting to Cloudflare Pages.
+- Historical attendance and earnings data are not migration requirements.
+- The old Firebase application does not constrain v2.
+
+## 2026-07-21: Proposed v2 product direction
+
+Pending Sterling's approval:
+
+- BroTM Poker is an organizer tool, not a general CRM.
+- The primary workflow runs from planning through event closeout.
+- The MVP is organizer-only.
+- Players do not need accounts in the MVP.
+- Invitation delivery stays outside the application initially.
+- Attendance is core.
+- Money tracking is optional by event and follows after the first vertical slice.
+- D1 is the proposed authoritative relational database.
+- Pages Functions form the server-side API.
+- Cloudflare Access is the proposed MVP authentication boundary.
+- API routes must independently validate the Access JWT and organizer authorization.

--- a/docs/FIRST_SLICE_WORK_ORDER.md
+++ b/docs/FIRST_SLICE_WORK_ORDER.md
@@ -1,0 +1,287 @@
+# BroTM Poker v2 first vertical slice work order
+
+Status: Blocked until `docs/PRODUCT_SPEC_V2.md` is approved.
+
+## Goal
+
+Build the smallest complete, production-shaped workflow that proves the new application architecture and the organizer experience.
+
+At the end of this slice, a trusted organizer can create one player, create one poker night, attach the player to it, mark attendance, complete the event, and see the result in history.
+
+## Branch
+
+Create from the latest `main` after the product-specification pull request is merged:
+
+`agent/v2-first-vertical-slice`
+
+## Technical foundation
+
+Replace the dependency-free preview shell with a maintainable TypeScript application while preserving the existing Cloudflare Pages deployment.
+
+Recommended stack:
+
+- Vite
+- React
+- TypeScript
+- React Router
+- Zod
+- Cloudflare Pages Functions
+- Cloudflare D1
+- Wrangler
+- Vitest
+- Playwright
+
+Do not introduce a general UI framework unless the slice demonstrates a concrete need for one.
+
+## Required repository structure
+
+```text
+src/
+  app/
+  components/
+  features/
+    dashboard/
+    players/
+    events/
+    history/
+  lib/
+functions/
+  api/
+  _middleware.ts
+migrations/
+public/
+tests/
+```
+
+The exact internal organization may vary, but feature code, API code, migrations, and tests must remain clearly separated.
+
+## D1 schema
+
+Implement migrations for:
+
+- `organizers`
+- `players`
+- `events`
+- `event_players`
+- `event_audit_log`
+
+Do not add the cash ledger in this slice.
+
+All IDs should be generated server-side. All timestamps should be stored consistently in UTC.
+
+Add unique and foreign-key constraints wherever the relationship requires them, including one `event_players` row per event-player pair.
+
+## Authentication and authorization
+
+Add Cloudflare Access JWT validation middleware for `/api/*`.
+
+The middleware must:
+
+1. require `Cf-Access-Jwt-Assertion`
+2. validate its signature
+3. validate issuer and application audience
+4. extract the verified email address
+5. resolve an active organizer in D1
+6. reject unknown or inactive organizers
+
+Do not trust a browser-supplied email header, query parameter, or request body value.
+
+Expected environment values:
+
+- `TEAM_DOMAIN`
+- `POLICY_AUD`
+- D1 binding named `DB`
+
+## API routes
+
+Implement JSON APIs for the slice.
+
+### Session
+
+- `GET /api/session`
+
+Returns the verified organizer identity.
+
+### Players
+
+- `GET /api/players`
+- `POST /api/players`
+- `GET /api/players/:id`
+
+### Events
+
+- `GET /api/events`
+- `POST /api/events`
+- `GET /api/events/:id`
+- `PATCH /api/events/:id`
+
+### Event players
+
+- `POST /api/events/:eventId/players`
+- `PATCH /api/events/:eventId/players/:playerId`
+
+### Event completion
+
+- `POST /api/events/:id/complete`
+
+Completion must:
+
+- require a valid event
+- reject already completed or cancelled events
+- set status to `completed`
+- set `completed_at`
+- append an audit-log entry
+
+## Validation
+
+Use shared Zod schemas for request payloads and domain enums.
+
+Return consistent API errors:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Readable message",
+    "fields": {}
+  }
+}
+```
+
+Use appropriate status codes. Do not expose SQL errors, stack traces, binding identifiers, or Access tokens to the browser.
+
+## User interface
+
+### Application shell
+
+- authenticated organizer identity
+- mobile navigation
+- loading and error boundaries
+- production-safe empty states
+
+### Dashboard
+
+- next open event, if any
+- count of active players
+- recent completed events
+- create-player and create-event actions
+
+### Players
+
+- list active players
+- create-player form
+- player detail view
+
+For this slice, player fields are:
+
+- first name
+- last name
+- display name
+- optional email
+- optional phone
+- optional notes
+
+### Events
+
+- create draft event
+- date and start time
+- optional host
+- location
+- game notes
+- status display
+- add existing player
+- invitation and RSVP state
+- attendance toggle
+- complete event
+
+### History
+
+- list completed events
+- show event date, host, and attendance count
+- open event detail
+
+## Design requirements
+
+- mobile-first layout
+- minimum 44-pixel touch targets for primary controls
+- clear status language instead of unexplained icons
+- usable at 320 pixels wide
+- keyboard accessible on desktop
+- visible focus styles
+- reduced-motion support
+- no horizontal scrolling for the primary workflow
+
+The existing dark poker aesthetic may be refined, but the interface should prioritize speed and clarity over decorative card-table imagery.
+
+## Tests
+
+### Unit tests
+
+- request validation
+- status transitions
+- attendance derivation
+- completed-event calculations
+
+### API tests
+
+Run against local D1 and cover:
+
+- unauthorized request rejected
+- unknown organizer rejected
+- player creation and retrieval
+- event creation
+- player added to event
+- attendance updated
+- event completed
+- invalid status transition rejected
+
+### Browser smoke test
+
+Automate the complete slice:
+
+1. open dashboard with test authentication context
+2. create player
+3. create event
+4. add player
+5. mark attendance
+6. complete event
+7. verify event appears in history
+
+## Cloudflare configuration documentation
+
+Update repository documentation with exact steps for:
+
+- creating development and production D1 databases
+- applying migrations locally and remotely
+- binding `DB` to preview and production
+- adding `TEAM_DOMAIN` and `POLICY_AUD`
+- configuring Cloudflare Access for `poker.skpfam.com`
+- adding the first organizer row
+- running local development
+
+Do not commit real account IDs, database IDs, audience tags, secrets, or personal email addresses.
+
+## CI
+
+The pull request must run:
+
+- formatting check
+- lint
+- type check
+- unit tests
+- API tests
+- production build
+
+The Playwright smoke test may run in a separate job if setup cost makes that cleaner.
+
+## Done when
+
+- the entire organizer flow works locally
+- preview deployment builds successfully
+- D1 preview binding is documented and verified
+- tests pass in GitHub Actions
+- no Firebase code or references return
+- no historical-data migration exists
+- API authorization is enforced server-side
+- the full flow is reviewable from a phone
+- documentation allows the production setup to be repeated without guesswork

--- a/docs/MVP_NON_GOALS.md
+++ b/docs/MVP_NON_GOALS.md
@@ -1,0 +1,15 @@
+# BroTM Poker MVP non-goals
+
+The first release should not attempt to become:
+
+- an online poker client
+- a tournament-management suite
+- a payment processor
+- a bulk email or SMS platform
+- a public social network
+- a general-purpose CRM
+- a poker coaching application
+- a historical-data preservation project
+- a public financial leaderboard
+
+These exclusions protect the core organizer workflow from unnecessary complexity.

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -1,0 +1,7 @@
+# Product naming
+
+Use **BroTM Poker** as the product name in user-facing copy.
+
+Use `brotm-poker` for package and Cloudflare resource names where practical.
+
+The repository remains `poker-crm` for continuity, but the product should not describe itself as a CRM.

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,0 +1,12 @@
+# Remaining product questions
+
+The proposed specification is complete enough for review, but these details may be refined during implementation without changing the core product:
+
+- which organizers receive admin versus organizer role
+- default location and house-rule text
+- whether host must be a player-directory record
+- whether cancelled events remain in normal history views
+- how long an event remains editable before completion
+- whether player phone and email fields should both appear in the first slice
+
+These questions should not delay approval of the organizer-first workflow.

--- a/docs/PRODUCT_GLOSSARY.md
+++ b/docs/PRODUCT_GLOSSARY.md
@@ -1,0 +1,9 @@
+# Product glossary
+
+- **Organizer:** A trusted authenticated person allowed to operate BroTM Poker.
+- **Player:** A person who may be invited to and attend poker nights.
+- **Poker night:** One planned event from draft through completion.
+- **Event player:** The authoritative relationship between one player and one poker night.
+- **Live Night:** The mobile operational screen used during an active event.
+- **Ledger entry:** One buy-in, rebuy, cash-out, or adjustment recorded for a player during a money-tracked event.
+- **Complete:** The locked final state of a poker night.

--- a/docs/PRODUCT_PHASES.md
+++ b/docs/PRODUCT_PHASES.md
@@ -1,0 +1,45 @@
+# BroTM Poker v2 product phases
+
+## Phase 1: Organizer foundation
+
+- Cloudflare Access
+- organizer identity
+- players
+- events
+- event-player attendance
+- event completion
+- history
+
+## Phase 2: Live money tracking
+
+- buy-ins
+- rebuys
+- cash-outs
+- adjustments
+- event balance validation
+- player net results
+
+## Phase 3: Invitation improvements
+
+- reusable invite templates
+- secure RSVP links
+- player response flow without full accounts
+- optional delivery integrations
+
+## Phase 4: Useful analytics
+
+- attendance trends
+- hosting frequency
+- RSVP conversion
+- player participation summaries
+- event-balance health
+
+## Phase 5: Optional community features
+
+Only after the organizer workflow is mature:
+
+- player accounts
+- public or group-visible statistics
+- achievements
+- leaderboards
+- richer profiles

--- a/docs/PRODUCT_SPEC_V2.md
+++ b/docs/PRODUCT_SPEC_V2.md
@@ -1,0 +1,418 @@
+# BroTM Poker v2 product specification
+
+Status: Proposed for approval  
+Owner: Sterling  
+Production URL: `https://poker.skpfam.com`
+
+## 1. Product purpose
+
+**BroTM Poker is a private, mobile-first organizer tool for planning, running, and closing recurring home poker nights without scattered texts, paper notes, or duplicated bookkeeping.**
+
+The product is not a general CRM. It is the operating system for one small poker community.
+
+## 2. Primary user
+
+The primary user is a trusted BroTM Poker organizer.
+
+The first release should support Sterling and a small number of additional organizers. Players do not need accounts in the first release.
+
+### Organizer permissions
+
+Organizers can:
+
+- manage the player directory
+- create and edit poker nights
+- choose invitees
+- record invitation and RSVP status
+- check players in during the night
+- optionally record buy-ins, rebuys, cash-outs, and adjustments
+- close and lock an event
+- review event and player history
+
+### Player access
+
+Player accounts, self-service RSVP, and public statistics are later features. The MVP should not carry the complexity of custom player authentication.
+
+## 3. Core job
+
+The application must make this sequence fast and reliable:
+
+> Decide when poker night is happening, decide who is invited, see who is coming, run check-in and money tracking from a phone, then close the night with a clean permanent record.
+
+If the application does this well, it is useful even without advanced analytics.
+
+## 4. Product principles
+
+1. **Mobile first.** The live-night screen must be comfortable to use one-handed at the table.
+2. **One source of truth.** Attendance, RSVP state, and money records each exist in one authoritative place.
+3. **No rote duplicate entry.** Data entered during the night becomes the permanent event record.
+4. **Fast over elaborate.** Common actions should take one or two taps.
+5. **Private by default.** Contact information and financial results are organizer-only.
+6. **Archive, do not destroy.** Players and completed nights should normally be archived or locked, not deleted.
+7. **Optional money tracking.** A poker night can be completed with attendance only, or with a balanced cash ledger.
+8. **Purpose before statistics.** Analytics are derived from operational records and never become a second data store.
+
+## 5. Complete poker-night workflow
+
+### Phase A: Plan
+
+An organizer creates a poker night with:
+
+- date and start time
+- host
+- location
+- game or format notes
+- stakes and house-rule notes
+- optional capacity
+- optional money tracking toggle
+
+Initial status: `draft`.
+
+### Phase B: Invite
+
+The organizer selects players from the directory and assigns an invitation state:
+
+- `invited`
+- `not invited`
+
+Each invited player can then receive an RSVP state:
+
+- `pending`
+- `yes`
+- `maybe`
+- `no`
+
+The MVP does not need to send messages. It should provide a clean invite summary and copyable invite text. Automatic email, SMS, and player RSVP links belong to a later phase.
+
+When the invite list is ready, the event becomes `open`.
+
+### Phase C: Run the night
+
+The organizer opens **Live Night** on a phone.
+
+Each player row shows:
+
+- name
+- RSVP state
+- checked-in state
+- current money position when money tracking is enabled
+
+Primary actions:
+
+- check in or undo check-in
+- add buy-in
+- add rebuy
+- record cash-out
+- add a labeled adjustment
+- add a quick event note
+
+The screen should prioritize active attendees and hide unnecessary profile details.
+
+### Phase D: Close
+
+The organizer reviews:
+
+- final attendance
+- unresolved RSVP states
+- players missing cash-out values
+- total money in
+- total money out
+- any imbalance
+
+The organizer can complete an attendance-only event without money records.
+
+For a money-tracked event, the app should warn when cash-in and cash-out do not balance. An organizer may close with an explicit adjustment and note, but the imbalance must never be silently ignored.
+
+Final status: `completed`.
+
+Completed events are locked against accidental edits. An organizer can deliberately reopen one with an audit note.
+
+### Phase E: Review
+
+The completed record powers:
+
+- event history
+- player attendance history
+- last attended date
+- attendance rate
+- host frequency
+- total buy-ins and cash-outs
+- derived net result
+- unresolved or adjusted event warnings
+
+No player-level totals are manually stored.
+
+## 6. MVP features
+
+### Required
+
+- organizer-only access
+- dashboard with next or active poker night
+- player directory
+- create and edit poker night
+- invite roster and RSVP states
+- mobile Live Night mode
+- attendance check-in
+- optional cash ledger
+- event closeout validation
+- completed event history
+- player history
+- search and filtering
+- archive players
+- responsive design
+- loading, empty, success, and error states
+
+### Explicitly later
+
+- player accounts
+- self-service RSVP links
+- automated email or text delivery
+- public leaderboards
+- achievements or badges
+- poker strategy tools
+- online poker gameplay
+- payment processing
+- tournament clock or blind structure
+- historical Firebase data migration
+
+## 7. Screen inventory
+
+### Dashboard
+
+- next upcoming event
+- active event entry point
+- RSVP totals
+- expected attendance
+- incomplete closeouts
+- recent events
+- quick actions
+
+### Night Builder
+
+- details
+- invitees
+- RSVP status
+- copied invite summary
+- open, cancel, or archive controls
+
+### Live Night
+
+- large touch targets
+- attendee-first sorting
+- check-in
+- buy-in, rebuy, cash-out, and adjustment actions
+- running event totals
+- close event action
+
+### Players
+
+- searchable directory
+- active and archived filters
+- contact information
+- organizer notes
+- attendance summary
+- event history
+
+### History
+
+- completed events
+- date, host, attendance, and balance status
+- event detail view
+- deliberate reopen action
+
+### Settings
+
+- organizer list
+- default location
+- default game and stakes text
+- money-tracking defaults
+- access and security status
+
+## 8. Authoritative data model
+
+The proposed database is relational because events, players, attendance, and ledger entries have clear relationships.
+
+### `organizers`
+
+- `id`
+- `email`
+- `display_name`
+- `role`: `admin` or `organizer`
+- `active`
+- `created_at`
+- `updated_at`
+
+### `players`
+
+- `id`
+- `first_name`
+- `last_name`
+- `display_name`
+- `email`
+- `phone`
+- `status`: `active` or `archived`
+- `notes`
+- `created_at`
+- `updated_at`
+
+### `events`
+
+- `id`
+- `title`
+- `starts_at`
+- `host_player_id`, nullable
+- `location`
+- `game_notes`
+- `stakes_notes`
+- `capacity`, nullable
+- `money_tracking_enabled`
+- `status`: `draft`, `open`, `active`, `completed`, `cancelled`, or `archived`
+- `notes`
+- `created_by_organizer_id`
+- `created_at`
+- `updated_at`
+- `completed_at`, nullable
+
+### `event_players`
+
+Composite uniqueness: one row per event and player.
+
+- `id`
+- `event_id`
+- `player_id`
+- `invitation_status`: `invited` or `not_invited`
+- `rsvp_status`: `pending`, `yes`, `maybe`, or `no`
+- `attended`
+- `checked_in_at`, nullable
+- `notes`
+- `created_at`
+- `updated_at`
+
+### `ledger_entries`
+
+Money is stored as integer cents.
+
+- `id`
+- `event_id`
+- `player_id`
+- `entry_type`: `buy_in`, `rebuy`, `cash_out`, or `adjustment`
+- `amount_cents`
+- `note`, nullable
+- `created_by_organizer_id`
+- `created_at`
+
+### `event_audit_log`
+
+- `id`
+- `event_id`
+- `organizer_id`
+- `action`
+- `details_json`
+- `created_at`
+
+## 9. Derived values
+
+The application derives these values rather than storing competing copies:
+
+- attendance count from `event_players.attended`
+- player attendance total from completed event-player rows
+- last attended date from completed events
+- total cash in from buy-ins, rebuys, and positive adjustments
+- total cash out from cash-outs and negative adjustments
+- player net from ledger entries
+- event balance from total cash in minus total cash out
+- RSVP totals from event-player rows
+
+## 10. Cloudflare architecture
+
+### Frontend
+
+- Cloudflare Pages
+- TypeScript application
+- mobile-first component architecture
+- production at `poker.skpfam.com`
+
+### Server-side API
+
+- Cloudflare Pages Functions under `/api/*`
+- all writes handled server-side
+- request validation on every mutation
+- no direct browser access to the database
+
+### Database
+
+- Cloudflare D1
+- SQL migrations committed to the repository
+- local development database separate from production
+- preview and production bindings kept separate
+
+### Authentication
+
+For the MVP, protect the organizer application with Cloudflare Access using approved organizer email addresses.
+
+Pages Functions must still validate the signed Access JWT for API requests and use the verified email identity to resolve an active organizer record.
+
+This avoids building a custom password system while preserving server-side authorization.
+
+### Not needed for MVP
+
+- KV
+- R2
+- Durable Objects
+- Queues
+- custom OAuth provider
+
+These services should only be added when a concrete workflow requires them.
+
+## 11. First vertical slice
+
+The first implementation should prove one complete path rather than build disconnected screens.
+
+### Slice scope
+
+1. Organizer passes Cloudflare Access.
+2. Dashboard loads from a Pages Function.
+3. Organizer creates a player.
+4. Organizer creates a draft event.
+5. Organizer adds that player to the event.
+6. Organizer marks the player as attending.
+7. Organizer completes the event.
+8. History shows the completed event and attendance.
+
+### Included technical work
+
+- TypeScript frontend foundation
+- Pages Functions API foundation
+- D1 schema and migrations
+- Access JWT validation middleware
+- organizer identity resolution
+- players API
+- events API
+- event-player API
+- dashboard, player, event, and history UI for the slice
+- unit tests for validation and calculations
+- API tests against local D1
+- smoke test for the complete path
+
+### Excluded from the first slice
+
+- cash ledger
+- automatic invitations
+- player accounts
+- analytics dashboards
+- public pages
+
+## 12. Acceptance criteria for product approval
+
+This specification is approved when the following are accepted:
+
+- organizer-first scope
+- planning through closeout as the core workflow
+- players do not need accounts in the MVP
+- invitation delivery remains outside the app initially
+- attendance is required and money tracking is optional
+- D1 is the authoritative data store
+- Cloudflare Access protects the organizer application
+- the first vertical slice excludes advanced analytics and money tracking
+
+After approval, implementation may begin on a new feature branch.

--- a/docs/PR_SUMMARY.md
+++ b/docs/PR_SUMMARY.md
@@ -1,0 +1,5 @@
+# Product-specification pull request summary
+
+This branch defines the organizer-first purpose, complete poker-night workflow, MVP boundaries, screen inventory, relational data model, Cloudflare architecture, approval checklist, and first vertical-slice work order for BroTM Poker v2.
+
+No application feature code, database schema, or authentication implementation is included. Implementation remains blocked until the product decisions are approved.

--- a/docs/QUALITY_BAR.md
+++ b/docs/QUALITY_BAR.md
@@ -1,0 +1,15 @@
+# BroTM Poker v2 quality bar
+
+Every production feature must meet these conditions:
+
+- responsive at 320 pixels and above
+- keyboard accessible
+- visible focus states
+- no direct database access from browser code
+- server-side authorization for every write
+- one authoritative storage location for each fact
+- typed request and response contracts
+- tested status transitions
+- useful loading, empty, and error states
+- preview deployment reviewed before merge
+- documentation updated with configuration changes

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# BroTM Poker documentation
+
+- [`PRODUCT_SPEC_V2.md`](PRODUCT_SPEC_V2.md): proposed product purpose, workflow, permissions, screens, data model, and Cloudflare architecture
+- [`FIRST_SLICE_WORK_ORDER.md`](FIRST_SLICE_WORK_ORDER.md): implementation order for the first complete organizer workflow
+- [`DECISION_LOG.md`](DECISION_LOG.md): durable record of approved and proposed decisions
+- [`CLOUDFLARE_PAGES_SETUP.md`](CLOUDFLARE_PAGES_SETUP.md): hosting setup and cutover
+- [`PRODUCT_RESET.md`](PRODUCT_RESET.md): boundary between the retired prototype and v2

--- a/docs/REVIEW_NOTES.md
+++ b/docs/REVIEW_NOTES.md
@@ -1,0 +1,13 @@
+# Product review notes
+
+The proposed v2 direction deliberately favors an organizer-first operating tool over a broad CRM.
+
+The most consequential choices for Sterling to review are:
+
+1. Organizer-only MVP versus player accounts immediately.
+2. Invitation preparation versus automated delivery immediately.
+3. Attendance as the first operational record.
+4. Money tracking as the second product phase rather than the first vertical slice.
+5. Cloudflare Access plus D1 versus custom authentication.
+
+Specific revisions should be recorded in the decision log before implementation begins.

--- a/docs/SECURITY_REQUIREMENTS.md
+++ b/docs/SECURITY_REQUIREMENTS.md
@@ -1,0 +1,13 @@
+# BroTM Poker v2 security requirements
+
+- Cloudflare Access must gate the organizer application.
+- Pages Functions must validate the signed Access JWT for API requests.
+- Verified identity must resolve to an active organizer record.
+- Browser-provided identity values are never trusted.
+- D1 is accessible only from server-side Functions.
+- All SQL uses prepared statements.
+- All mutation payloads are validated.
+- Contact data and money records are organizer-only.
+- Audit records accompany event reopening and material corrections.
+- Secrets, audience tags, database IDs, and personal emails are not committed.
+- Preview deployments must not use production D1 data.

--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -1,0 +1,24 @@
+# Event state model
+
+Allowed primary transitions:
+
+```text
+draft -> open
+open -> active
+open -> cancelled
+active -> completed
+active -> cancelled
+completed -> active only through deliberate reopen
+cancelled -> archived
+completed -> archived
+```
+
+Invalid transitions must be rejected server-side.
+
+Reopening a completed event requires:
+
+- an authenticated organizer
+- a reason
+- an audit-log entry
+
+Archiving changes normal visibility but does not remove historical records.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -1,0 +1,30 @@
+# BroTM Poker v2 organizer user stories
+
+## Planning
+
+- As an organizer, I can create a poker night with a date, time, host, location, and notes so the event has one authoritative plan.
+- As an organizer, I can start from prior defaults so recurring nights do not require rote entry.
+
+## Invitations
+
+- As an organizer, I can select invitees from the player directory so I do not rebuild the roster from memory.
+- As an organizer, I can record yes, maybe, no, and pending responses so expected attendance is visible.
+- As an organizer, I can copy a concise invite summary so I can use the communication channel the group already uses.
+
+## Live night
+
+- As an organizer, I can check a player in with one tap so attendance tracking does not interrupt the game.
+- As an organizer, I can see expected players before everyone arrives.
+- As an organizer, I can correct an accidental check-in without editing a database record manually.
+
+## Closeout
+
+- As an organizer, I can complete an attendance-only night.
+- As an organizer, I can see missing money records and imbalances when optional money tracking is enabled.
+- As an organizer, I can lock a completed night so later accidental edits do not rewrite history.
+
+## History
+
+- As an organizer, I can see who attended each night.
+- As an organizer, I can see a player's attendance history without maintaining a separate count.
+- As an organizer, I can reopen a completed event deliberately with an audit note when a correction is necessary.


### PR DESCRIPTION
## What this does

Defines the clean-slate product direction for BroTM Poker v2 before application implementation begins.

The branch adds:

- one-sentence product purpose
- organizer-first permission model
- complete plan, invite, run, close, and review workflow
- MVP requirements and explicit non-goals
- screen inventory
- authoritative relational data model
- Cloudflare Pages, Pages Functions, D1, and Access architecture
- security and data-authority rules
- phased roadmap
- approval checklist
- detailed first vertical-slice work order

## Proposed core decision

BroTM Poker becomes a private, mobile-first operating tool for one small poker community, not a general CRM.

The first release is organizer-only. It prioritizes event planning, invite and RSVP tracking, live attendance, event completion, and history. Money tracking remains optional by event and follows after the first vertical slice.

## Why implementation is not included

Issue #86 explicitly requires product purpose and the first complete workflow to be approved before D1 schema or authentication work begins. This pull request is the approval boundary.

## Review focus

Please review `docs/APPROVAL_CHECKLIST.md` and record any revisions before merge.

## Implementation after approval

`docs/FIRST_SLICE_WORK_ORDER.md` defines the next build branch and its acceptance criteria.

Closes #86 when the product decisions are approved and this PR is merged.