### PR TITLE
Use one D1 database and restore dashboard bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,45 @@
 # BroTM Poker
 
-A private, mobile-first organizer application for planning, running, and closing recurring home poker nights.
+A private, mobile-first organizer application for planning, running, and closing recurring poker nights.
 
-## Current slice
-
-The v2 organizer foundation supports:
-
-- Cloudflare Access-backed organizer identity
-- player creation and directory browsing
-- draft poker-night creation
-- event rosters and RSVP status
-- live attendance check-in
-- controlled event status transitions
-- event completion and history
-
-Money tracking, automatic invitations, player accounts, and analytics are intentionally later phases.
-
-## Stack
+## Technology
 
 - Cloudflare Pages
 - Cloudflare Pages Functions
-- Cloudflare D1
+- One remote Cloudflare D1 database
+- Wrangler local D1 storage for development
 - Cloudflare Access
-- React
-- TypeScript
-- Vite
-- Zod
-- Vitest
+- React, TypeScript, and Vite
 
-## Install and validate
+## Local validation
 
 ```bash
 npm install
 npm run check
 ```
 
-The production build writes to `dist/`.
-
-## Local development
-
-Apply the initial migration and add a development organizer before starting Pages Functions. See [`docs/CLOUDFLARE_V2_SETUP.md`](docs/CLOUDFLARE_V2_SETUP.md).
+## Local application development
 
 ```bash
+npm run db:migrate:local
 npm run build
 npm run dev
 ```
 
-For frontend-only styling work:
-
-```bash
-npm run dev:web
-```
+Create `.dev.vars` and seed a local organizer before starting the application. See [`docs/CLOUDFLARE_V2_SETUP.md`](docs/CLOUDFLARE_V2_SETUP.md).
 
 ## Cloudflare Pages
 
 - Build command: `npm run build`
 - Build output directory: `dist`
 - Root directory: leave blank
-- D1 binding: `DB`
-- Required variables: `TEAM_DOMAIN`, `POLICY_AUD`, `ENVIRONMENT`
+- Production branch: `main`
 
-Production: `https://poker.skpfam.com`
+The Production environment needs one D1 binding named `DB`, pointing to `brotm-poker`. Bindings are managed in the Cloudflare dashboard.
+
+## Documentation
+
+- [`docs/CLOUDFLARE_V2_SETUP.md`](docs/CLOUDFLARE_V2_SETUP.md): D1, Access, Pages variables, and organizer setup
+- [`docs/PRODUCT_SPEC_V2.md`](docs/PRODUCT_SPEC_V2.md): approved product definition
+- [`docs/FIRST_SLICE_WORK_ORDER.md`](docs/FIRST_SLICE_WORK_ORDER.md): implementation scope and acceptance criteria
+- [`docs/DECISION_LOG.md`](docs/DECISION_LOG.md): durable product and architecture decisions

--- a/docs/CLOUDFLARE_V2_SETUP.md
+++ b/docs/CLOUDFLARE_V2_SETUP.md
@@ -1,75 +1,65 @@
 # Cloudflare v2 setup
 
-This guide connects the first BroTM Poker application slice to D1 and Cloudflare Access without committing account identifiers or personal email addresses.
+This guide connects the first BroTM Poker application slice to one remote D1 database and Cloudflare Access without committing account identifiers or personal email addresses.
 
-## 1. Create D1 databases
+## 1. Create one D1 database
 
-Create separate databases for preview/development and production.
+Create one remote database:
 
 ```bash
-npx wrangler d1 create brotm-poker-dev
-npx wrangler d1 create brotm-poker-production
+npx wrangler d1 create brotm-poker
 ```
 
-Keep the returned database IDs in Cloudflare configuration. Do not commit them to the repository.
+This consumes one Cloudflare D1 database slot. Local development uses Wrangler's local D1 storage and does not consume another remote slot.
 
 ## 2. Apply migrations
+
+Local development database:
+
+```bash
+npm run db:migrate:local
+```
+
+Remote production database:
+
+```bash
+npm run db:migrate:remote
+```
+
+Both commands apply the committed migrations in `migrations/`. Local data is stored under `.wrangler/state` and remains separate from production.
+
+## 3. Add the first organizer
+
+Replace every placeholder before running.
 
 Local development:
 
 ```bash
-npx wrangler d1 migrations apply brotm-poker-dev --local
-```
-
-Remote preview/development database:
-
-```bash
-npx wrangler d1 migrations apply brotm-poker-dev --remote
-```
-
-Production database:
-
-```bash
-npx wrangler d1 migrations apply brotm-poker-production --remote
-```
-
-## 3. Add the first organizer
-
-Generate UUIDs locally or use any standards-compliant UUID generator. Replace every placeholder before running.
-
-Development:
-
-```bash
-npx wrangler d1 execute brotm-poker-dev --remote --command "INSERT INTO organizers (id, email, display_name, role, active, created_at, updated_at) VALUES ('<UUID>', '<ORGANIZER_EMAIL>', '<DISPLAY_NAME>', 'admin', 1, datetime('now'), datetime('now'));"
+npx wrangler d1 execute brotm-poker --local --command "INSERT INTO organizers (id, email, display_name, role, active, created_at, updated_at) VALUES ('<UUID>', '<ORGANIZER_EMAIL>', '<DISPLAY_NAME>', 'admin', 1, datetime('now'), datetime('now'));"
 ```
 
 Production:
 
 ```bash
-npx wrangler d1 execute brotm-poker-production --remote --command "INSERT INTO organizers (id, email, display_name, role, active, created_at, updated_at) VALUES ('<UUID>', '<ORGANIZER_EMAIL>', '<DISPLAY_NAME>', 'admin', 1, datetime('now'), datetime('now'));"
+npx wrangler d1 execute brotm-poker --remote --command "INSERT INTO organizers (id, email, display_name, role, active, created_at, updated_at) VALUES ('<UUID>', '<ORGANIZER_EMAIL>', '<DISPLAY_NAME>', 'admin', 1, datetime('now'), datetime('now'));"
 ```
 
