### PR TITLE
Add full editing and audited event corrections

### DIFF
--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -5,8 +5,11 @@ import {
   eventCreateSchema,
   eventPatchSchema,
   eventPlayerCreateSchema,
+  eventPlayerDeleteSchema,
   eventPlayerPatchSchema,
+  eventReopenSchema,
   playerCreateSchema,
+  playerPatchSchema,
   type EventStatus,
 } from "../../shared/domain";
 import { apiError, json, readJson, validationError } from "../lib/http";
@@ -33,6 +36,7 @@ interface EventRow {
   host_name: string | null;
   location: string;
   game_notes: string | null;
+  notes: string | null;
   status: EventStatus;
   created_at: string;
   updated_at: string;
@@ -51,6 +55,14 @@ interface EventPlayerRow {
   attended: number;
   checked_in_at: string | null;
   notes: string | null;
+}
+
+interface EventAuditRow {
+  id: string;
+  action: string;
+  details_json: string;
+  created_at: string;
+  organizer_name: string;
 }
 
 function playerJson(row: PlayerRow) {
@@ -77,6 +89,7 @@ function eventJson(row: EventRow) {
     hostName: row.host_name,
     location: row.location,
     gameNotes: row.game_notes,
+    notes: row.notes,
     status: row.status,
     attendanceCount: Number(row.attendance_count ?? 0),
     playerCount: Number(row.player_count ?? 0),
@@ -100,6 +113,63 @@ function eventPlayerJson(row: EventPlayerRow) {
   };
 }
 
+function auditJson(row: EventAuditRow) {
+  let details: Record<string, unknown> = {};
+  try {
+    details = JSON.parse(row.details_json) as Record<string, unknown>;
+  } catch {
+    details = {};
+  }
+  return {
+    id: row.id,
+    action: row.action,
+    details,
+    organizerName: row.organizer_name,
+    createdAt: row.created_at,
+  };
+}
+
+function isLockedStatus(status: EventStatus): boolean {
+  return ["completed", "cancelled", "archived"].includes(status);
+}
+
+function requireCorrectionNote(event: EventRow, note?: string): string | undefined {
+  if (!isLockedStatus(event.status)) return undefined;
+  if (!note) {
+    throw new Response("A correction note is required to edit a locked event.", { status: 409 });
+  }
+  return note;
+}
+
+function auditStatement(
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+  action: string,
+  details: Record<string, unknown>,
+  createdAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO event_audit_log
+       (id, event_id, organizer_id, action, details_json, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(crypto.randomUUID(), eventId, organizer.id, action, JSON.stringify(details), createdAt);
+}
+
+function changesBetween(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): Record<string, { from: unknown; to: unknown }> {
+  const changes: Record<string, { from: unknown; to: unknown }> = {};
+  for (const [field, to] of Object.entries(after)) {
+    const from = before[field];
+    if (!Object.is(from, to)) changes[field] = { from, to };
+  }
+  return changes;
+}
+
 async function getEvent(db: D1Database, id: string): Promise<EventRow | null> {
   return db
     .prepare(
@@ -116,12 +186,9 @@ async function getEvent(db: D1Database, id: string): Promise<EventRow | null> {
     .first<EventRow>();
 }
 
-async function requireEditableEvent(db: D1Database, id: string): Promise<EventRow> {
+async function requireEvent(db: D1Database, id: string): Promise<EventRow> {
   const event = await getEvent(db, id);
   if (!event) throw new Response("Event not found", { status: 404 });
-  if (["completed", "cancelled", "archived"].includes(event.status)) {
-    throw new Response("Completed or cancelled events cannot be edited", { status: 409 });
-  }
   return event;
 }
 
@@ -165,10 +232,17 @@ async function dashboard(db: D1Database): Promise<Response> {
   });
 }
 
-async function listPlayers(db: D1Database): Promise<Response> {
-  const rows = await db
-    .prepare("SELECT * FROM players WHERE status = 'active' ORDER BY display_name COLLATE NOCASE")
-    .all<PlayerRow>();
+async function listPlayers(request: Request, db: D1Database): Promise<Response> {
+  const status = new URL(request.url).searchParams.get("status") ?? "active";
+  if (!["active", "archived", "all"].includes(status)) {
+    return apiError(400, "BAD_REQUEST", "Player status filter is invalid.");
+  }
+
+  const statement =
+    status === "all"
+      ? db.prepare("SELECT * FROM players ORDER BY status, display_name COLLATE NOCASE")
+      : db.prepare("SELECT * FROM players WHERE status = ?1 ORDER BY display_name COLLATE NOCASE").bind(status);
+  const rows = await statement.all<PlayerRow>();
   return json({ players: rows.results.map(playerJson) });
 }
 
@@ -221,6 +295,38 @@ async function playerDetail(db: D1Database, id: string): Promise<Response> {
   return json({ player: playerJson(player), history: history.results.map(eventJson) });
 }
 
+async function patchPlayer(request: Request, db: D1Database, id: string): Promise<Response> {
+  const current = await db.prepare("SELECT * FROM players WHERE id = ?1").bind(id).first<PlayerRow>();
+  if (!current) return apiError(404, "NOT_FOUND", "Player not found.");
+
+  const input = playerPatchSchema.parse(await readJson(request));
+  const firstName = input.firstName ?? current.first_name;
+  const lastName = input.lastName ?? current.last_name;
+  const displayName =
+    input.displayName !== undefined
+      ? deriveDisplayName({ firstName, lastName, displayName: input.displayName })
+      : current.display_name;
+  const email = input.email !== undefined ? input.email : (current.email ?? "");
+  const phone = input.phone !== undefined ? input.phone : (current.phone ?? "");
+  const notes = input.notes !== undefined ? input.notes : (current.notes ?? "");
+  const status = input.status ?? current.status;
+  const now = new Date().toISOString();
+
+  await db
+    .prepare(
+      `UPDATE players
+       SET first_name = ?1, last_name = ?2, display_name = ?3,
+           email = NULLIF(?4, ''), phone = NULLIF(?5, ''), notes = NULLIF(?6, ''),
+           status = ?7, updated_at = ?8
+       WHERE id = ?9`,
+    )
+    .bind(firstName, lastName, displayName, email, phone, notes, status, now, id)
+    .run();
+
+  const row = await db.prepare("SELECT * FROM players WHERE id = ?1").bind(id).first<PlayerRow>();
+  return json({ player: playerJson(row as PlayerRow) });
+}
+
 async function listEvents(request: Request, db: D1Database): Promise<Response> {
   const status = new URL(request.url).searchParams.get("status");
   const where = status ? "WHERE e.status = ?1" : "";
@@ -251,9 +357,9 @@ async function createEvent(
   await db
     .prepare(
       `INSERT INTO events
-       (id, title, starts_at, host_player_id, location, game_notes, status,
+       (id, title, starts_at, host_player_id, location, game_notes, notes, status,
         created_by_organizer_id, created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, NULLIF(?6, ''), 'draft', ?7, ?8, ?8)`,
+       VALUES (?1, ?2, ?3, ?4, ?5, NULLIF(?6, ''), NULLIF(?7, ''), 'draft', ?8, ?9, ?9)`,
     )
     .bind(
       id,
@@ -262,6 +368,7 @@ async function createEvent(
       input.hostPlayerId ?? null,
       input.location,
       input.gameNotes ?? "",
+      input.notes ?? "",
       organizer.id,
       now,
     )
@@ -272,7 +379,7 @@ async function createEvent(
 }
 
 async function eventDetail(db: D1Database, id: string): Promise<Response> {
-  const [event, players] = await Promise.all([
+  const [event, players, audits] = await Promise.all([
     getEvent(db, id),
     db
       .prepare(
@@ -280,66 +387,140 @@ async function eventDetail(db: D1Database, id: string): Promise<Response> {
          FROM event_players ep
          JOIN players p ON p.id = ep.player_id
          WHERE ep.event_id = ?1
-         ORDER BY p.display_name COLLATE NOCASE`,
+         ORDER BY ep.attended DESC, p.display_name COLLATE NOCASE`,
       )
       .bind(id)
       .all<EventPlayerRow>(),
+    db
+      .prepare(
+        `SELECT l.id, l.action, l.details_json, l.created_at,
+                o.display_name AS organizer_name
+         FROM event_audit_log l
+         JOIN organizers o ON o.id = l.organizer_id
+         WHERE l.event_id = ?1
+         ORDER BY l.created_at DESC`,
+      )
+      .bind(id)
+      .all<EventAuditRow>(),
   ]);
   if (!event) return apiError(404, "NOT_FOUND", "Event not found.");
-  return json({ event: eventJson(event), players: players.results.map(eventPlayerJson) });
+  return json({
+    event: eventJson(event),
+    players: players.results.map(eventPlayerJson),
+    audits: audits.results.map(auditJson),
+  });
 }
 
-async function patchEvent(request: Request, db: D1Database, id: string): Promise<Response> {
-  const current = await requireEditableEvent(db, id);
+async function patchEvent(
+  request: Request,
+  db: D1Database,
+  id: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const current = await requireEvent(db, id);
   const input = eventPatchSchema.parse(await readJson(request));
+  const correction = requireCorrectionNote(current, input.correctionNote);
 
-  if (input.status && !canTransition(current.status, input.status)) {
-    return apiError(409, "INVALID_TRANSITION", `Cannot move from ${current.status} to ${input.status}.`);
+  if (input.status) {
+    if (isLockedStatus(current.status)) {
+      return apiError(409, "LOCKED_EVENT", "Use the dedicated reopen action for a completed event.");
+    }
+    if (!canTransition(current.status, input.status)) {
+      return apiError(409, "INVALID_TRANSITION", `Cannot move from ${current.status} to ${input.status}.`);
+    }
   }
 
-  const columnMap = {
-    title: "title",
-    startsAt: "starts_at",
-    hostPlayerId: "host_player_id",
-    location: "location",
-    gameNotes: "game_notes",
-    status: "status",
-  } as const;
-  const entries = Object.entries(input) as Array<[keyof typeof columnMap, unknown]>;
-  const assignments = entries.map(([key], index) => `${columnMap[key]} = ?${index + 1}`);
-  const values = entries.map(([, value]) => value);
-  assignments.push(`updated_at = ?${values.length + 1}`);
-  values.push(new Date().toISOString(), id);
+  const updates: string[] = [];
+  const values: unknown[] = [];
+  const before: Record<string, unknown> = {};
+  const after: Record<string, unknown> = {};
+  const setField = (field: string, column: string, currentValue: unknown, value: unknown) => {
+    values.push(value);
+    updates.push(`${column} = ?${values.length}`);
+    before[field] = currentValue;
+    after[field] = value;
+  };
 
-  await db
-    .prepare(`UPDATE events SET ${assignments.join(", ")} WHERE id = ?${values.length}`)
-    .bind(...values)
-    .run();
+  if (input.title !== undefined) setField("title", "title", current.title, input.title);
+  if (input.startsAt !== undefined) setField("startsAt", "starts_at", current.starts_at, input.startsAt);
+  if (input.hostPlayerId !== undefined) {
+    setField("hostPlayerId", "host_player_id", current.host_player_id, input.hostPlayerId);
+  }
+  if (input.location !== undefined) setField("location", "location", current.location, input.location);
+  if (input.gameNotes !== undefined) {
+    setField("gameNotes", "game_notes", current.game_notes, input.gameNotes || null);
+  }
+  if (input.notes !== undefined) setField("notes", "notes", current.notes, input.notes || null);
+  if (input.status !== undefined) setField("status", "status", current.status, input.status);
+
+  const now = new Date().toISOString();
+  values.push(now, id);
+  updates.push(`updated_at = ?${values.length - 1}`);
+  const update = db
+    .prepare(`UPDATE events SET ${updates.join(", ")} WHERE id = ?${values.length}`)
+    .bind(...values);
+
+  if (correction) {
+    await db.batch([
+      update,
+      auditStatement(
+        db,
+        id,
+        organizer,
+        "event_corrected",
+        { correctionNote: correction, changes: changesBetween(before, after) },
+        now,
+      ),
+    ]);
+  } else {
+    await update.run();
+  }
 
   const event = await getEvent(db, id);
   return json({ event: eventJson(event as EventRow) });
 }
 
-async function addEventPlayer(request: Request, db: D1Database, eventId: string): Promise<Response> {
-  await requireEditableEvent(db, eventId);
+async function addEventPlayer(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
   const input = eventPlayerCreateSchema.parse(await readJson(request));
-  const player = await db
-    .prepare("SELECT id FROM players WHERE id = ?1 AND status = 'active'")
-    .bind(input.playerId)
-    .first<{ id: string }>();
+  const correction = requireCorrectionNote(event, input.correctionNote);
+  const player = await db.prepare("SELECT id, display_name FROM players WHERE id = ?1").bind(input.playerId).first<{
+    id: string;
+    display_name: string;
+  }>();
   if (!player) return apiError(404, "NOT_FOUND", "Player not found.");
 
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
+  const insert = db
+    .prepare(
+      `INSERT INTO event_players
+       (id, event_id, player_id, invitation_status, rsvp_status, attended, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?6)`,
+    )
+    .bind(id, eventId, input.playerId, input.invitationStatus, input.rsvpStatus, now);
+
   try {
-    await db
-      .prepare(
-        `INSERT INTO event_players
-         (id, event_id, player_id, invitation_status, rsvp_status, attended, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?6)`,
-      )
-      .bind(id, eventId, input.playerId, input.invitationStatus, input.rsvpStatus, now)
-      .run();
+    if (correction) {
+      await db.batch([
+        insert,
+        auditStatement(
+          db,
+          eventId,
+          organizer,
+          "event_player_added_correction",
+          { correctionNote: correction, playerId: player.id, playerName: player.display_name },
+          now,
+        ),
+      ]);
+    } else {
+      await insert.run();
+    }
   } catch {
     return apiError(409, "ALREADY_EXISTS", "That player is already on this event.");
   }
@@ -352,38 +533,134 @@ async function patchEventPlayer(
   db: D1Database,
   eventId: string,
   playerId: string,
+  organizer: OrganizerIdentity,
 ): Promise<Response> {
-  await requireEditableEvent(db, eventId);
+  const event = await requireEvent(db, eventId);
   const input = eventPlayerPatchSchema.parse(await readJson(request));
+  const correction = requireCorrectionNote(event, input.correctionNote);
+  const current = await db
+    .prepare(
+      `SELECT ep.*, p.display_name
+       FROM event_players ep
+       JOIN players p ON p.id = ep.player_id
+       WHERE ep.event_id = ?1 AND ep.player_id = ?2`,
+    )
+    .bind(eventId, playerId)
+    .first<EventPlayerRow>();
+  if (!current) return apiError(404, "NOT_FOUND", "Event player not found.");
+
   const updates: string[] = [];
   const values: unknown[] = [];
+  const before: Record<string, unknown> = {};
+  const after: Record<string, unknown> = {};
+  const setField = (field: string, column: string, currentValue: unknown, value: unknown) => {
+    values.push(value);
+    updates.push(`${column} = ?${values.length}`);
+    before[field] = currentValue;
+    after[field] = value;
+  };
 
+  if (input.invitationStatus !== undefined) {
+    setField(
+      "invitationStatus",
+      "invitation_status",
+      current.invitation_status,
+      input.invitationStatus,
+    );
+  }
   if (input.rsvpStatus !== undefined) {
-    values.push(input.rsvpStatus);
-    updates.push(`rsvp_status = ?${values.length}`);
+    setField("rsvpStatus", "rsvp_status", current.rsvp_status, input.rsvpStatus);
   }
   if (input.attended !== undefined) {
-    values.push(input.attended ? 1 : 0);
-    updates.push(`attended = ?${values.length}`);
+    setField("attended", "attended", Boolean(current.attended), input.attended ? 1 : 0);
     values.push(input.attended ? new Date().toISOString() : null);
     updates.push(`checked_in_at = ?${values.length}`);
   }
   if (input.notes !== undefined) {
-    values.push(input.notes);
-    updates.push(`notes = ?${values.length}`);
+    setField("notes", "notes", current.notes, input.notes || null);
   }
-  values.push(new Date().toISOString(), eventId, playerId);
-  updates.push(`updated_at = ?${values.length - 2}`);
 
-  const result = await db
+  const now = new Date().toISOString();
+  values.push(now, eventId, playerId);
+  updates.push(`updated_at = ?${values.length - 2}`);
+  const update = db
     .prepare(
       `UPDATE event_players SET ${updates.join(", ")}
        WHERE event_id = ?${values.length - 1} AND player_id = ?${values.length}`,
     )
-    .bind(...values)
-    .run();
+    .bind(...values);
 
-  if (!result.meta.changes) return apiError(404, "NOT_FOUND", "Event player not found.");
+  if (correction) {
+    await db.batch([
+      update,
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        "event_player_corrected",
+        {
+          correctionNote: correction,
+          playerId,
+          playerName: current.display_name,
+          changes: changesBetween(before, after),
+        },
+        now,
+      ),
+    ]);
+  } else {
+    await update.run();
+  }
+
+  return eventDetail(db, eventId);
+}
+
+async function removeEventPlayer(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  playerId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  const input = eventPlayerDeleteSchema.parse(await readJson(request));
+  const correction = requireCorrectionNote(event, input.correctionNote);
+  const current = await db
+    .prepare(
+      `SELECT ep.*, p.display_name
+       FROM event_players ep
+       JOIN players p ON p.id = ep.player_id
+       WHERE ep.event_id = ?1 AND ep.player_id = ?2`,
+    )
+    .bind(eventId, playerId)
+    .first<EventPlayerRow>();
+  if (!current) return apiError(404, "NOT_FOUND", "Event player not found.");
+
+  const now = new Date().toISOString();
+  const remove = db
+    .prepare("DELETE FROM event_players WHERE event_id = ?1 AND player_id = ?2")
+    .bind(eventId, playerId);
+
+  if (correction) {
+    await db.batch([
+      remove,
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        "event_player_removed_correction",
+        {
+          correctionNote: correction,
+          playerId,
+          playerName: current.display_name,
+          attended: Boolean(current.attended),
+        },
+        now,
+      ),
+    ]);
+  } else {
+    await remove.run();
+  }
+
   return eventDetail(db, eventId);
 }
 
@@ -407,23 +684,52 @@ async function completeEvent(
          WHERE id = ?2 AND status = 'active'`,
       )
       .bind(now, id),
-    db
-      .prepare(
-        `INSERT INTO event_audit_log
-         (id, event_id, organizer_id, action, details_json, created_at)
-         VALUES (?1, ?2, ?3, 'event_completed', ?4, ?5)`,
-      )
-      .bind(
-        crypto.randomUUID(),
-        id,
-        organizer.id,
-        JSON.stringify({ attendanceCount: event.attendance_count ?? 0 }),
-        now,
-      ),
+    auditStatement(
+      db,
+      id,
+      organizer,
+      "event_completed",
+      { attendanceCount: event.attendance_count ?? 0 },
+      now,
+    ),
   ]);
 
   const completed = await getEvent(db, id);
   return json({ event: eventJson(completed as EventRow) });
+}
+
+async function reopenEvent(
+  request: Request,
+  db: D1Database,
+  id: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, id);
+  if (event.status !== "completed") {
+    return apiError(409, "INVALID_TRANSITION", "Only a completed event can be reopened.");
+  }
+  const input = eventReopenSchema.parse(await readJson(request));
+  const now = new Date().toISOString();
+
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE events
+         SET status = 'active', completed_at = NULL, updated_at = ?1
+         WHERE id = ?2 AND status = 'completed'`,
+      )
+      .bind(now, id),
+    auditStatement(
+      db,
+      id,
+      organizer,
+      "event_reopened",
+      { correctionNote: input.correctionNote, previousStatus: "completed" },
+      now,
+    ),
+  ]);
+
+  return eventDetail(db, id);
 }
 
 export const onRequest: AppPagesFunction = async (context) => {
@@ -440,11 +746,12 @@ export const onRequest: AppPagesFunction = async (context) => {
       return dashboard(context.env.DB);
     }
     if (parts[0] === "players" && parts.length === 1) {
-      if (method === "GET") return listPlayers(context.env.DB);
+      if (method === "GET") return listPlayers(request, context.env.DB);
       if (method === "POST") return createPlayer(request, context.env.DB);
     }
-    if (method === "GET" && parts[0] === "players" && parts[1] && parts.length === 2) {
-      return playerDetail(context.env.DB, parts[1]);
+    if (parts[0] === "players" && parts[1] && parts.length === 2) {
+      if (method === "GET") return playerDetail(context.env.DB, parts[1]);
+      if (method === "PATCH") return patchPlayer(request, context.env.DB, parts[1]);
     }
     if (parts[0] === "events" && parts.length === 1) {
       if (method === "GET") return listEvents(request, context.env.DB);
@@ -452,27 +759,26 @@ export const onRequest: AppPagesFunction = async (context) => {
     }
     if (parts[0] === "events" && parts[1] && parts.length === 2) {
       if (method === "GET") return eventDetail(context.env.DB, parts[1]);
-      if (method === "PATCH") return patchEvent(request, context.env.DB, parts[1]);
+      if (method === "PATCH") {
+        return patchEvent(request, context.env.DB, parts[1], context.data.organizer);
+      }
     }
     if (method === "POST" && parts[0] === "events" && parts[2] === "players" && parts.length === 3) {
-      return addEventPlayer(request, context.env.DB, parts[1]);
+      return addEventPlayer(request, context.env.DB, parts[1], context.data.organizer);
     }
-    if (
-      method === "PATCH" &&
-      parts[0] === "events" &&
-      parts[2] === "players" &&
-      parts[3] &&
-      parts.length === 4
-    ) {
-      return patchEventPlayer(request, context.env.DB, parts[1], parts[3]);
+    if (parts[0] === "events" && parts[2] === "players" && parts[3] && parts.length === 4) {
+      if (method === "PATCH") {
+        return patchEventPlayer(request, context.env.DB, parts[1], parts[3], context.data.organizer);
+      }
+      if (method === "DELETE") {
+        return removeEventPlayer(request, context.env.DB, parts[1], parts[3], context.data.organizer);
+      }
     }
-    if (
-      method === "POST" &&
-      parts[0] === "events" &&
-      parts[2] === "complete" &&
-      parts.length === 3
-    ) {
+    if (method === "POST" && parts[0] === "events" && parts[2] === "complete" && parts.length === 3) {
       return completeEvent(context.env.DB, parts[1], context.data.organizer);
+    }
+    if (method === "POST" && parts[0] === "events" && parts[2] === "reopen" && parts.length === 3) {
+      return reopenEvent(request, context.env.DB, parts[1], context.data.organizer);
     }
 
     return apiError(404, "NOT_FOUND", "API route not found.");

--- a/shared/domain.ts
+++ b/shared/domain.ts
@@ -13,14 +13,32 @@ export type EventStatus = (typeof eventStatuses)[number];
 export const rsvpStatuses = ["pending", "yes", "maybe", "no"] as const;
 export type RsvpStatus = (typeof rsvpStatuses)[number];
 
+export const invitationStatuses = ["invited", "not_invited"] as const;
+export type InvitationStatus = (typeof invitationStatuses)[number];
+
+const optionalEmail = z.string().trim().email().max(200).optional().or(z.literal(""));
+const correctionNote = z.string().trim().min(3).max(500).optional();
+
 export const playerCreateSchema = z.object({
   firstName: z.string().trim().min(1).max(80),
   lastName: z.string().trim().max(80).default(""),
   displayName: z.string().trim().min(1).max(120).optional(),
-  email: z.string().trim().email().max(200).optional().or(z.literal("")),
+  email: optionalEmail,
   phone: z.string().trim().max(40).optional(),
   notes: z.string().trim().max(1000).optional(),
 });
+
+export const playerPatchSchema = z
+  .object({
+    firstName: z.string().trim().min(1).max(80).optional(),
+    lastName: z.string().trim().max(80).optional(),
+    displayName: z.string().trim().max(120).optional(),
+    email: optionalEmail,
+    phone: z.string().trim().max(40).optional(),
+    notes: z.string().trim().max(1000).optional(),
+    status: z.enum(["active", "archived"]).optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, "At least one field is required");
 
 export const eventCreateSchema = z.object({
   title: z.string().trim().min(1).max(120).default("Poker Night"),
@@ -28,6 +46,7 @@ export const eventCreateSchema = z.object({
   hostPlayerId: z.string().uuid().nullable().optional(),
   location: z.string().trim().max(240).default(""),
   gameNotes: z.string().trim().max(1200).optional(),
+  notes: z.string().trim().max(1200).optional(),
 });
 
 export const eventPatchSchema = z
@@ -37,23 +56,42 @@ export const eventPatchSchema = z
     hostPlayerId: z.string().uuid().nullable().optional(),
     location: z.string().trim().max(240).optional(),
     gameNotes: z.string().trim().max(1200).nullable().optional(),
+    notes: z.string().trim().max(1200).nullable().optional(),
     status: z.enum(eventStatuses).optional(),
+    correctionNote,
   })
-  .refine((value) => Object.keys(value).length > 0, "At least one field is required");
+  .refine(
+    (value) => Object.keys(value).some((key) => key !== "correctionNote"),
+    "At least one event field is required",
+  );
 
 export const eventPlayerCreateSchema = z.object({
   playerId: z.string().uuid(),
-  invitationStatus: z.enum(["invited", "not_invited"]).default("invited"),
+  invitationStatus: z.enum(invitationStatuses).default("invited"),
   rsvpStatus: z.enum(rsvpStatuses).default("pending"),
+  correctionNote,
 });
 
 export const eventPlayerPatchSchema = z
   .object({
+    invitationStatus: z.enum(invitationStatuses).optional(),
     rsvpStatus: z.enum(rsvpStatuses).optional(),
     attended: z.boolean().optional(),
     notes: z.string().trim().max(500).nullable().optional(),
+    correctionNote,
   })
-  .refine((value) => Object.keys(value).length > 0, "At least one field is required");
+  .refine(
+    (value) => Object.keys(value).some((key) => key !== "correctionNote"),
+    "At least one roster field is required",
+  );
+
+export const eventPlayerDeleteSchema = z.object({
+  correctionNote,
+});
+
+export const eventReopenSchema = z.object({
+  correctionNote: z.string().trim().min(3).max(500),
+});
 
 const allowedTransitions: Record<EventStatus, readonly EventStatus[]> = {
   draft: ["open", "cancelled"],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,23 @@ import {
 import { api, ApiError } from "./api";
 import type {
   DashboardData,
+  EventAuditEntry,
   EventPlayer,
   Organizer,
   Player,
   PokerEvent,
 } from "./types";
-import type { EventStatus, RsvpStatus } from "../shared/domain";
+import type {
+  EventStatus,
+  InvitationStatus,
+  RsvpStatus,
+} from "../shared/domain";
+
+interface EventDetailResponse {
+  event: PokerEvent;
+  players: EventPlayer[];
+  audits: EventAuditEntry[];
+}
 
 function formatDate(value: string): string {
   return new Intl.DateTimeFormat("en-US", {
@@ -24,8 +35,35 @@ function formatDate(value: string): string {
   }).format(new Date(value));
 }
 
+function toLocalDateTime(value: string): string {
+  const date = new Date(value);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+function formValue(fields: FormData, name: string): string {
+  return String(fields.get(name) ?? "");
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+function auditLabel(action: string): string {
+  const labels: Record<string, string> = {
+    event_completed: "Event completed",
+    event_corrected: "Event details corrected",
+    event_player_added_correction: "Player added to completed record",
+    event_player_corrected: "Roster record corrected",
+    event_player_removed_correction: "Player removed from completed record",
+    event_reopened: "Event reopened",
+  };
+  return labels[action] ?? action.replaceAll("_", " ");
+}
+
+function auditNote(entry: EventAuditEntry): string | null {
+  const note = entry.details.correctionNote;
+  return typeof note === "string" ? note : null;
 }
 
 function Button({
@@ -76,12 +114,24 @@ function ErrorPanel({ error }: { error: unknown }) {
   );
 }
 
+function SuccessPanel({ children }: { children: ReactNode }) {
+  return (
+    <div className="state-card state-success" role="status">
+      {children}
+    </div>
+  );
+}
+
 function EmptyState({ children }: { children: ReactNode }) {
   return <div className="state-card">{children}</div>;
 }
 
 function StatusBadge({ status }: { status: EventStatus }) {
   return <span className={`status-badge status-${status}`}>{status.replace("_", " ")}</span>;
+}
+
+function PlayerStatusBadge({ status }: { status: Player["status"] }) {
+  return <span className={`status-badge player-status-${status}`}>{status}</span>;
 }
 
 function EventCard({ event }: { event: PokerEvent }) {
@@ -180,17 +230,23 @@ function DashboardPage() {
 
 function PlayersPage() {
   const [players, setPlayers] = useState<Player[]>();
+  const [filter, setFilter] = useState<"active" | "archived" | "all">("active");
   const [error, setError] = useState<unknown>();
   const [saving, setSaving] = useState(false);
 
-  const load = () =>
-    api<{ players: Player[] }>("/api/players")
-      .then((response) => setPlayers(response.players))
-      .catch(setError);
+  const load = async (status = filter) => {
+    try {
+      const response = await api<{ players: Player[] }>(`/api/players?status=${status}`);
+      setPlayers(response.players);
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
 
   useEffect(() => {
-    void load();
-  }, []);
+    void load(filter);
+  }, [filter]);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -202,16 +258,17 @@ function PlayersPage() {
       await api("/api/players", {
         method: "POST",
         body: JSON.stringify({
-          firstName: fields.get("firstName"),
-          lastName: fields.get("lastName"),
-          displayName: fields.get("displayName") || undefined,
-          email: fields.get("email") || undefined,
-          phone: fields.get("phone") || undefined,
-          notes: fields.get("notes") || undefined,
+          firstName: formValue(fields, "firstName"),
+          lastName: formValue(fields, "lastName"),
+          displayName: formValue(fields, "displayName") || undefined,
+          email: formValue(fields, "email") || undefined,
+          phone: formValue(fields, "phone") || undefined,
+          notes: formValue(fields, "notes") || undefined,
         }),
       });
       form.reset();
-      await load();
+      setFilter("active");
+      await load("active");
     } catch (caught) {
       setError(caught);
     } finally {
@@ -257,7 +314,21 @@ function PlayersPage() {
 
         <section className="panel">
           <div className="section-heading-row">
-            <h2>Active directory</h2>
+            <div>
+              <h2>Directory</h2>
+              <div className="filter-row" aria-label="Player status filter">
+                {(["active", "archived", "all"] as const).map((status) => (
+                  <Button
+                    key={status}
+                    type="button"
+                    variant={filter === status ? "primary" : "secondary"}
+                    onClick={() => setFilter(status)}
+                  >
+                    {status}
+                  </Button>
+                ))}
+              </div>
+            </div>
             <span>{players?.length ?? 0}</span>
           </div>
           {!players ? (
@@ -269,15 +340,18 @@ function PlayersPage() {
                   <span className="avatar" aria-hidden="true">
                     {player.displayName.slice(0, 1).toUpperCase()}
                   </span>
-                  <span>
-                    <strong>{player.displayName}</strong>
+                  <span className="person-row-copy">
+                    <span className="person-row-heading">
+                      <strong>{player.displayName}</strong>
+                      <PlayerStatusBadge status={player.status} />
+                    </span>
                     <small>{player.email || player.phone || "No contact details"}</small>
                   </span>
                 </Link>
               ))}
             </div>
           ) : (
-            <EmptyState>Add the first player to begin building the roster.</EmptyState>
+            <EmptyState>No players match this filter.</EmptyState>
           )}
         </section>
       </div>
@@ -289,40 +363,110 @@ function PlayerDetailPage() {
   const { id = "" } = useParams();
   const [data, setData] = useState<{ player: Player; history: PokerEvent[] }>();
   const [error, setError] = useState<unknown>();
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const load = async () => {
+    try {
+      const response = await api<{ player: Player; history: PokerEvent[] }>(`/api/players/${id}`);
+      setData(response);
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
 
   useEffect(() => {
-    api<{ player: Player; history: PokerEvent[] }>(`/api/players/${id}`)
-      .then(setData)
-      .catch(setError);
+    void load();
   }, [id]);
 
-  if (error) return <ErrorPanel error={error} />;
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fields = new FormData(event.currentTarget);
+    setSaving(true);
+    setSaved(false);
+    setError(undefined);
+    try {
+      await api(`/api/players/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          firstName: formValue(fields, "firstName"),
+          lastName: formValue(fields, "lastName"),
+          displayName: formValue(fields, "displayName"),
+          email: formValue(fields, "email"),
+          phone: formValue(fields, "phone"),
+          notes: formValue(fields, "notes"),
+          status: formValue(fields, "status"),
+        }),
+      });
+      await load();
+      setSaved(true);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (error && !data) return <ErrorPanel error={error} />;
   if (!data) return <Loading label="Loading player" />;
 
   return (
     <>
-      <PageHeader eyebrow="Player" title={data.player.displayName} />
+      <PageHeader
+        eyebrow="Player"
+        title={data.player.displayName}
+        actions={<PlayerStatusBadge status={data.player.status} />}
+      />
+      {error ? <ErrorPanel error={error} /> : null}
+      {saved ? <SuccessPanel>Player record updated.</SuccessPanel> : null}
       <div className="two-column-layout">
-        <section className="panel detail-list">
-          <h2>Contact</h2>
-          <dl>
-            <div>
-              <dt>Email</dt>
-              <dd>{data.player.email || "Not recorded"}</dd>
-            </div>
-            <div>
-              <dt>Phone</dt>
-              <dd>{data.player.phone || "Not recorded"}</dd>
-            </div>
-            <div>
-              <dt>Notes</dt>
-              <dd>{data.player.notes || "No notes"}</dd>
-            </div>
-          </dl>
+        <section className="panel">
+          <h2>Edit player</h2>
+          <form className="form-stack" key={data.player.updatedAt} onSubmit={submit}>
+            <label>
+              First name
+              <input name="firstName" defaultValue={data.player.firstName} required maxLength={80} />
+            </label>
+            <label>
+              Last name
+              <input name="lastName" defaultValue={data.player.lastName} maxLength={80} />
+            </label>
+            <label>
+              Display name
+              <span className="field-hint">Leave blank to derive it from first and last name.</span>
+              <input name="displayName" defaultValue={data.player.displayName} maxLength={120} />
+            </label>
+            <label>
+              Email
+              <input name="email" type="email" defaultValue={data.player.email ?? ""} maxLength={200} />
+            </label>
+            <label>
+              Phone
+              <input
+                name="phone"
+                inputMode="tel"
+                defaultValue={data.player.phone ?? ""}
+                maxLength={40}
+              />
+            </label>
+            <label>
+              Organizer notes
+              <textarea name="notes" rows={5} defaultValue={data.player.notes ?? ""} maxLength={1000} />
+            </label>
+            <label>
+              Directory status
+              <select name="status" defaultValue={data.player.status}>
+                <option value="active">Active</option>
+                <option value="archived">Archived</option>
+              </select>
+            </label>
+            <Button disabled={saving}>{saving ? "Saving…" : "Save player"}</Button>
+          </form>
         </section>
         <section className="panel">
           <h2>Completed nights</h2>
-          <div className="card-list">
+          <div className="card-list history-list">
             {data.history.length ? (
               data.history.map((event) => <EventCard event={event} key={event.id} />)
             ) : (
@@ -388,15 +532,16 @@ function NewEventPage() {
     setSaving(true);
     setError(undefined);
     try {
-      const startsAt = new Date(String(fields.get("startsAt"))).toISOString();
+      const startsAt = new Date(formValue(fields, "startsAt")).toISOString();
       const response = await api<{ event: PokerEvent }>("/api/events", {
         method: "POST",
         body: JSON.stringify({
-          title: fields.get("title"),
+          title: formValue(fields, "title"),
           startsAt,
-          hostPlayerId: fields.get("hostPlayerId") || null,
-          location: fields.get("location"),
-          gameNotes: fields.get("gameNotes") || undefined,
+          hostPlayerId: formValue(fields, "hostPlayerId") || null,
+          location: formValue(fields, "location"),
+          gameNotes: formValue(fields, "gameNotes") || undefined,
+          notes: formValue(fields, "notes") || undefined,
         }),
       });
       navigate(`/events/${response.event.id}`);
@@ -433,12 +578,16 @@ function NewEventPage() {
             </select>
           </label>
           <label>
-            Location
+            Location or address
             <input name="location" maxLength={240} />
           </label>
           <label>
             Game and house-rule notes <span className="field-hint">optional</span>
             <textarea name="gameNotes" rows={4} maxLength={1200} />
+          </label>
+          <label>
+            General event notes <span className="field-hint">optional</span>
+            <textarea name="notes" rows={4} maxLength={1200} />
           </label>
           <Button disabled={saving}>{saving ? "Creating…" : "Create draft"}</Button>
         </form>
@@ -447,23 +596,137 @@ function NewEventPage() {
   );
 }
 
+function EventPlayerEditor({
+  player,
+  disabled,
+  saving,
+  onPatch,
+  onRemove,
+}: {
+  player: EventPlayer;
+  disabled: boolean;
+  saving: boolean;
+  onPatch: (body: {
+    invitationStatus?: InvitationStatus;
+    rsvpStatus?: RsvpStatus;
+    attended?: boolean;
+    notes?: string | null;
+  }) => Promise<void>;
+  onRemove: () => Promise<void>;
+}) {
+  const [notes, setNotes] = useState(player.notes ?? "");
+
+  useEffect(() => {
+    setNotes(player.notes ?? "");
+  }, [player.notes]);
+
+  return (
+    <article className={`live-player roster-editor ${player.attended ? "is-attending" : ""}`}>
+      <div className="live-player-name">
+        <span className="avatar" aria-hidden="true">
+          {player.displayName.slice(0, 1).toUpperCase()}
+        </span>
+        <div>
+          <strong>{player.displayName}</strong>
+          <small>{player.attended ? "Attended" : "Not checked in"}</small>
+        </div>
+      </div>
+      <div className="roster-field-grid">
+        <label>
+          <span>Invitation</span>
+          <select
+            value={player.invitationStatus}
+            disabled={disabled || saving}
+            onChange={(change) =>
+              void onPatch({ invitationStatus: change.target.value as InvitationStatus })
+            }
+          >
+            <option value="invited">Invited</option>
+            <option value="not_invited">Not invited</option>
+          </select>
+        </label>
+        <label>
+          <span>RSVP</span>
+          <select
+            value={player.rsvpStatus}
+            disabled={disabled || saving}
+            onChange={(change) =>
+              void onPatch({ rsvpStatus: change.target.value as RsvpStatus })
+            }
+          >
+            <option value="pending">Pending</option>
+            <option value="yes">Yes</option>
+            <option value="maybe">Maybe</option>
+            <option value="no">No</option>
+          </select>
+        </label>
+      </div>
+      <div className="roster-action-row">
+        <Button
+          type="button"
+          variant={player.attended ? "secondary" : "primary"}
+          disabled={disabled || saving}
+          onClick={() => void onPatch({ attended: !player.attended })}
+        >
+          {player.attended ? "Undo check-in" : "Check in"}
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          disabled={disabled || saving}
+          onClick={() => void onRemove()}
+        >
+          Remove
+        </Button>
+      </div>
+      <label className="roster-note-field">
+        <span>Event-specific player notes</span>
+        <textarea
+          rows={2}
+          maxLength={500}
+          value={notes}
+          disabled={disabled || saving}
+          onChange={(change) => setNotes(change.target.value)}
+        />
+      </label>
+      <Button
+        type="button"
+        variant="secondary"
+        disabled={disabled || saving || notes === (player.notes ?? "")}
+        onClick={() => void onPatch({ notes: notes || null })}
+      >
+        Save player note
+      </Button>
+    </article>
+  );
+}
+
 function EventDetailPage() {
   const { id = "" } = useParams();
   const [event, setEvent] = useState<PokerEvent>();
   const [eventPlayers, setEventPlayers] = useState<EventPlayer[]>([]);
+  const [audits, setAudits] = useState<EventAuditEntry[]>([]);
   const [directory, setDirectory] = useState<Player[]>([]);
   const [selectedPlayerId, setSelectedPlayerId] = useState("");
+  const [correctionMode, setCorrectionMode] = useState(false);
+  const [correctionNote, setCorrectionNote] = useState("");
   const [error, setError] = useState<unknown>();
   const [saving, setSaving] = useState(false);
+  const [savedMessage, setSavedMessage] = useState<string>();
+
+  const applyDetail = (detail: EventDetailResponse) => {
+    setEvent(detail.event);
+    setEventPlayers(detail.players);
+    setAudits(detail.audits);
+  };
 
   const load = async () => {
     try {
       const [detail, players] = await Promise.all([
-        api<{ event: PokerEvent; players: EventPlayer[] }>(`/api/events/${id}`),
-        api<{ players: Player[] }>("/api/players"),
+        api<EventDetailResponse>(`/api/events/${id}`),
+        api<{ players: Player[] }>("/api/players?status=all"),
       ]);
-      setEvent(detail.event);
-      setEventPlayers(detail.players);
+      applyDetail(detail);
       setDirectory(players.players);
       setError(undefined);
     } catch (caught) {
@@ -480,16 +743,37 @@ function EventDetailPage() {
     [directory, eventPlayers],
   );
 
-  async function addPlayer() {
-    if (!selectedPlayerId) return;
+  if (error && !event) return <ErrorPanel error={error} />;
+  if (!event) return <Loading label="Loading poker night" />;
+
+  const locked = ["completed", "cancelled", "archived"].includes(event.status);
+  const correctionReady = correctionNote.trim().length >= 3;
+  const canEdit = !locked || (correctionMode && correctionReady);
+  const editDisabled = saving || !canEdit;
+
+  const correctionFields = locked ? { correctionNote: correctionNote.trim() } : {};
+
+  async function saveEventDetails(formEvent: FormEvent<HTMLFormElement>) {
+    formEvent.preventDefault();
+    const fields = new FormData(formEvent.currentTarget);
     setSaving(true);
+    setSavedMessage(undefined);
+    setError(undefined);
     try {
-      await api(`/api/events/${id}/players`, {
-        method: "POST",
-        body: JSON.stringify({ playerId: selectedPlayerId }),
+      await api(`/api/events/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          title: formValue(fields, "title"),
+          startsAt: new Date(formValue(fields, "startsAt")).toISOString(),
+          hostPlayerId: formValue(fields, "hostPlayerId") || null,
+          location: formValue(fields, "location"),
+          gameNotes: formValue(fields, "gameNotes") || null,
+          notes: formValue(fields, "notes") || null,
+          ...correctionFields,
+        }),
       });
-      setSelectedPlayerId("");
       await load();
+      setSavedMessage(locked ? "Completed event correction saved and audited." : "Event details saved.");
     } catch (caught) {
       setError(caught);
     } finally {
@@ -497,15 +781,64 @@ function EventDetailPage() {
     }
   }
 
-  async function updatePlayer(playerId: string, body: { rsvpStatus?: RsvpStatus; attended?: boolean }) {
+  async function addPlayer() {
+    if (!selectedPlayerId) return;
     setSaving(true);
+    setSavedMessage(undefined);
     try {
-      const response = await api<{ event: PokerEvent; players: EventPlayer[] }>(
-        `/api/events/${id}/players/${playerId}`,
-        { method: "PATCH", body: JSON.stringify(body) },
-      );
-      setEvent(response.event);
-      setEventPlayers(response.players);
+      const response = await api<EventDetailResponse>(`/api/events/${id}/players`, {
+        method: "POST",
+        body: JSON.stringify({ playerId: selectedPlayerId, ...correctionFields }),
+      });
+      applyDetail(response);
+      setSelectedPlayerId("");
+      setSavedMessage(locked ? "Roster correction saved and audited." : "Player added.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function updatePlayer(
+    playerId: string,
+    body: {
+      invitationStatus?: InvitationStatus;
+      rsvpStatus?: RsvpStatus;
+      attended?: boolean;
+      notes?: string | null;
+    },
+  ) {
+    setSaving(true);
+    setSavedMessage(undefined);
+    try {
+      const response = await api<EventDetailResponse>(`/api/events/${id}/players/${playerId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ ...body, ...correctionFields }),
+      });
+      applyDetail(response);
+      setSavedMessage(locked ? "Roster correction saved and audited." : "Roster updated.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function removePlayer(player: EventPlayer) {
+    const warning = player.attended
+      ? `Remove ${player.displayName}? This also removes their recorded attendance.`
+      : `Remove ${player.displayName} from this event?`;
+    if (!window.confirm(warning)) return;
+    setSaving(true);
+    setSavedMessage(undefined);
+    try {
+      const response = await api<EventDetailResponse>(`/api/events/${id}/players/${player.playerId}`, {
+        method: "DELETE",
+        body: JSON.stringify(correctionFields),
+      });
+      applyDetail(response);
+      setSavedMessage(locked ? "Roster correction saved and audited." : "Player removed.");
     } catch (caught) {
       setError(caught);
     } finally {
@@ -515,12 +848,14 @@ function EventDetailPage() {
 
   async function transition(status: EventStatus) {
     setSaving(true);
+    setSavedMessage(undefined);
     try {
       const response = await api<{ event: PokerEvent }>(`/api/events/${id}`, {
         method: "PATCH",
         body: JSON.stringify({ status }),
       });
       setEvent(response.event);
+      setSavedMessage(`Event moved to ${status}.`);
     } catch (caught) {
       setError(caught);
     } finally {
@@ -531,11 +866,11 @@ function EventDetailPage() {
   async function complete() {
     if (!window.confirm("Complete and lock this poker night?")) return;
     setSaving(true);
+    setSavedMessage(undefined);
     try {
-      const response = await api<{ event: PokerEvent }>(`/api/events/${id}/complete`, {
-        method: "POST",
-      });
-      setEvent(response.event);
+      await api<{ event: PokerEvent }>(`/api/events/${id}/complete`, { method: "POST" });
+      await load();
+      setSavedMessage("Event completed and locked.");
     } catch (caught) {
       setError(caught);
     } finally {
@@ -543,9 +878,26 @@ function EventDetailPage() {
     }
   }
 
-  if (error && !event) return <ErrorPanel error={error} />;
-  if (!event) return <Loading label="Loading poker night" />;
-  const locked = ["completed", "cancelled", "archived"].includes(event.status);
+  async function reopen() {
+    if (!correctionReady) return;
+    if (!window.confirm("Reopen this completed event as an active Live Night?")) return;
+    setSaving(true);
+    setSavedMessage(undefined);
+    try {
+      const response = await api<EventDetailResponse>(`/api/events/${id}/reopen`, {
+        method: "POST",
+        body: JSON.stringify({ correctionNote: correctionNote.trim() }),
+      });
+      applyDetail(response);
+      setCorrectionMode(false);
+      setCorrectionNote("");
+      setSavedMessage("Event reopened. The action was added to the audit history.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
 
   return (
     <>
@@ -555,6 +907,7 @@ function EventDetailPage() {
         actions={<StatusBadge status={event.status} />}
       />
       {error ? <ErrorPanel error={error} /> : null}
+      {savedMessage ? <SuccessPanel>{savedMessage}</SuccessPanel> : null}
 
       <section className="event-hero panel">
         <div>
@@ -575,89 +928,192 @@ function EventDetailPage() {
         </div>
       </section>
 
-      {!locked ? (
+      {locked ? (
+        <section className="panel correction-panel">
+          <div>
+            <p className="eyebrow">Locked record</p>
+            <h2>Correct completed history deliberately</h2>
+            <p>
+              Corrections keep the event in its current status and write the reason to the permanent audit history.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant={correctionMode ? "secondary" : "primary"}
+            onClick={() => {
+              setCorrectionMode((current) => !current);
+              setSavedMessage(undefined);
+            }}
+          >
+            {correctionMode ? "Cancel correction" : "Correct this event"}
+          </Button>
+          {correctionMode ? (
+            <div className="correction-controls">
+              <label>
+                Required correction note
+                <textarea
+                  rows={3}
+                  maxLength={500}
+                  value={correctionNote}
+                  onChange={(change) => setCorrectionNote(change.target.value)}
+                  placeholder="Example: Forgot to mark Ryan as attending."
+                />
+              </label>
+              <small>Enter at least three characters before editing controls unlock.</small>
+              {event.status === "completed" ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={!correctionReady || saving}
+                  onClick={() => void reopen()}
+                >
+                  Reopen as Live Night
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </section>
+      ) : (
         <section className="workflow-bar" aria-label="Event workflow actions">
           {event.status === "draft" ? (
-            <Button onClick={() => transition("open")} disabled={saving}>
+            <Button onClick={() => void transition("open")} disabled={saving}>
               Open invitations
             </Button>
           ) : null}
           {event.status === "open" ? (
-            <Button onClick={() => transition("active")} disabled={saving}>
+            <Button onClick={() => void transition("active")} disabled={saving}>
               Start Live Night
             </Button>
           ) : null}
           {event.status === "active" ? (
-            <Button onClick={complete} disabled={saving}>
+            <Button onClick={() => void complete()} disabled={saving}>
               Complete event
             </Button>
           ) : null}
         </section>
-      ) : null}
+      )}
+
+      <section className="panel content-section">
+        <div className="section-heading-row">
+          <div>
+            <p className="eyebrow">Details</p>
+            <h2>Edit event information</h2>
+          </div>
+          {locked && !correctionMode ? <span>Locked</span> : null}
+        </div>
+        <form className="form-grid" key={event.updatedAt} onSubmit={saveEventDetails}>
+          <label>
+            Event title
+            <input
+              name="title"
+              defaultValue={event.title}
+              required
+              maxLength={120}
+              disabled={editDisabled}
+            />
+          </label>
+          <label>
+            Date and start time
+            <input
+              name="startsAt"
+              type="datetime-local"
+              defaultValue={toLocalDateTime(event.startsAt)}
+              required
+              disabled={editDisabled}
+            />
+          </label>
+          <label>
+            Host
+            <select name="hostPlayerId" defaultValue={event.hostPlayerId ?? ""} disabled={editDisabled}>
+              <option value="">No host selected</option>
+              {directory.map((player) => (
+                <option value={player.id} key={player.id}>
+                  {player.displayName}
+                  {player.status === "archived" ? " (archived)" : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Location or address
+            <input
+              name="location"
+              defaultValue={event.location}
+              maxLength={240}
+              disabled={editDisabled}
+            />
+          </label>
+          <label className="form-grid-wide">
+            Game and house-rule notes
+            <textarea
+              name="gameNotes"
+              rows={4}
+              defaultValue={event.gameNotes ?? ""}
+              maxLength={1200}
+              disabled={editDisabled}
+            />
+          </label>
+          <label className="form-grid-wide">
+            General event notes
+            <textarea
+              name="notes"
+              rows={4}
+              defaultValue={event.notes ?? ""}
+              maxLength={1200}
+              disabled={editDisabled}
+            />
+          </label>
+          <Button className="form-grid-action" disabled={editDisabled}>
+            {saving ? "Saving…" : "Save event details"}
+          </Button>
+        </form>
+      </section>
 
       <div className="two-column-layout event-layout">
         <section className="panel">
           <div className="section-heading-row">
             <div>
               <p className="eyebrow">Roster</p>
-              <h2>Players</h2>
+              <h2>Players and attendance</h2>
             </div>
             <span>{eventPlayers.length}</span>
           </div>
 
-          {!locked ? (
-            <div className="inline-form">
-              <select
-                aria-label="Player to add"
-                value={selectedPlayerId}
-                onChange={(change) => setSelectedPlayerId(change.target.value)}
-              >
-                <option value="">Select player</option>
-                {availablePlayers.map((player) => (
-                  <option value={player.id} key={player.id}>
-                    {player.displayName}
-                  </option>
-                ))}
-              </select>
-              <Button onClick={addPlayer} disabled={!selectedPlayerId || saving}>
-                Add
-              </Button>
-            </div>
-          ) : null}
+          <div className="inline-form">
+            <select
+              aria-label="Player to add"
+              value={selectedPlayerId}
+              disabled={editDisabled}
+              onChange={(change) => setSelectedPlayerId(change.target.value)}
+            >
+              <option value="">Select player</option>
+              {availablePlayers.map((player) => (
+                <option value={player.id} key={player.id}>
+                  {player.displayName}
+                  {player.status === "archived" ? " (archived)" : ""}
+                </option>
+              ))}
+            </select>
+            <Button
+              type="button"
+              onClick={() => void addPlayer()}
+              disabled={!selectedPlayerId || editDisabled}
+            >
+              Add
+            </Button>
+          </div>
 
           <div className="live-roster">
             {eventPlayers.length ? (
               eventPlayers.map((player) => (
-                <article className={`live-player ${player.attended ? "is-attending" : ""}`} key={player.id}>
-                  <div className="live-player-name">
-                    <span className="avatar" aria-hidden="true">
-                      {player.displayName.slice(0, 1).toUpperCase()}
-                    </span>
-                    <strong>{player.displayName}</strong>
-                  </div>
-                  <label>
-                    <span>RSVP</span>
-                    <select
-                      value={player.rsvpStatus}
-                      disabled={locked || saving}
-                      onChange={(change) =>
-                        updatePlayer(player.playerId, { rsvpStatus: change.target.value as RsvpStatus })
-                      }
-                    >
-                      <option value="pending">Pending</option>
-                      <option value="yes">Yes</option>
-                      <option value="maybe">Maybe</option>
-                      <option value="no">No</option>
-                    </select>
-                  </label>
-                  <Button
-                    variant={player.attended ? "secondary" : "primary"}
-                    disabled={locked || saving}
-                    onClick={() => updatePlayer(player.playerId, { attended: !player.attended })}
-                  >
-                    {player.attended ? "Checked in" : "Check in"}
-                  </Button>
-                </article>
+                <EventPlayerEditor
+                  key={player.id}
+                  player={player}
+                  disabled={editDisabled}
+                  saving={saving}
+                  onPatch={(body) => updatePlayer(player.playerId, body)}
+                  onRemove={() => removePlayer(player)}
+                />
               ))
             ) : (
               <EmptyState>Add players to build the event roster.</EmptyState>
@@ -665,22 +1121,29 @@ function EventDetailPage() {
           </div>
         </section>
 
-        <aside className="panel detail-list">
-          <h2>Event notes</h2>
-          <dl>
+        <aside className="panel audit-panel">
+          <div className="section-heading-row">
             <div>
-              <dt>Game</dt>
-              <dd>{event.gameNotes || "No game notes"}</dd>
+              <p className="eyebrow">Permanent record</p>
+              <h2>Audit history</h2>
             </div>
-            <div>
-              <dt>Rostered</dt>
-              <dd>{event.playerCount}</dd>
-            </div>
-            <div>
-              <dt>Attended</dt>
-              <dd>{event.attendanceCount}</dd>
-            </div>
-          </dl>
+            <span>{audits.length}</span>
+          </div>
+          {audits.length ? (
+            <ol className="audit-list">
+              {audits.map((entry) => (
+                <li key={entry.id}>
+                  <strong>{auditLabel(entry.action)}</strong>
+                  <span>
+                    {formatDate(entry.createdAt)} by {entry.organizerName}
+                  </span>
+                  {auditNote(entry) ? <p>{auditNote(entry)}</p> : null}
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <EmptyState>Completion and correction actions will appear here.</EmptyState>
+          )}
         </aside>
       </div>
     </>

--- a/src/editing.css
+++ b/src/editing.css
@@ -1,0 +1,198 @@
+.state-success {
+  margin-bottom: 1rem;
+  border-color: rgba(150, 199, 136, 0.5);
+  color: var(--green);
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.8rem;
+}
+
+.filter-row .button {
+  min-height: 36px;
+  padding: 0.45rem 0.7rem;
+  text-transform: capitalize;
+}
+
+.person-row-copy {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.person-row-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.player-status-archived {
+  color: var(--gold);
+}
+
+.history-list {
+  margin-top: 1rem;
+}
+
+.correction-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 1rem;
+  margin: 1rem 0;
+  border-color: rgba(215, 178, 103, 0.45);
+}
+
+.correction-panel p:not(.eyebrow) {
+  max-width: 70ch;
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+}
+
+.correction-controls {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.correction-controls label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--gold);
+  font-weight: 800;
+}
+
+.correction-controls small {
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.form-grid label {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.form-grid-wide,
+.form-grid-action {
+  grid-column: 1 / -1;
+}
+
+.form-grid-action {
+  justify-self: start;
+}
+
+.roster-editor.live-player {
+  grid-template-columns: 1fr;
+  align-items: stretch;
+  gap: 0.85rem;
+}
+
+.live-player-name > div {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.live-player-name small {
+  color: var(--muted);
+}
+
+.roster-field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.roster-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.roster-action-row .button {
+  flex: 1 1 150px;
+}
+
+.roster-note-field {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.audit-panel {
+  position: sticky;
+  top: 5.5rem;
+}
+
+.audit-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.audit-list li {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.audit-list li:last-child {
+  border-bottom: 0;
+}
+
+.audit-list span {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.audit-list p {
+  margin: 0;
+  color: var(--gold);
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 800px) {
+  .correction-panel,
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-grid-wide,
+  .form-grid-action {
+    grid-column: auto;
+  }
+
+  .audit-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 560px) {
+  .roster-field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .correction-panel > .button,
+  .form-grid-action {
+    width: 100%;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 import "./styles.css";
+import "./editing.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Application root was not found");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { EventStatus, RsvpStatus } from "../shared/domain";
+import type { EventStatus, InvitationStatus, RsvpStatus } from "../shared/domain";
 
 export interface Organizer {
   id: string;
@@ -28,6 +28,7 @@ export interface PokerEvent {
   hostName: string | null;
   location: string;
   gameNotes: string | null;
+  notes: string | null;
   status: EventStatus;
   attendanceCount: number;
   playerCount: number;
@@ -41,11 +42,19 @@ export interface EventPlayer {
   eventId: string;
   playerId: string;
   displayName: string;
-  invitationStatus: "invited" | "not_invited";
+  invitationStatus: InvitationStatus;
   rsvpStatus: RsvpStatus;
   attended: boolean;
   checkedInAt: string | null;
   notes: string | null;
+}
+
+export interface EventAuditEntry {
+  id: string;
+  action: string;
+  details: Record<string, unknown>;
+  organizerName: string;
+  createdAt: string;
 }
 
 export interface DashboardData {

--- a/tests/domain.test.ts
+++ b/tests/domain.test.ts
@@ -4,7 +4,10 @@ import {
   countAttendance,
   deriveDisplayName,
   eventCreateSchema,
+  eventPatchSchema,
+  eventPlayerPatchSchema,
   playerCreateSchema,
+  playerPatchSchema,
 } from "../shared/domain";
 
 describe("event status transitions", () => {
@@ -18,7 +21,7 @@ describe("event status transitions", () => {
     expect(canTransition("draft", "completed")).toBe(false);
   });
 
-  it("keeps completed events locked", () => {
+  it("keeps completed events out of normal transitions", () => {
     expect(canTransition("completed", "active")).toBe(false);
   });
 });
@@ -36,6 +39,11 @@ describe("request validation", () => {
     expect(deriveDisplayName(result)).toBe("Sterling Knight-Pinneo");
   });
 
+  it("allows a player to be archived and restored", () => {
+    expect(playerPatchSchema.parse({ status: "archived" }).status).toBe("archived");
+    expect(playerPatchSchema.parse({ status: "active" }).status).toBe("active");
+  });
+
   it("requires an offset-aware event timestamp", () => {
     expect(() =>
       eventCreateSchema.parse({ title: "Poker Night", startsAt: "2026-08-01T19:00", location: "" }),
@@ -47,5 +55,25 @@ describe("request validation", () => {
         location: "",
       }).startsAt,
     ).toBe("2026-08-01T19:00:00-06:00");
+  });
+
+  it("accepts correction notes alongside event edits", () => {
+    const result = eventPatchSchema.parse({
+      location: "Updated address",
+      correctionNote: "Corrected the saved location.",
+    });
+    expect(result.location).toBe("Updated address");
+  });
+
+  it("supports every editable roster field", () => {
+    const result = eventPlayerPatchSchema.parse({
+      invitationStatus: "not_invited",
+      rsvpStatus: "no",
+      attended: false,
+      notes: "Entered after the night.",
+      correctionNote: "Corrected the roster record.",
+    });
+    expect(result.invitationStatus).toBe("not_invited");
+    expect(result.attended).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed

- Added full player editing for names, display name, email, phone, notes, and active or archived status.
- Added active, archived, and all-player directory filters.
- Added full event-detail editing for title, date and time, host, location, game notes, and general notes.
- Added editable invitation state, RSVP state, attendance, event-specific player notes, roster additions, and roster removals.
- Added deliberate correction mode for completed, cancelled, and archived events.
- Required a correction note before locked records can be changed.
- Added audit records for completed-event detail and roster corrections.
- Added a separate audited reopen action for completed events.
- Added visible event audit history in the organizer interface.
- Added validation and tests for the new editable fields.

## Intended workflow

1. Edit a player's contact details or archive and restore the player.
2. Edit any current event details and roster fields.
3. Complete an event.
4. Enter correction mode with a reason.
5. Correct event details, RSVP, attendance, notes, or roster membership without silently rewriting history.
6. Review the correction in the audit history.
7. Reopen a completed event only when it was actually closed too early.

## Database

No migration is required. This uses the existing `notes`, status, roster, and `event_audit_log` fields.

## Validation

CI should run format checking, source lint, TypeScript type checking, Vitest, and the production Vite build.