-The organizer email must exactly match the email authenticated by Cloudflare Access. Matching is case-insensitive.
+The organizer email must match the email authenticated by Cloudflare Access. Matching is case-insensitive.
 
 ## 4. Bind D1 to Pages
 
-In the Cloudflare dashboard, open the Git-integrated Pages project.
+Bindings are managed in the Cloudflare dashboard.
 
-For **Preview**:
+1. Open the Pages project.
+2. Go to **Settings**.
+3. Select the **Production** environment.
+4. Open **Bindings**.
+5. Select **Add** and choose **D1 database**.
+6. Variable name: `DB`.
+7. Database: `brotm-poker`.
+8. Save and redeploy `main`.
 
-1. Open **Settings**.
-2. Open **Bindings**.
-3. Add a D1 database binding.
-4. Variable name: `DB`.
-5. Database: `brotm-poker-dev`.
-
-For **Production**:
-
-1. Switch the environment selector to Production.
-2. Add the same `DB` binding.
-3. Database: `brotm-poker-production`.
-
-Preview deployments must never bind to the production database.
+Do not bind the production database to Preview deployments. Preview builds can validate the frontend; full data-flow testing happens locally.
 
 ## 5. Configure Cloudflare Access
 
@@ -86,17 +76,17 @@ Do not commit either value.
 
 ## 6. Add Pages variables
 
-Add these plain-text variables to both Preview and Production, using the proper values for each environment:
+For the **Production** environment, add:
 
 - `TEAM_DOMAIN`: the Zero Trust team domain without `https://`
 - `POLICY_AUD`: the Access application audience tag
-- `ENVIRONMENT`: `preview` or `production`
+- `ENVIRONMENT`: `production`
 
-The API validates the signed `Cf-Access-Jwt-Assertion` header, issuer, audience, expiry, signature, and organizer database record.
+For Preview, `ENVIRONMENT=preview` may be set, but no production D1 binding should be attached.
 
 ## 7. Local development identity
 
-For local Pages development only, create a `.dev.vars` file:
+Create a `.dev.vars` file:
 
 ```text
 ENVIRONMENT=development
@@ -104,8 +94,6 @@ DEV_ORGANIZER_EMAIL=<ORGANIZER_EMAIL>
 TEAM_DOMAIN=unused-locally
 POLICY_AUD=unused-locally
 ```
-
-`.dev.vars` is ignored by Git and must not be committed.
 
 The local organizer email must exist in the local D1 database.
 
@@ -128,9 +116,10 @@ npm run dev
 - Access challenges an unauthenticated visit to `poker.skpfam.com`.
 - An approved organizer reaches the application.
 - An authenticated but unregistered email receives a forbidden message.
+- Production has one D1 binding named `DB` pointing to `brotm-poker`.
+- `ENVIRONMENT` is `production`, not `development`.
 - A player can be created.
 - A draft event can be created.
 - A player can be added and checked in.
 - The event can move from draft to open to active to completed.
 - The completed event appears in History.
-- Preview data does not appear in production.

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -21,3 +21,10 @@ Sterling approved the following direction:
 - Pages Functions form the server-side API.
 - Cloudflare Access is the MVP authentication boundary.
 - API routes independently validate the Access JWT and organizer authorization.
+
+## 2026-07-22: One remote D1 database
+
+- Production uses one remote D1 database named `brotm-poker`.
+- Local development uses Wrangler local D1 storage and consumes no remote database slot.
+- Preview deployments do not bind to production data.
+- Pages bindings are managed in the Cloudflare dashboard rather than a deployed `wrangler.toml`.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build",
-    "db:migrate:local": "wrangler d1 migrations apply brotm-poker-dev --local",
-    "db:migrate:remote": "wrangler d1 migrations apply brotm-poker-production --remote"
+    "db:migrate:local": "wrangler d1 migrations apply brotm-poker --local",
+    "db:migrate:remote": "wrangler d1 migrations apply brotm-poker --remote"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,0 @@
-name = "brotm-poker"
-compatibility_date = "2026-07-21"
-pages_build_output_dir = "dist"
-
-[vars]
-ENVIRONMENT = "development"


### PR DESCRIPTION
## What changed

- Removed the deployed `wrangler.toml` that was locking Pages bindings to repository configuration.
- Restored Cloudflare dashboard control for Pages bindings.
- Revised BroTM Poker to use one remote D1 database named `brotm-poker`.
- Kept local development on Wrangler local D1 storage, which consumes no Cloudflare database slot.
- Removed the separate preview/development remote database requirement.
- Updated scripts and setup documentation.

## Result

After this PR is merged and Cloudflare completes a new deployment from `main`, the **Add** control under **Settings > Bindings** should become editable again.

Configure only the Production environment:

- Binding type: D1 database
- Variable name: `DB`
- Database: `brotm-poker`

Leave Preview without the production D1 binding.

Also change the Production `ENVIRONMENT` variable from `development` to `production`.
