### PR TITLE
Add optional cash ledger and balanced event closeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,17 @@ jobs:
         run: npm run lint
 
       - name: Typecheck
-        run: npm run typecheck
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run typecheck 2>&1 | tee typecheck.log
+
+      - name: Upload typecheck diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: typecheck-diagnostics
+          path: typecheck.log
 
       - name: Run tests
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,7 @@ jobs:
         run: npm run lint
 
       - name: Typecheck
-        shell: bash
-        run: |
-          set -o pipefail
-          npm run typecheck 2>&1 | tee typecheck.log
-
-      - name: Upload typecheck diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: typecheck-diagnostics
-          path: typecheck.log
+        run: npm run typecheck
 
       - name: Run tests
         run: npm run test

--- a/docs/CASH_LEDGER_ROLLOUT.md
+++ b/docs/CASH_LEDGER_ROLLOUT.md
@@ -1,0 +1,55 @@
+# Cash ledger rollout
+
+The cash ledger requires D1 migration `0002_cash_ledger.sql` before the feature branch is merged into production.
+
+## What the migration adds
+
+- event-level money tracking toggle
+- default buy-in amount stored in integer cents
+- stakes and money notes
+- immutable ledger-entry identifiers
+- buy-in, rebuy, cash-out, and adjustment entry types
+- organizer and timestamp attribution
+- indexes for event and player money history
+- a database trigger that prevents unresolved money-tracked events from being completed
+
+## Apply locally
+
+The repository expects the ignored `wrangler.local.jsonc` admin configuration created during initial setup.
+
+```bash
+npm run db:migrate:local
+```
+
+## Apply to production
+
+Confirm the Cloudflare API token and account ID are exported in the terminal, then run:
+
+```bash
+npm run db:migrate:remote
+```
+
+Wrangler should report `0002_cash_ledger.sql` as applied to the remote `brotm-poker` database.
+
+## Verification query
+
+```bash
+npx wrangler d1 execute brotm-poker --remote --config wrangler.local.jsonc --command "SELECT name FROM sqlite_master WHERE type IN ('table','trigger') AND name IN ('ledger_entries','prevent_unresolved_money_closeout') ORDER BY name;"
+```
+
+Expected names:
+
+- `ledger_entries`
+- `prevent_unresolved_money_closeout`
+
+## Production smoke test
+
+1. Open an active event and use the **Money ledger** shortcut.
+2. Enable money tracking and set a default buy-in.
+3. Record a buy-in for every attending player.
+4. Record cash-outs, including `$0` for a player who busted.
+5. Confirm cash in equals cash out.
+6. Complete the event from the ledger or the normal event page.
+7. Open a completed event, enter a correction reason, and edit one ledger entry.
+8. Confirm the event audit history records the correction.
+9. Open a player and confirm **Money history** shows completed tracked events and derived net results.

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -3,7 +3,8 @@ import { apiError } from "./lib/http";
 import type { AppPagesFunction } from "./lib/types";
 
 export const onRequest: AppPagesFunction = async (context) => {
-  if (!new URL(context.request.url).pathname.startsWith("/api/")) {
+  const pathname = new URL(context.request.url).pathname;
+  if (!pathname.startsWith("/api/") && !pathname.startsWith("/money-api/")) {
     return context.next();
   }
 

--- a/functions/api/events/[id]/complete.ts
+++ b/functions/api/events/[id]/complete.ts
@@ -1,0 +1,154 @@
+import { calculateLedger, type LedgerEntryType } from "../../../../shared/money";
+import { apiError, json } from "../../../lib/http";
+import type { AppPagesFunction } from "../../../lib/types";
+
+interface EventRow {
+  id: string;
+  title: string;
+  starts_at: string;
+  host_player_id: string | null;
+  host_name: string | null;
+  location: string;
+  game_notes: string | null;
+  notes: string | null;
+  status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  money_tracking_enabled: number;
+  default_buy_in_cents: number;
+  stakes_notes: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  attendance_count: number;
+  player_count: number;
+}
+
+function eventJson(row: EventRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    startsAt: row.starts_at,
+    hostPlayerId: row.host_player_id,
+    hostName: row.host_name,
+    location: row.location,
+    gameNotes: row.game_notes,
+    notes: row.notes,
+    status: row.status,
+    attendanceCount: Number(row.attendance_count ?? 0),
+    playerCount: Number(row.player_count ?? 0),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+async function getEvent(db: D1Database, id: string): Promise<EventRow | null> {
+  return db
+    .prepare(
+      `SELECT e.*, p.display_name AS host_name,
+              COUNT(ep.id) AS player_count,
+              COALESCE(SUM(ep.attended), 0) AS attendance_count
+       FROM events e
+       LEFT JOIN players p ON p.id = e.host_player_id
+       LEFT JOIN event_players ep ON ep.event_id = e.id
+       WHERE e.id = ?1
+       GROUP BY e.id`,
+    )
+    .bind(id)
+    .first<EventRow>();
+}
+
+export const onRequestPost: AppPagesFunction = async (context) => {
+  const id = String(context.params.id ?? "");
+  const event = await getEvent(context.env.DB, id);
+  if (!event) return apiError(404, "NOT_FOUND", "Event not found.");
+  if (event.status !== "active") {
+    return apiError(409, "INVALID_TRANSITION", "Start Live Night before completing the event.");
+  }
+
+  let moneyDetails: Record<string, unknown> = { moneyTrackingEnabled: false };
+  if (event.money_tracking_enabled) {
+    const [entryRows, missingRows] = await Promise.all([
+      context.env.DB
+        .prepare(
+          `SELECT player_id, entry_type, amount_cents
+           FROM ledger_entries
+           WHERE event_id = ?1`,
+        )
+        .bind(id)
+        .all<{ player_id: string; entry_type: LedgerEntryType; amount_cents: number }>(),
+      context.env.DB
+        .prepare(
+          `SELECT p.display_name
+           FROM event_players ep
+           JOIN players p ON p.id = ep.player_id
+           WHERE ep.event_id = ?1
+             AND ep.attended = 1
+             AND NOT EXISTS (
+               SELECT 1
+               FROM ledger_entries le
+               WHERE le.event_id = ep.event_id
+                 AND le.player_id = ep.player_id
+                 AND le.entry_type = 'cash_out'
+             )
+           ORDER BY p.display_name COLLATE NOCASE`,
+        )
+        .bind(id)
+        .all<{ display_name: string }>(),
+    ]);
+    const totals = calculateLedger(
+      entryRows.results.map((entry) => ({
+        playerId: entry.player_id,
+        entryType: entry.entry_type,
+        amountCents: Number(entry.amount_cents),
+      })),
+    );
+    const issues: string[] = [];
+    if (missingRows.results.length) {
+      issues.push(`Missing cash-outs: ${missingRows.results.map((row) => row.display_name).join(", ")}.`);
+    }
+    if (totals.differenceCents !== 0) {
+      issues.push(
+        `Cash in and cash out differ by ${new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+        }).format(totals.differenceCents / 100)}.`,
+      );
+    }
+    if (issues.length) {
+      return apiError(409, "UNRESOLVED_CLOSEOUT", issues.join(" "), { closeout: issues });
+    }
+    moneyDetails = {
+      moneyTrackingEnabled: true,
+      cashInCents: totals.cashInCents,
+      cashOutCents: totals.cashOutCents,
+      differenceCents: totals.differenceCents,
+    };
+  }
+
+  const now = new Date().toISOString();
+  await context.env.DB.batch([
+    context.env.DB
+      .prepare(
+        `UPDATE events
+         SET status = 'completed', completed_at = ?1, updated_at = ?1
+         WHERE id = ?2 AND status = 'active'`,
+      )
+      .bind(now, id),
+    context.env.DB
+      .prepare(
+        `INSERT INTO event_audit_log
+         (id, event_id, organizer_id, action, details_json, created_at)
+         VALUES (?1, ?2, ?3, 'event_completed', ?4, ?5)`,
+      )
+      .bind(
+        crypto.randomUUID(),
+        id,
+        context.data.organizer.id,
+        JSON.stringify({ attendanceCount: Number(event.attendance_count ?? 0), ...moneyDetails }),
+        now,
+      ),
+  ]);
+
+  const completed = await getEvent(context.env.DB, id);
+  return json({ event: eventJson(completed as EventRow) });
+};

--- a/functions/money-api/[[path]].ts
+++ b/functions/money-api/[[path]].ts
@@ -1,0 +1,605 @@
+import { ZodError } from "zod";
+import {
+  calculateLedger,
+  ledgerEntryCreateSchema,
+  ledgerEntryDeleteSchema,
+  ledgerEntryPatchSchema,
+  moneyCompleteSchema,
+  moneyEventPatchSchema,
+  type LedgerEntryType,
+} from "../../shared/money";
+import { apiError, json, readJson, validationError } from "../lib/http";
+import type { AppPagesFunction, OrganizerIdentity } from "../lib/types";
+
+interface MoneyEventRow {
+  id: string;
+  title: string;
+  status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  money_tracking_enabled: number;
+  default_buy_in_cents: number;
+  stakes_notes: string | null;
+}
+
+interface MoneyPlayerRow {
+  player_id: string;
+  display_name: string;
+  attended: number;
+  rsvp_status: "pending" | "yes" | "maybe" | "no";
+}
+
+interface LedgerRow {
+  id: string;
+  event_id: string;
+  player_id: string;
+  player_name: string;
+  entry_type: LedgerEntryType;
+  amount_cents: number;
+  note: string | null;
+  organizer_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PlayerHistoryEventRow extends MoneyEventRow {
+  starts_at: string;
+  location: string;
+}
+
+function isLocked(status: MoneyEventRow["status"]): boolean {
+  return ["completed", "cancelled", "archived"].includes(status);
+}
+
+function requireCorrection(event: MoneyEventRow, correctionNote?: string): string | undefined {
+  if (!isLocked(event.status)) return undefined;
+  if (!correctionNote) {
+    throw new Response("A correction note is required to change money records on a locked event.", {
+      status: 409,
+    });
+  }
+  return correctionNote;
+}
+
+function auditStatement(
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+  action: string,
+  details: Record<string, unknown>,
+  createdAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO event_audit_log
+       (id, event_id, organizer_id, action, details_json, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(crypto.randomUUID(), eventId, organizer.id, action, JSON.stringify(details), createdAt);
+}
+
+async function getEvent(db: D1Database, eventId: string): Promise<MoneyEventRow | null> {
+  return db
+    .prepare(
+      `SELECT id, title, status, money_tracking_enabled, default_buy_in_cents, stakes_notes
+       FROM events
+       WHERE id = ?1`,
+    )
+    .bind(eventId)
+    .first<MoneyEventRow>();
+}
+
+async function requireEvent(db: D1Database, eventId: string): Promise<MoneyEventRow> {
+  const event = await getEvent(db, eventId);
+  if (!event) throw new Response("Event not found.", { status: 404 });
+  return event;
+}
+
+async function getPlayers(db: D1Database, eventId: string): Promise<MoneyPlayerRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT ep.player_id, p.display_name, ep.attended, ep.rsvp_status
+       FROM event_players ep
+       JOIN players p ON p.id = ep.player_id
+       WHERE ep.event_id = ?1
+       ORDER BY ep.attended DESC, p.display_name COLLATE NOCASE`,
+    )
+    .bind(eventId)
+    .all<MoneyPlayerRow>();
+  return rows.results;
+}
+
+async function getEntries(db: D1Database, eventId: string): Promise<LedgerRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT le.*, p.display_name AS player_name, o.display_name AS organizer_name
+       FROM ledger_entries le
+       JOIN players p ON p.id = le.player_id
+       JOIN organizers o ON o.id = le.created_by_organizer_id
+       WHERE le.event_id = ?1
+       ORDER BY le.created_at DESC, le.id DESC`,
+    )
+    .bind(eventId)
+    .all<LedgerRow>();
+  return rows.results;
+}
+
+function detailJson(event: MoneyEventRow, players: MoneyPlayerRow[], entries: LedgerRow[]) {
+  const totals = calculateLedger(
+    entries.map((entry) => ({
+      playerId: entry.player_id,
+      entryType: entry.entry_type,
+      amountCents: Number(entry.amount_cents),
+    })),
+  );
+  const summaries = new Map(totals.playerSummaries.map((summary) => [summary.playerId, summary]));
+  const playerJson = players.map((player) => {
+    const summary = summaries.get(player.player_id);
+    return {
+      playerId: player.player_id,
+      displayName: player.display_name,
+      attended: Boolean(player.attended),
+      rsvpStatus: player.rsvp_status,
+      cashInCents: summary?.cashInCents ?? 0,
+      cashOutCents: summary?.cashOutCents ?? 0,
+      netCents: summary?.netCents ?? 0,
+      rebuyCount: summary?.rebuyCount ?? 0,
+      hasCashOut: summary?.hasCashOut ?? false,
+    };
+  });
+
+  const missingCashOuts = playerJson.filter((player) => player.attended && !player.hasCashOut);
+  const issues: string[] = [];
+  if (event.money_tracking_enabled) {
+    if (missingCashOuts.length) {
+      issues.push(
+        `${missingCashOuts.length} attending player${missingCashOuts.length === 1 ? " is" : "s are"} missing a cash-out.`,
+      );
+    }
+    if (totals.differenceCents !== 0) {
+      issues.push("Cash in and cash out do not balance.");
+    }
+  }
+
+  return {
+    event: {
+      id: event.id,
+      title: event.title,
+      status: event.status,
+      moneyTrackingEnabled: Boolean(event.money_tracking_enabled),
+      defaultBuyInCents: Number(event.default_buy_in_cents),
+      stakesNotes: event.stakes_notes,
+    },
+    players: playerJson,
+    entries: entries.map((entry) => ({
+      id: entry.id,
+      eventId: entry.event_id,
+      playerId: entry.player_id,
+      playerName: entry.player_name,
+      entryType: entry.entry_type,
+      amountCents: Number(entry.amount_cents),
+      note: entry.note,
+      organizerName: entry.organizer_name,
+      createdAt: entry.created_at,
+      updatedAt: entry.updated_at,
+    })),
+    totals: {
+      cashInCents: totals.cashInCents,
+      cashOutCents: totals.cashOutCents,
+      differenceCents: totals.differenceCents,
+      missingCashOutCount: missingCashOuts.length,
+      balanced: totals.differenceCents === 0,
+    },
+    issues,
+    closeoutReady: !event.money_tracking_enabled || issues.length === 0,
+  };
+}
+
+async function eventDetail(db: D1Database, eventId: string): Promise<Response> {
+  const [event, players, entries] = await Promise.all([
+    requireEvent(db, eventId),
+    getPlayers(db, eventId),
+    getEntries(db, eventId),
+  ]);
+  return json(detailJson(event, players, entries));
+}
+
+async function patchMoneyEvent(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  const input = moneyEventPatchSchema.parse(await readJson(request));
+  const correction = requireCorrection(event, input.correctionNote);
+
+  if (input.moneyTrackingEnabled === false) {
+    const count = await db
+      .prepare("SELECT COUNT(*) AS count FROM ledger_entries WHERE event_id = ?1")
+      .bind(eventId)
+      .first<{ count: number }>();
+    if (Number(count?.count ?? 0) > 0) {
+      return apiError(409, "LEDGER_EXISTS", "Delete all ledger entries before turning money tracking off.");
+    }
+  }
+
+  const before = {
+    moneyTrackingEnabled: Boolean(event.money_tracking_enabled),
+    defaultBuyInCents: Number(event.default_buy_in_cents),
+    stakesNotes: event.stakes_notes,
+  };
+  const after = {
+    moneyTrackingEnabled: input.moneyTrackingEnabled ?? before.moneyTrackingEnabled,
+    defaultBuyInCents: input.defaultBuyInCents ?? before.defaultBuyInCents,
+    stakesNotes: input.stakesNotes !== undefined ? input.stakesNotes : before.stakesNotes,
+  };
+  const now = new Date().toISOString();
+  const update = db
+    .prepare(
+      `UPDATE events
+       SET money_tracking_enabled = ?1,
+           default_buy_in_cents = ?2,
+           stakes_notes = NULLIF(?3, ''),
+           updated_at = ?4
+       WHERE id = ?5`,
+    )
+    .bind(
+      after.moneyTrackingEnabled ? 1 : 0,
+      after.defaultBuyInCents,
+      after.stakesNotes ?? "",
+      now,
+      eventId,
+    );
+
+  if (correction) {
+    await db.batch([
+      update,
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        "money_settings_corrected",
+        { correctionNote: correction, before, after },
+        now,
+      ),
+    ]);
+  } else {
+    await update.run();
+  }
+  return eventDetail(db, eventId);
+}
+
+async function createEntry(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  if (!event.money_tracking_enabled) {
+    return apiError(409, "MONEY_DISABLED", "Enable money tracking before adding ledger entries.");
+  }
+  const input = ledgerEntryCreateSchema.parse(await readJson(request));
+  const correction = requireCorrection(event, input.correctionNote);
+  const rostered = await db
+    .prepare("SELECT id FROM event_players WHERE event_id = ?1 AND player_id = ?2")
+    .bind(eventId, input.playerId)
+    .first<{ id: string }>();
+  if (!rostered) return apiError(409, "NOT_ROSTERED", "Add the player to the event roster first.");
+
+  const now = new Date().toISOString();
+  const entryId = crypto.randomUUID();
+  const insert = db
+    .prepare(
+      `INSERT INTO ledger_entries
+       (id, event_id, player_id, entry_type, amount_cents, note,
+        created_by_organizer_id, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, NULLIF(?6, ''), ?7, ?8, ?8)`,
+    )
+    .bind(
+      entryId,
+      eventId,
+      input.playerId,
+      input.entryType,
+      input.amountCents,
+      input.note ?? "",
+      organizer.id,
+      now,
+    );
+
+  if (correction) {
+    await db.batch([
+      insert,
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        "ledger_entry_added_correction",
+        {
+          correctionNote: correction,
+          entryId,
+          playerId: input.playerId,
+          entryType: input.entryType,
+          amountCents: input.amountCents,
+          note: input.note ?? null,
+        },
+        now,
+      ),
+    ]);
+  } else {
+    await insert.run();
+  }
+  return eventDetail(db, eventId);
+}
+
+async function patchEntry(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  entryId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  const input = ledgerEntryPatchSchema.parse(await readJson(request));
+  const correction = requireCorrection(event, input.correctionNote);
+  const current = await db
+    .prepare("SELECT * FROM ledger_entries WHERE id = ?1 AND event_id = ?2")
+    .bind(entryId, eventId)
+    .first<{
+      id: string;
+      player_id: string;
+      entry_type: LedgerEntryType;
+      amount_cents: number;
+      note: string | null;
+    }>();
+  if (!current) return apiError(404, "NOT_FOUND", "Ledger entry not found.");
+
+  const merged = ledgerEntryCreateSchema.parse({
+    playerId: current.player_id,
+    entryType: input.entryType ?? current.entry_type,
+    amountCents: input.amountCents ?? Number(current.amount_cents),
+    note: input.note !== undefined ? input.note : current.note,
+    correctionNote: input.correctionNote,
+  });
+  const before = {
+    entryType: current.entry_type,
+    amountCents: Number(current.amount_cents),
+    note: current.note,
+  };
+  const after = {
+    entryType: merged.entryType,
+    amountCents: merged.amountCents,
+    note: merged.note ?? null,
+  };
+  const now = new Date().toISOString();
+  const update = db
+    .prepare(
+      `UPDATE ledger_entries
+       SET entry_type = ?1, amount_cents = ?2, note = NULLIF(?3, ''), updated_at = ?4
+       WHERE id = ?5 AND event_id = ?6`,
+    )
+    .bind(after.entryType, after.amountCents, after.note ?? "", now, entryId, eventId);
+
+  if (correction) {
+    await db.batch([
+      update,
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        "ledger_entry_corrected",
+        { correctionNote: correction, entryId, playerId: current.player_id, before, after },
+        now,
+      ),
+    ]);
+  } else {
+    await update.run();
+  }
+  return eventDetail(db, eventId);
+}
+
+async function deleteEntry(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  entryId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  const input = ledgerEntryDeleteSchema.parse(await readJson(request));
+  const correction = requireCorrection(event, input.correctionNote);
+  const current = await db
+    .prepare("SELECT * FROM ledger_entries WHERE id = ?1 AND event_id = ?2")
+    .bind(entryId, eventId)
+    .first<{
+      id: string;
+      player_id: string;
+      entry_type: LedgerEntryType;
+      amount_cents: number;
+      note: string | null;
+    }>();
+  if (!current) return apiError(404, "NOT_FOUND", "Ledger entry not found.");
+
+  const remove = db
+    .prepare("DELETE FROM ledger_entries WHERE id = ?1 AND event_id = ?2")
+    .bind(entryId, eventId);
+  if (correction) {
+    const now = new Date().toISOString();
+    await db.batch([
+      remove,
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        "ledger_entry_removed_correction",
+        {
+          correctionNote: correction,
+          entryId,
+          playerId: current.player_id,
+          entryType: current.entry_type,
+          amountCents: Number(current.amount_cents),
+          note: current.note,
+        },
+        now,
+      ),
+    ]);
+  } else {
+    await remove.run();
+  }
+  return eventDetail(db, eventId);
+}
+
+async function completeMoneyEvent(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const input = moneyCompleteSchema.parse(await readJson(request));
+  const [event, players, entries] = await Promise.all([
+    requireEvent(db, eventId),
+    getPlayers(db, eventId),
+    getEntries(db, eventId),
+  ]);
+  if (event.status !== "active") {
+    return apiError(409, "INVALID_TRANSITION", "Start Live Night before completing the event.");
+  }
+  const detail = detailJson(event, players, entries);
+  if (detail.event.moneyTrackingEnabled && detail.issues.length) {
+    return apiError(409, "UNRESOLVED_CLOSEOUT", detail.issues.join(" "), {
+      closeout: detail.issues,
+    });
+  }
+
+  const now = new Date().toISOString();
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE events
+         SET status = 'completed', completed_at = ?1, updated_at = ?1
+         WHERE id = ?2 AND status = 'active'`,
+      )
+      .bind(now, eventId),
+    auditStatement(
+      db,
+      eventId,
+      organizer,
+      "event_completed",
+      {
+        correctionNote: input.correctionNote,
+        moneyTrackingEnabled: detail.event.moneyTrackingEnabled,
+        cashInCents: detail.totals.cashInCents,
+        cashOutCents: detail.totals.cashOutCents,
+        differenceCents: detail.totals.differenceCents,
+        attendanceCount: players.filter((player) => Boolean(player.attended)).length,
+      },
+      now,
+    ),
+  ]);
+  return eventDetail(db, eventId);
+}
+
+async function playerMoneyHistory(db: D1Database, playerId: string): Promise<Response> {
+  const player = await db
+    .prepare("SELECT id, display_name FROM players WHERE id = ?1")
+    .bind(playerId)
+    .first<{ id: string; display_name: string }>();
+  if (!player) return apiError(404, "NOT_FOUND", "Player not found.");
+
+  const eventRows = await db
+    .prepare(
+      `SELECT e.id, e.title, e.status, e.money_tracking_enabled, e.default_buy_in_cents,
+              e.stakes_notes, e.starts_at, e.location
+       FROM events e
+       JOIN event_players ep ON ep.event_id = e.id
+       WHERE ep.player_id = ?1
+         AND e.status = 'completed'
+         AND e.money_tracking_enabled = 1
+       ORDER BY e.starts_at DESC`,
+    )
+    .bind(playerId)
+    .all<PlayerHistoryEventRow>();
+
+  const history = await Promise.all(
+    eventRows.results.map(async (event) => {
+      const entries = await db
+        .prepare(
+          `SELECT player_id, entry_type, amount_cents
+           FROM ledger_entries
+           WHERE event_id = ?1 AND player_id = ?2`,
+        )
+        .bind(event.id, playerId)
+        .all<{ player_id: string; entry_type: LedgerEntryType; amount_cents: number }>();
+      const totals = calculateLedger(
+        entries.results.map((entry) => ({
+          playerId: entry.player_id,
+          entryType: entry.entry_type,
+          amountCents: Number(entry.amount_cents),
+        })),
+      );
+      const summary = totals.playerSummaries[0];
+      return {
+        eventId: event.id,
+        title: event.title,
+        startsAt: event.starts_at,
+        location: event.location,
+        stakesNotes: event.stakes_notes,
+        cashInCents: summary?.cashInCents ?? 0,
+        cashOutCents: summary?.cashOutCents ?? 0,
+        netCents: summary?.netCents ?? 0,
+        rebuyCount: summary?.rebuyCount ?? 0,
+      };
+    }),
+  );
+
+  return json({ player: { id: player.id, displayName: player.display_name }, history });
+}
+
+export const onRequest: AppPagesFunction = async (context) => {
+  const request = context.request;
+  const method = request.method.toUpperCase();
+  const path = new URL(request.url).pathname.replace(/^\/money-api\/?/, "");
+  const parts = path.split("/").filter(Boolean);
+
+  try {
+    if (parts[0] === "events" && parts[1] && parts.length === 2) {
+      if (method === "GET") return eventDetail(context.env.DB, parts[1]);
+      if (method === "PATCH") {
+        return patchMoneyEvent(request, context.env.DB, parts[1], context.data.organizer);
+      }
+    }
+    if (method === "POST" && parts[0] === "events" && parts[2] === "entries" && parts.length === 3) {
+      return createEntry(request, context.env.DB, parts[1], context.data.organizer);
+    }
+    if (parts[0] === "events" && parts[2] === "entries" && parts[3] && parts.length === 4) {
+      if (method === "PATCH") {
+        return patchEntry(request, context.env.DB, parts[1], parts[3], context.data.organizer);
+      }
+      if (method === "DELETE") {
+        return deleteEntry(request, context.env.DB, parts[1], parts[3], context.data.organizer);
+      }
+    }
+    if (method === "POST" && parts[0] === "events" && parts[2] === "complete" && parts.length === 3) {
+      return completeMoneyEvent(request, context.env.DB, parts[1], context.data.organizer);
+    }
+    if (method === "GET" && parts[0] === "players" && parts[1] && parts.length === 2) {
+      return playerMoneyHistory(context.env.DB, parts[1]);
+    }
+
+    return apiError(404, "NOT_FOUND", "Money API route not found.");
+  } catch (error) {
+    if (error instanceof ZodError) return validationError(error);
+    if (error instanceof TypeError) return apiError(400, "BAD_REQUEST", error.message);
+    if (error instanceof Response) {
+      return apiError(error.status, "REQUEST_REJECTED", await error.text());
+    }
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("Money closeout is unresolved")) {
+      return apiError(
+        409,
+        "UNRESOLVED_CLOSEOUT",
+        "Record every attending player's cash-out and balance cash in against cash out before completing.",
+      );
+    }
+    return apiError(500, "INTERNAL_ERROR", "The money request could not be completed.");
+  }
+};

--- a/migrations/0002_cash_ledger.sql
+++ b/migrations/0002_cash_ledger.sql
@@ -1,0 +1,83 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE events
+ADD COLUMN money_tracking_enabled INTEGER NOT NULL DEFAULT 0
+CHECK (money_tracking_enabled IN (0, 1));
+
+ALTER TABLE events
+ADD COLUMN default_buy_in_cents INTEGER NOT NULL DEFAULT 0
+CHECK (default_buy_in_cents >= 0);
+
+ALTER TABLE events
+ADD COLUMN stakes_notes TEXT;
+
+CREATE TABLE ledger_entries (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  player_id TEXT NOT NULL REFERENCES players(id) ON DELETE RESTRICT,
+  entry_type TEXT NOT NULL CHECK (entry_type IN ('buy_in', 'rebuy', 'cash_out', 'adjustment')),
+  amount_cents INTEGER NOT NULL,
+  note TEXT,
+  created_by_organizer_id TEXT NOT NULL REFERENCES organizers(id),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (
+    (entry_type IN ('buy_in', 'rebuy') AND amount_cents > 0) OR
+    (entry_type = 'cash_out' AND amount_cents >= 0) OR
+    (entry_type = 'adjustment' AND amount_cents <> 0 AND note IS NOT NULL AND length(trim(note)) > 0)
+  )
+);
+
+CREATE INDEX ledger_entries_event_created_idx
+ON ledger_entries(event_id, created_at);
+
+CREATE INDEX ledger_entries_player_event_idx
+ON ledger_entries(player_id, event_id);
+
+CREATE TRIGGER prevent_unresolved_money_closeout
+BEFORE UPDATE OF status ON events
+WHEN NEW.status = 'completed'
+  AND OLD.status <> 'completed'
+  AND NEW.money_tracking_enabled = 1
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM event_players ep
+      WHERE ep.event_id = NEW.id
+        AND ep.attended = 1
+        AND NOT EXISTS (
+          SELECT 1
+          FROM ledger_entries le
+          WHERE le.event_id = NEW.id
+            AND le.player_id = ep.player_id
+            AND le.entry_type = 'cash_out'
+        )
+    )
+    OR
+    COALESCE((
+      SELECT SUM(
+        CASE
+          WHEN entry_type IN ('buy_in', 'rebuy') THEN amount_cents
+          WHEN entry_type = 'adjustment' AND amount_cents > 0 THEN amount_cents
+          ELSE 0
+        END
+      )
+      FROM ledger_entries
+      WHERE event_id = NEW.id
+    ), 0)
+    <>
+    COALESCE((
+      SELECT SUM(
+        CASE
+          WHEN entry_type = 'cash_out' THEN amount_cents
+          WHEN entry_type = 'adjustment' AND amount_cents < 0 THEN -amount_cents
+          ELSE 0
+        END
+      )
+      FROM ledger_entries
+      WHERE event_id = NEW.id
+    ), 0)
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Money closeout is unresolved');
+END;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brotm-poker",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "description": "Private organizer application for BroTM Poker nights.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brotm-poker",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "description": "Private organizer application for BroTM Poker nights.",
@@ -13,8 +13,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build",
-    "db:migrate:local": "wrangler d1 migrations apply brotm-poker --local",
-    "db:migrate:remote": "wrangler d1 migrations apply brotm-poker --remote"
+    "db:migrate:local": "wrangler d1 migrations apply brotm-poker --local --config wrangler.local.jsonc",
+    "db:migrate:remote": "wrangler d1 migrations apply brotm-poker --remote --config wrangler.local.jsonc"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/shared/money.ts
+++ b/shared/money.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+
+export const ledgerEntryTypes = ["buy_in", "rebuy", "cash_out", "adjustment"] as const;
+export type LedgerEntryType = (typeof ledgerEntryTypes)[number];
+
+const cents = z.number().int().min(-100_000_000).max(100_000_000);
+
+export const moneyEventPatchSchema = z
+  .object({
+    moneyTrackingEnabled: z.boolean().optional(),
+    defaultBuyInCents: z.number().int().min(0).max(10_000_000).optional(),
+    stakesNotes: z.string().trim().max(500).nullable().optional(),
+    correctionNote: z.string().trim().min(3).max(500).optional(),
+  })
+  .refine(
+    (value) =>
+      value.moneyTrackingEnabled !== undefined ||
+      value.defaultBuyInCents !== undefined ||
+      value.stakesNotes !== undefined,
+    "At least one money setting is required",
+  );
+
+export const ledgerEntryCreateSchema = z
+  .object({
+    playerId: z.string().uuid(),
+    entryType: z.enum(ledgerEntryTypes),
+    amountCents: cents,
+    note: z.string().trim().max(500).nullable().optional(),
+    correctionNote: z.string().trim().min(3).max(500).optional(),
+  })
+  .superRefine((value, context) => validateEntry(value, context));
+
+export const ledgerEntryPatchSchema = z
+  .object({
+    entryType: z.enum(ledgerEntryTypes).optional(),
+    amountCents: cents.optional(),
+    note: z.string().trim().max(500).nullable().optional(),
+    correctionNote: z.string().trim().min(3).max(500).optional(),
+  })
+  .refine(
+    (value) => value.entryType !== undefined || value.amountCents !== undefined || value.note !== undefined,
+    "At least one ledger field is required",
+  );
+
+export const ledgerEntryDeleteSchema = z.object({
+  correctionNote: z.string().trim().min(3).max(500).optional(),
+});
+
+export const moneyCompleteSchema = z.object({
+  correctionNote: z.string().trim().min(3).max(500).optional(),
+});
+
+function validateEntry(
+  value: { entryType: LedgerEntryType; amountCents: number; note?: string | null },
+  context: z.RefinementCtx,
+): void {
+  if ((value.entryType === "buy_in" || value.entryType === "rebuy") && value.amountCents <= 0) {
+    context.addIssue({
+      code: "custom",
+      path: ["amountCents"],
+      message: "Buy-ins and rebuys must be greater than zero.",
+    });
+  }
+  if (value.entryType === "cash_out" && value.amountCents < 0) {
+    context.addIssue({
+      code: "custom",
+      path: ["amountCents"],
+      message: "Cash-out cannot be negative.",
+    });
+  }
+  if (value.entryType === "adjustment") {
+    if (value.amountCents === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["amountCents"],
+        message: "An adjustment cannot be zero.",
+      });
+    }
+    if (!value.note?.trim()) {
+      context.addIssue({
+        code: "custom",
+        path: ["note"],
+        message: "Adjustments require an explanation.",
+      });
+    }
+  }
+}
+
+export interface LedgerCalculationEntry {
+  playerId: string;
+  entryType: LedgerEntryType;
+  amountCents: number;
+}
+
+export interface PlayerLedgerSummary {
+  playerId: string;
+  cashInCents: number;
+  cashOutCents: number;
+  netCents: number;
+  rebuyCount: number;
+  hasCashOut: boolean;
+}
+
+export interface LedgerTotals {
+  cashInCents: number;
+  cashOutCents: number;
+  differenceCents: number;
+  playerSummaries: PlayerLedgerSummary[];
+}
+
+export function calculateLedger(entries: LedgerCalculationEntry[]): LedgerTotals {
+  const players = new Map<string, PlayerLedgerSummary>();
+  let cashInCents = 0;
+  let cashOutCents = 0;
+
+  for (const entry of entries) {
+    const summary = players.get(entry.playerId) ?? {
+      playerId: entry.playerId,
+      cashInCents: 0,
+      cashOutCents: 0,
+      netCents: 0,
+      rebuyCount: 0,
+      hasCashOut: false,
+    };
+
+    if (entry.entryType === "buy_in" || entry.entryType === "rebuy") {
+      cashInCents += entry.amountCents;
+      summary.cashInCents += entry.amountCents;
+      if (entry.entryType === "rebuy") summary.rebuyCount += 1;
+    } else if (entry.entryType === "cash_out") {
+      cashOutCents += entry.amountCents;
+      summary.cashOutCents += entry.amountCents;
+      summary.hasCashOut = true;
+    } else if (entry.amountCents > 0) {
+      cashInCents += entry.amountCents;
+      summary.cashInCents += entry.amountCents;
+    } else {
+      const absolute = Math.abs(entry.amountCents);
+      cashOutCents += absolute;
+      summary.cashOutCents += absolute;
+    }
+
+    summary.netCents = summary.cashOutCents - summary.cashInCents;
+    players.set(entry.playerId, summary);
+  }
+
+  return {
+    cashInCents,
+    cashOutCents,
+    differenceCents: cashInCents - cashOutCents,
+    playerSummaries: [...players.values()],
+  };
+}

--- a/src/Money.tsx
+++ b/src/Money.tsx
@@ -1,0 +1,682 @@
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
+import { api } from "./api";
+import type { LedgerEntryType } from "../shared/money";
+
+interface MoneyEvent {
+  id: string;
+  title: string;
+  status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  moneyTrackingEnabled: boolean;
+  defaultBuyInCents: number;
+  stakesNotes: string | null;
+}
+
+interface MoneyPlayer {
+  playerId: string;
+  displayName: string;
+  attended: boolean;
+  rsvpStatus: "pending" | "yes" | "maybe" | "no";
+  cashInCents: number;
+  cashOutCents: number;
+  netCents: number;
+  rebuyCount: number;
+  hasCashOut: boolean;
+}
+
+interface LedgerEntry {
+  id: string;
+  eventId: string;
+  playerId: string;
+  playerName: string;
+  entryType: LedgerEntryType;
+  amountCents: number;
+  note: string | null;
+  organizerName: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MoneyDetail {
+  event: MoneyEvent;
+  players: MoneyPlayer[];
+  entries: LedgerEntry[];
+  totals: {
+    cashInCents: number;
+    cashOutCents: number;
+    differenceCents: number;
+    missingCashOutCount: number;
+    balanced: boolean;
+  };
+  issues: string[];
+  closeoutReady: boolean;
+}
+
+interface PlayerMoneyHistory {
+  player: { id: string; displayName: string };
+  history: Array<{
+    eventId: string;
+    title: string;
+    startsAt: string;
+    location: string;
+    stakesNotes: string | null;
+    cashInCents: number;
+    cashOutCents: number;
+    netCents: number;
+    rebuyCount: number;
+  }>;
+}
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: cents % 100 === 0 ? 0 : 2,
+  }).format(cents / 100);
+}
+
+function dateTime(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The request could not be completed.";
+}
+
+function centsFromInput(value: string): number | null {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return null;
+  return Math.round(amount * 100);
+}
+
+function Button({
+  children,
+  variant = "primary",
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "danger";
+}) {
+  return (
+    <button className={`button button-${variant}`} {...props}>
+      {children}
+    </button>
+  );
+}
+
+function MoneyShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="money-shell">
+      <header className="money-topbar">
+        <Link className="brand-lockup" to="/">
+          <span aria-hidden="true">♠</span>
+          <strong>BroTM Poker</strong>
+        </Link>
+        <span>Cash ledger</span>
+      </header>
+      <main className="money-page">{children}</main>
+    </div>
+  );
+}
+
+function Loading() {
+  return <div className="state-card">Loading cash ledger…</div>;
+}
+
+function ErrorPanel({ error }: { error: unknown }) {
+  return (
+    <div className="state-card state-error" role="alert">
+      <strong>Could not load the cash ledger.</strong>
+      <span>{errorMessage(error)}</span>
+    </div>
+  );
+}
+
+function NetAmount({ cents }: { cents: number }) {
+  const className = cents > 0 ? "net-positive" : cents < 0 ? "net-negative" : "net-zero";
+  return <strong className={className}>{money(cents)}</strong>;
+}
+
+function entryLabel(type: LedgerEntryType): string {
+  const labels: Record<LedgerEntryType, string> = {
+    buy_in: "Buy-in",
+    rebuy: "Rebuy",
+    cash_out: "Cash-out",
+    adjustment: "Adjustment",
+  };
+  return labels[type];
+}
+
+function LedgerEntryEditor({
+  entry,
+  disabled,
+  onSave,
+  onDelete,
+}: {
+  entry: LedgerEntry;
+  disabled: boolean;
+  onSave: (entryId: string, body: { entryType: LedgerEntryType; amountCents: number; note: string | null }) => void;
+  onDelete: (entry: LedgerEntry) => void;
+}) {
+  const [entryType, setEntryType] = useState<LedgerEntryType>(entry.entryType);
+  const [amount, setAmount] = useState((entry.amountCents / 100).toFixed(2));
+  const [note, setNote] = useState(entry.note ?? "");
+
+  useEffect(() => {
+    setEntryType(entry.entryType);
+    setAmount((entry.amountCents / 100).toFixed(2));
+    setNote(entry.note ?? "");
+  }, [entry]);
+
+  const changed =
+    entryType !== entry.entryType ||
+    centsFromInput(amount) !== entry.amountCents ||
+    note !== (entry.note ?? "");
+
+  return (
+    <article className="ledger-entry-card">
+      <div className="ledger-entry-heading">
+        <div>
+          <strong>{entry.playerName}</strong>
+          <small>
+            {entryLabel(entry.entryType)} · {dateTime(entry.createdAt)} · {entry.organizerName}
+          </small>
+        </div>
+        <NetAmount
+          cents={
+            entry.entryType === "cash_out" || (entry.entryType === "adjustment" && entry.amountCents < 0)
+              ? Math.abs(entry.amountCents)
+              : -Math.abs(entry.amountCents)
+          }
+        />
+      </div>
+      <div className="ledger-edit-grid">
+        <label>
+          Type
+          <select
+            value={entryType}
+            disabled={disabled}
+            onChange={(change) => setEntryType(change.target.value as LedgerEntryType)}
+          >
+            <option value="buy_in">Buy-in</option>
+            <option value="rebuy">Rebuy</option>
+            <option value="cash_out">Cash-out</option>
+            <option value="adjustment">Adjustment</option>
+          </select>
+        </label>
+        <label>
+          Amount
+          <input
+            type="number"
+            step="0.01"
+            value={amount}
+            disabled={disabled}
+            onChange={(change) => setAmount(change.target.value)}
+          />
+        </label>
+        <label className="ledger-note-field">
+          Note
+          <input
+            value={note}
+            maxLength={500}
+            disabled={disabled}
+            onChange={(change) => setNote(change.target.value)}
+            placeholder={entryType === "adjustment" ? "Required explanation" : "Optional note"}
+          />
+        </label>
+      </div>
+      <div className="ledger-entry-actions">
+        <Button
+          type="button"
+          variant="secondary"
+          disabled={disabled || !changed || centsFromInput(amount) === null}
+          onClick={() => {
+            const amountCents = centsFromInput(amount);
+            if (amountCents === null) return;
+            onSave(entry.id, { entryType, amountCents, note: note || null });
+          }}
+        >
+          Save entry
+        </Button>
+        <Button type="button" variant="danger" disabled={disabled} onClick={() => onDelete(entry)}>
+          Delete
+        </Button>
+      </div>
+    </article>
+  );
+}
+
+export function MoneyEventPage() {
+  const { id = "" } = useParams();
+  const [detail, setDetail] = useState<MoneyDetail>();
+  const [error, setError] = useState<unknown>();
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string>();
+  const [correctionNote, setCorrectionNote] = useState("");
+
+  const load = async () => {
+    try {
+      const response = await api<MoneyDetail>(`/money-api/events/${id}`);
+      setDetail(response);
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [id]);
+
+  const summaries = useMemo(
+    () => new Map((detail?.players ?? []).map((player) => [player.playerId, player])),
+    [detail?.players],
+  );
+
+  if (error && !detail) {
+    return (
+      <MoneyShell>
+        <ErrorPanel error={error} />
+        <Link className="button button-secondary" to={`/events/${id}`}>
+          Return to event
+        </Link>
+      </MoneyShell>
+    );
+  }
+  if (!detail) return <MoneyShell><Loading /></MoneyShell>;
+
+  const locked = ["completed", "cancelled", "archived"].includes(detail.event.status);
+  const correctionReady = correctionNote.trim().length >= 3;
+  const editDisabled = saving || (locked && !correctionReady);
+  const correctionFields = locked ? { correctionNote: correctionNote.trim() } : {};
+
+  async function run<T>(action: () => Promise<T>, success: string): Promise<void> {
+    setSaving(true);
+    setMessage(undefined);
+    setError(undefined);
+    try {
+      const response = await action();
+      if (response && typeof response === "object" && "event" in response) {
+        setDetail(response as MoneyDetail);
+      } else {
+        await load();
+      }
+      setMessage(success);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveSettings(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fields = new FormData(event.currentTarget);
+    const defaultBuyInCents = centsFromInput(String(fields.get("defaultBuyIn") ?? ""));
+    if (defaultBuyInCents === null || defaultBuyInCents < 0) {
+      setError(new Error("Enter a valid default buy-in."));
+      return;
+    }
+    await run(
+      () =>
+        api<MoneyDetail>(`/money-api/events/${id}`, {
+          method: "PATCH",
+          body: JSON.stringify({
+            moneyTrackingEnabled: fields.get("moneyTrackingEnabled") === "on",
+            defaultBuyInCents,
+            stakesNotes: String(fields.get("stakesNotes") ?? "") || null,
+            ...correctionFields,
+          }),
+        }),
+      locked ? "Money settings correction saved and audited." : "Money settings saved.",
+    );
+  }
+
+  async function createEntry(
+    player: MoneyPlayer,
+    entryType: LedgerEntryType,
+    amountCents: number,
+    note?: string | null,
+  ) {
+    await run(
+      () =>
+        api<MoneyDetail>(`/money-api/events/${id}/entries`, {
+          method: "POST",
+          body: JSON.stringify({
+            playerId: player.playerId,
+            entryType,
+            amountCents,
+            note: note ?? null,
+            ...correctionFields,
+          }),
+        }),
+      `${entryLabel(entryType)} recorded for ${player.displayName}.`,
+    );
+  }
+
+  function promptAmount(label: string, initial: number): number | null {
+    const value = window.prompt(`${label} amount in dollars`, (initial / 100).toFixed(2));
+    if (value === null) return null;
+    const cents = centsFromInput(value);
+    if (cents === null) setError(new Error("Enter a valid dollar amount."));
+    return cents;
+  }
+
+  async function quickBuyIn(player: MoneyPlayer, type: "buy_in" | "rebuy") {
+    const amount = promptAmount(entryLabel(type), detail.event.defaultBuyInCents);
+    if (amount === null) return;
+    await createEntry(player, type, amount);
+  }
+
+  async function quickCashOut(player: MoneyPlayer) {
+    const amount = promptAmount("Cash-out", player.cashOutCents);
+    if (amount === null) return;
+    await createEntry(player, "cash_out", amount);
+  }
+
+  async function quickAdjustment(player: MoneyPlayer) {
+    const amount = promptAmount("Adjustment: positive adds to cash in; negative adds to cash out", 0);
+    if (amount === null) return;
+    const note = window.prompt("Required adjustment explanation");
+    if (!note?.trim()) {
+      setError(new Error("Adjustments require an explanation."));
+      return;
+    }
+    await createEntry(player, "adjustment", amount, note.trim());
+  }
+
+  async function saveEntry(
+    entryId: string,
+    body: { entryType: LedgerEntryType; amountCents: number; note: string | null },
+  ) {
+    await run(
+      () =>
+        api<MoneyDetail>(`/money-api/events/${id}/entries/${entryId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ ...body, ...correctionFields }),
+        }),
+      locked ? "Ledger correction saved and audited." : "Ledger entry updated.",
+    );
+  }
+
+  async function deleteEntry(entry: LedgerEntry) {
+    if (!window.confirm(`Delete the ${entryLabel(entry.entryType).toLowerCase()} for ${entry.playerName}?`)) {
+      return;
+    }
+    await run(
+      () =>
+        api<MoneyDetail>(`/money-api/events/${id}/entries/${entry.id}`, {
+          method: "DELETE",
+          body: JSON.stringify(correctionFields),
+        }),
+      locked ? "Ledger removal saved and audited." : "Ledger entry deleted.",
+    );
+  }
+
+  async function completeEvent() {
+    if (!window.confirm("Complete and lock this balanced poker night?")) return;
+    await run(
+      () =>
+        api<MoneyDetail>(`/money-api/events/${id}/complete`, {
+          method: "POST",
+          body: JSON.stringify({}),
+        }),
+      "Event completed with a balanced cash ledger.",
+    );
+  }
+
+  return (
+    <MoneyShell>
+      <div className="money-page-header">
+        <div>
+          <p className="eyebrow">{detail.event.status} event</p>
+          <h1>{detail.event.title}</h1>
+          <p>{detail.event.stakesNotes || "No stakes notes recorded."}</p>
+        </div>
+        <Link className="button button-secondary" to={`/events/${id}`}>
+          Event details
+        </Link>
+      </div>
+
+      {error ? <ErrorPanel error={error} /> : null}
+      {message ? <div className="state-card state-success">{message}</div> : null}
+
+      {locked ? (
+        <section className="panel money-correction-panel">
+          <div>
+            <p className="eyebrow">Locked money record</p>
+            <h2>Correction reason required</h2>
+            <p>All changes to a completed ledger are written to the event audit history.</p>
+          </div>
+          <label>
+            Correction note
+            <textarea
+              rows={3}
+              maxLength={500}
+              value={correctionNote}
+              onChange={(change) => setCorrectionNote(change.target.value)}
+              placeholder="Example: Ryan's cash-out was entered as $45 instead of $54."
+            />
+          </label>
+        </section>
+      ) : null}
+
+      <section className="panel">
+        <div className="section-heading-row">
+          <div>
+            <p className="eyebrow">Setup</p>
+            <h2>Money tracking</h2>
+          </div>
+          <span>{detail.event.moneyTrackingEnabled ? "Enabled" : "Disabled"}</span>
+        </div>
+        <form className="money-settings-form" onSubmit={saveSettings} key={`${detail.event.id}-${detail.event.defaultBuyInCents}-${detail.event.moneyTrackingEnabled}-${detail.event.stakesNotes}`}>
+          <label className="toggle-field">
+            <input
+              type="checkbox"
+              name="moneyTrackingEnabled"
+              defaultChecked={detail.event.moneyTrackingEnabled}
+              disabled={editDisabled}
+            />
+            <span>Track money for this night</span>
+          </label>
+          <label>
+            Default buy-in
+            <input
+              type="number"
+              name="defaultBuyIn"
+              min="0"
+              step="0.01"
+              defaultValue={(detail.event.defaultBuyInCents / 100).toFixed(2)}
+              disabled={editDisabled}
+            />
+          </label>
+          <label className="money-settings-wide">
+            Stakes and money notes
+            <textarea
+              name="stakesNotes"
+              rows={3}
+              maxLength={500}
+              defaultValue={detail.event.stakesNotes ?? ""}
+              disabled={editDisabled}
+            />
+          </label>
+          <Button disabled={editDisabled}>{saving ? "Saving…" : "Save money settings"}</Button>
+        </form>
+      </section>
+
+      {detail.event.moneyTrackingEnabled ? (
+        <>
+          <section className="money-total-grid" aria-label="Cash closeout totals">
+            <article className="metric-card">
+              <span>Cash in</span>
+              <strong>{money(detail.totals.cashInCents)}</strong>
+            </article>
+            <article className="metric-card">
+              <span>Cash out</span>
+              <strong>{money(detail.totals.cashOutCents)}</strong>
+            </article>
+            <article className={`metric-card ${detail.totals.balanced ? "is-balanced" : "is-unbalanced"}`}>
+              <span>Difference</span>
+              <strong>{money(detail.totals.differenceCents)}</strong>
+            </article>
+            <article className={`metric-card ${detail.totals.missingCashOutCount ? "is-unbalanced" : "is-balanced"}`}>
+              <span>Missing cash-outs</span>
+              <strong>{detail.totals.missingCashOutCount}</strong>
+            </article>
+          </section>
+
+          <section className={`panel closeout-panel ${detail.closeoutReady ? "is-ready" : "has-issues"}`}>
+            <div>
+              <p className="eyebrow">Closeout</p>
+              <h2>{detail.closeoutReady ? "Ready to close" : "Resolve before closing"}</h2>
+            </div>
+            {detail.issues.length ? (
+              <ul>
+                {detail.issues.map((issue) => <li key={issue}>{issue}</li>)}
+              </ul>
+            ) : (
+              <p>Cash in matches cash out, and every attending player has a recorded cash-out.</p>
+            )}
+            {detail.event.status === "active" ? (
+              <Button disabled={saving || !detail.closeoutReady} onClick={() => void completeEvent()}>
+                Complete balanced event
+              </Button>
+            ) : null}
+          </section>
+
+          <section className="panel">
+            <div className="section-heading-row">
+              <div>
+                <p className="eyebrow">Live Night</p>
+                <h2>Players</h2>
+              </div>
+              <span>{detail.players.length}</span>
+            </div>
+            <div className="money-player-list">
+              {detail.players.map((player) => (
+                <article className={`money-player-card ${player.attended ? "is-attending" : ""}`} key={player.playerId}>
+                  <div className="money-player-heading">
+                    <div>
+                      <strong>{player.displayName}</strong>
+                      <small>
+                        {player.attended ? "Checked in" : `RSVP: ${player.rsvpStatus}`} · {player.rebuyCount} rebuys
+                      </small>
+                    </div>
+                    <NetAmount cents={player.netCents} />
+                  </div>
+                  <div className="money-player-totals">
+                    <span>In {money(player.cashInCents)}</span>
+                    <span>Out {player.hasCashOut ? money(player.cashOutCents) : "Not entered"}</span>
+                  </div>
+                  <div className="money-action-grid">
+                    <Button disabled={editDisabled} onClick={() => void quickBuyIn(player, "buy_in")}>Buy in</Button>
+                    <Button variant="secondary" disabled={editDisabled} onClick={() => void quickBuyIn(player, "rebuy")}>Rebuy</Button>
+                    <Button variant="secondary" disabled={editDisabled} onClick={() => void quickCashOut(player)}>Cash out</Button>
+                    <Button variant="secondary" disabled={editDisabled} onClick={() => void quickAdjustment(player)}>Adjustment</Button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="panel">
+            <div className="section-heading-row">
+              <div>
+                <p className="eyebrow">Transactions</p>
+                <h2>Ledger entries</h2>
+              </div>
+              <span>{detail.entries.length}</span>
+            </div>
+            <p className="ledger-help">
+              Positive adjustments add to cash in. Negative adjustments add their absolute value to cash out.
+            </p>
+            <div className="ledger-entry-list">
+              {detail.entries.length ? (
+                detail.entries.map((entry) => (
+                  <LedgerEntryEditor
+                    key={entry.id}
+                    entry={entry}
+                    disabled={editDisabled}
+                    onSave={(entryId, body) => void saveEntry(entryId, body)}
+                    onDelete={(selected) => void deleteEntry(selected)}
+                  />
+                ))
+              ) : (
+                <div className="state-card">No money has been recorded yet.</div>
+              )}
+            </div>
+          </section>
+        </>
+      ) : (
+        <section className="state-card">
+          Enable money tracking to record buy-ins, rebuys, cash-outs, adjustments, and closeout totals.
+        </section>
+      )}
+    </MoneyShell>
+  );
+}
+
+export function PlayerMoneyPage() {
+  const { id = "" } = useParams();
+  const [data, setData] = useState<PlayerMoneyHistory>();
+  const [error, setError] = useState<unknown>();
+
+  useEffect(() => {
+    api<PlayerMoneyHistory>(`/money-api/players/${id}`).then(setData).catch(setError);
+  }, [id]);
+
+  if (error) return <MoneyShell><ErrorPanel error={error} /></MoneyShell>;
+  if (!data) return <MoneyShell><Loading /></MoneyShell>;
+
+  const lifetimeNet = data.history.reduce((total, event) => total + event.netCents, 0);
+  const totalBuyIns = data.history.reduce((total, event) => total + event.cashInCents, 0);
+  const totalCashOuts = data.history.reduce((total, event) => total + event.cashOutCents, 0);
+
+  return (
+    <MoneyShell>
+      <div className="money-page-header">
+        <div>
+          <p className="eyebrow">Player money history</p>
+          <h1>{data.player.displayName}</h1>
+        </div>
+        <Link className="button button-secondary" to={`/players/${id}`}>Player details</Link>
+      </div>
+      <section className="money-total-grid">
+        <article className="metric-card"><span>Total in</span><strong>{money(totalBuyIns)}</strong></article>
+        <article className="metric-card"><span>Total out</span><strong>{money(totalCashOuts)}</strong></article>
+        <article className="metric-card"><span>Derived net</span><NetAmount cents={lifetimeNet} /></article>
+        <article className="metric-card"><span>Tracked nights</span><strong>{data.history.length}</strong></article>
+      </section>
+      <section className="panel">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Completed events</p><h2>Financial record</h2></div>
+        </div>
+        <div className="player-money-history">
+          {data.history.length ? data.history.map((event) => (
+            <Link to={`/money/events/${event.eventId}`} className="player-money-history-card" key={event.eventId}>
+              <div><strong>{event.title}</strong><span>{dateTime(event.startsAt)} · {event.location || "No location"}</span></div>
+              <div><span>In {money(event.cashInCents)}</span><span>Out {money(event.cashOutCents)}</span><NetAmount cents={event.netCents} /></div>
+              <small>{event.rebuyCount} rebuys · {event.stakesNotes || "No stakes notes"}</small>
+            </Link>
+          )) : <div className="state-card">No completed money-tracked events yet.</div>}
+        </div>
+      </section>
+    </MoneyShell>
+  );
+}
+
+export function MoneyShortcut() {
+  const location = useLocation();
+  const eventMatch = location.pathname.match(/^\/events\/([0-9a-f-]+)$/i);
+  const playerMatch = location.pathname.match(/^\/players\/([0-9a-f-]+)$/i);
+
+  if (eventMatch) {
+    return <Link className="money-shortcut" to={`/money/events/${eventMatch[1]}`}>$ Money ledger</Link>;
+  }
+  if (playerMatch) {
+    return <Link className="money-shortcut" to={`/money/players/${playerMatch[1]}`}>$ Money history</Link>;
+  }
+  return null;
+}

--- a/src/Money.tsx
+++ b/src/Money.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
-import { api } from "./api";
 import type { LedgerEntryType } from "../shared/money";
+import { api } from "./api";
 
 interface MoneyEvent {
   id: string;
@@ -26,7 +26,6 @@ interface MoneyPlayer {
 
 interface LedgerEntry {
   id: string;
-  eventId: string;
   playerId: string;
   playerName: string;
   entryType: LedgerEntryType;
@@ -34,7 +33,6 @@ interface LedgerEntry {
   note: string | null;
   organizerName: string;
   createdAt: string;
-  updatedAt: string;
 }
 
 interface MoneyDetail {
@@ -67,7 +65,7 @@ interface PlayerMoneyHistory {
   }>;
 }
 
-function money(cents: number): string {
+function formatMoney(cents: number): string {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
@@ -75,7 +73,7 @@ function money(cents: number): string {
   }).format(cents / 100);
 }
 
-function dateTime(value: string): string {
+function formatDate(value: string): string {
   return new Intl.DateTimeFormat("en-US", {
     dateStyle: "medium",
     timeStyle: "short",
@@ -86,10 +84,18 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "The request could not be completed.";
 }
 
-function centsFromInput(value: string): number | null {
+function parseCents(value: string): number | null {
   const amount = Number(value);
-  if (!Number.isFinite(amount)) return null;
-  return Math.round(amount * 100);
+  return Number.isFinite(amount) ? Math.round(amount * 100) : null;
+}
+
+function entryLabel(type: LedgerEntryType): string {
+  return {
+    buy_in: "Buy-in",
+    rebuy: "Rebuy",
+    cash_out: "Cash-out",
+    adjustment: "Adjustment",
+  }[type];
 }
 
 function Button({
@@ -121,10 +127,6 @@ function MoneyShell({ children }: { children: ReactNode }) {
   );
 }
 
-function Loading() {
-  return <div className="state-card">Loading cash ledger…</div>;
-}
-
 function ErrorPanel({ error }: { error: unknown }) {
   return (
     <div className="state-card state-error" role="alert">
@@ -136,17 +138,7 @@ function ErrorPanel({ error }: { error: unknown }) {
 
 function NetAmount({ cents }: { cents: number }) {
   const className = cents > 0 ? "net-positive" : cents < 0 ? "net-negative" : "net-zero";
-  return <strong className={className}>{money(cents)}</strong>;
-}
-
-function entryLabel(type: LedgerEntryType): string {
-  const labels: Record<LedgerEntryType, string> = {
-    buy_in: "Buy-in",
-    rebuy: "Rebuy",
-    cash_out: "Cash-out",
-    adjustment: "Adjustment",
-  };
-  return labels[type];
+  return <strong className={className}>{formatMoney(cents)}</strong>;
 }
 
 function LedgerEntryEditor({
@@ -157,7 +149,7 @@ function LedgerEntryEditor({
 }: {
   entry: LedgerEntry;
   disabled: boolean;
-  onSave: (entryId: string, body: { entryType: LedgerEntryType; amountCents: number; note: string | null }) => void;
+  onSave: (entryId: string, entryType: LedgerEntryType, amountCents: number, note: string | null) => void;
   onDelete: (entry: LedgerEntry) => void;
 }) {
   const [entryType, setEntryType] = useState<LedgerEntryType>(entry.entryType);
@@ -170,10 +162,9 @@ function LedgerEntryEditor({
     setNote(entry.note ?? "");
   }, [entry]);
 
+  const parsedAmount = parseCents(amount);
   const changed =
-    entryType !== entry.entryType ||
-    centsFromInput(amount) !== entry.amountCents ||
-    note !== (entry.note ?? "");
+    entryType !== entry.entryType || parsedAmount !== entry.amountCents || note !== (entry.note ?? "");
 
   return (
     <article className="ledger-entry-card">
@@ -181,16 +172,10 @@ function LedgerEntryEditor({
         <div>
           <strong>{entry.playerName}</strong>
           <small>
-            {entryLabel(entry.entryType)} · {dateTime(entry.createdAt)} · {entry.organizerName}
+            {entryLabel(entry.entryType)} · {formatDate(entry.createdAt)} · {entry.organizerName}
           </small>
         </div>
-        <NetAmount
-          cents={
-            entry.entryType === "cash_out" || (entry.entryType === "adjustment" && entry.amountCents < 0)
-              ? Math.abs(entry.amountCents)
-              : -Math.abs(entry.amountCents)
-          }
-        />
+        <span>{formatMoney(entry.amountCents)}</span>
       </div>
       <div className="ledger-edit-grid">
         <label>
@@ -222,8 +207,8 @@ function LedgerEntryEditor({
             value={note}
             maxLength={500}
             disabled={disabled}
-            onChange={(change) => setNote(change.target.value)}
             placeholder={entryType === "adjustment" ? "Required explanation" : "Optional note"}
+            onChange={(change) => setNote(change.target.value)}
           />
         </label>
       </div>
@@ -231,11 +216,9 @@ function LedgerEntryEditor({
         <Button
           type="button"
           variant="secondary"
-          disabled={disabled || !changed || centsFromInput(amount) === null}
+          disabled={disabled || !changed || parsedAmount === null}
           onClick={() => {
-            const amountCents = centsFromInput(amount);
-            if (amountCents === null) return;
-            onSave(entry.id, { entryType, amountCents, note: note || null });
+            if (parsedAmount !== null) onSave(entry.id, entryType, parsedAmount, note || null);
           }}
         >
           Save entry
@@ -258,8 +241,7 @@ export function MoneyEventPage() {
 
   const load = async () => {
     try {
-      const response = await api<MoneyDetail>(`/money-api/events/${id}`);
-      setDetail(response);
+      setDetail(await api<MoneyDetail>(`/money-api/events/${id}`));
       setError(undefined);
     } catch (caught) {
       setError(caught);
@@ -269,11 +251,6 @@ export function MoneyEventPage() {
   useEffect(() => {
     void load();
   }, [id]);
-
-  const summaries = useMemo(
-    () => new Map((detail?.players ?? []).map((player) => [player.playerId, player])),
-    [detail?.players],
-  );
 
   if (error && !detail) {
     return (
@@ -285,24 +262,20 @@ export function MoneyEventPage() {
       </MoneyShell>
     );
   }
-  if (!detail) return <MoneyShell><Loading /></MoneyShell>;
+  if (!detail) return <MoneyShell><div className="state-card">Loading cash ledger…</div></MoneyShell>;
 
-  const locked = ["completed", "cancelled", "archived"].includes(detail.event.status);
+  const current = detail;
+  const locked = ["completed", "cancelled", "archived"].includes(current.event.status);
   const correctionReady = correctionNote.trim().length >= 3;
   const editDisabled = saving || (locked && !correctionReady);
   const correctionFields = locked ? { correctionNote: correctionNote.trim() } : {};
 
-  async function run<T>(action: () => Promise<T>, success: string): Promise<void> {
+  async function mutate(action: () => Promise<MoneyDetail>, success: string) {
     setSaving(true);
-    setMessage(undefined);
     setError(undefined);
+    setMessage(undefined);
     try {
-      const response = await action();
-      if (response && typeof response === "object" && "event" in response) {
-        setDetail(response as MoneyDetail);
-      } else {
-        await load();
-      }
+      setDetail(await action());
       setMessage(success);
     } catch (caught) {
       setError(caught);
@@ -314,12 +287,12 @@ export function MoneyEventPage() {
   async function saveSettings(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const fields = new FormData(event.currentTarget);
-    const defaultBuyInCents = centsFromInput(String(fields.get("defaultBuyIn") ?? ""));
+    const defaultBuyInCents = parseCents(String(fields.get("defaultBuyIn") ?? ""));
     if (defaultBuyInCents === null || defaultBuyInCents < 0) {
       setError(new Error("Enter a valid default buy-in."));
       return;
     }
-    await run(
+    await mutate(
       () =>
         api<MoneyDetail>(`/money-api/events/${id}`, {
           method: "PATCH",
@@ -334,13 +307,8 @@ export function MoneyEventPage() {
     );
   }
 
-  async function createEntry(
-    player: MoneyPlayer,
-    entryType: LedgerEntryType,
-    amountCents: number,
-    note?: string | null,
-  ) {
-    await run(
+  async function createEntry(player: MoneyPlayer, entryType: LedgerEntryType, amountCents: number, note?: string) {
+    await mutate(
       () =>
         api<MoneyDetail>(`/money-api/events/${id}/entries`, {
           method: "POST",
@@ -348,7 +316,7 @@ export function MoneyEventPage() {
             playerId: player.playerId,
             entryType,
             amountCents,
-            note: note ?? null,
+            note: note || null,
             ...correctionFields,
           }),
         }),
@@ -356,56 +324,54 @@ export function MoneyEventPage() {
     );
   }
 
-  function promptAmount(label: string, initial: number): number | null {
-    const value = window.prompt(`${label} amount in dollars`, (initial / 100).toFixed(2));
+  function promptAmount(label: string, initialCents: number): number | null {
+    const value = window.prompt(`${label} amount in dollars`, (initialCents / 100).toFixed(2));
     if (value === null) return null;
-    const cents = centsFromInput(value);
-    if (cents === null) setError(new Error("Enter a valid dollar amount."));
-    return cents;
+    const amount = parseCents(value);
+    if (amount === null) setError(new Error("Enter a valid dollar amount."));
+    return amount;
   }
 
-  async function quickBuyIn(player: MoneyPlayer, type: "buy_in" | "rebuy") {
-    const amount = promptAmount(entryLabel(type), detail.event.defaultBuyInCents);
-    if (amount === null) return;
-    await createEntry(player, type, amount);
+  async function addBuyIn(player: MoneyPlayer, entryType: "buy_in" | "rebuy") {
+    const amount = promptAmount(entryLabel(entryType), current.event.defaultBuyInCents);
+    if (amount !== null) await createEntry(player, entryType, amount);
   }
 
-  async function quickCashOut(player: MoneyPlayer) {
+  async function addCashOut(player: MoneyPlayer) {
     const amount = promptAmount("Cash-out", player.cashOutCents);
-    if (amount === null) return;
-    await createEntry(player, "cash_out", amount);
+    if (amount !== null) await createEntry(player, "cash_out", amount);
   }
 
-  async function quickAdjustment(player: MoneyPlayer) {
+  async function addAdjustment(player: MoneyPlayer) {
     const amount = promptAmount("Adjustment: positive adds to cash in; negative adds to cash out", 0);
     if (amount === null) return;
-    const note = window.prompt("Required adjustment explanation");
-    if (!note?.trim()) {
+    const note = window.prompt("Required adjustment explanation")?.trim();
+    if (!note) {
       setError(new Error("Adjustments require an explanation."));
       return;
     }
-    await createEntry(player, "adjustment", amount, note.trim());
+    await createEntry(player, "adjustment", amount, note);
   }
 
   async function saveEntry(
     entryId: string,
-    body: { entryType: LedgerEntryType; amountCents: number; note: string | null },
+    entryType: LedgerEntryType,
+    amountCents: number,
+    note: string | null,
   ) {
-    await run(
+    await mutate(
       () =>
         api<MoneyDetail>(`/money-api/events/${id}/entries/${entryId}`, {
           method: "PATCH",
-          body: JSON.stringify({ ...body, ...correctionFields }),
+          body: JSON.stringify({ entryType, amountCents, note, ...correctionFields }),
         }),
       locked ? "Ledger correction saved and audited." : "Ledger entry updated.",
     );
   }
 
   async function deleteEntry(entry: LedgerEntry) {
-    if (!window.confirm(`Delete the ${entryLabel(entry.entryType).toLowerCase()} for ${entry.playerName}?`)) {
-      return;
-    }
-    await run(
+    if (!window.confirm(`Delete the ${entryLabel(entry.entryType).toLowerCase()} for ${entry.playerName}?`)) return;
+    await mutate(
       () =>
         api<MoneyDetail>(`/money-api/events/${id}/entries/${entry.id}`, {
           method: "DELETE",
@@ -417,7 +383,7 @@ export function MoneyEventPage() {
 
   async function completeEvent() {
     if (!window.confirm("Complete and lock this balanced poker night?")) return;
-    await run(
+    await mutate(
       () =>
         api<MoneyDetail>(`/money-api/events/${id}/complete`, {
           method: "POST",
@@ -431,9 +397,9 @@ export function MoneyEventPage() {
     <MoneyShell>
       <div className="money-page-header">
         <div>
-          <p className="eyebrow">{detail.event.status} event</p>
-          <h1>{detail.event.title}</h1>
-          <p>{detail.event.stakesNotes || "No stakes notes recorded."}</p>
+          <p className="eyebrow">{current.event.status} event</p>
+          <h1>{current.event.title}</h1>
+          <p>{current.event.stakesNotes || "No stakes notes recorded."}</p>
         </div>
         <Link className="button button-secondary" to={`/events/${id}`}>
           Event details
@@ -448,7 +414,7 @@ export function MoneyEventPage() {
           <div>
             <p className="eyebrow">Locked money record</p>
             <h2>Correction reason required</h2>
-            <p>All changes to a completed ledger are written to the event audit history.</p>
+            <p>Changes to a completed ledger are written to the event audit history.</p>
           </div>
           <label>
             Correction note
@@ -457,7 +423,7 @@ export function MoneyEventPage() {
               maxLength={500}
               value={correctionNote}
               onChange={(change) => setCorrectionNote(change.target.value)}
-              placeholder="Example: Ryan's cash-out was entered as $45 instead of $54."
+              placeholder="Example: Cash-out was entered incorrectly."
             />
           </label>
         </section>
@@ -465,18 +431,19 @@ export function MoneyEventPage() {
 
       <section className="panel">
         <div className="section-heading-row">
-          <div>
-            <p className="eyebrow">Setup</p>
-            <h2>Money tracking</h2>
-          </div>
-          <span>{detail.event.moneyTrackingEnabled ? "Enabled" : "Disabled"}</span>
+          <div><p className="eyebrow">Setup</p><h2>Money tracking</h2></div>
+          <span>{current.event.moneyTrackingEnabled ? "Enabled" : "Disabled"}</span>
         </div>
-        <form className="money-settings-form" onSubmit={saveSettings} key={`${detail.event.id}-${detail.event.defaultBuyInCents}-${detail.event.moneyTrackingEnabled}-${detail.event.stakesNotes}`}>
+        <form
+          className="money-settings-form"
+          onSubmit={saveSettings}
+          key={`${current.event.defaultBuyInCents}-${current.event.moneyTrackingEnabled}-${current.event.stakesNotes}`}
+        >
           <label className="toggle-field">
             <input
               type="checkbox"
               name="moneyTrackingEnabled"
-              defaultChecked={detail.event.moneyTrackingEnabled}
+              defaultChecked={current.event.moneyTrackingEnabled}
               disabled={editDisabled}
             />
             <span>Track money for this night</span>
@@ -488,7 +455,7 @@ export function MoneyEventPage() {
               name="defaultBuyIn"
               min="0"
               step="0.01"
-              defaultValue={(detail.event.defaultBuyInCents / 100).toFixed(2)}
+              defaultValue={(current.event.defaultBuyInCents / 100).toFixed(2)}
               disabled={editDisabled}
             />
           </label>
@@ -498,7 +465,7 @@ export function MoneyEventPage() {
               name="stakesNotes"
               rows={3}
               maxLength={500}
-              defaultValue={detail.event.stakesNotes ?? ""}
+              defaultValue={current.event.stakesNotes ?? ""}
               disabled={editDisabled}
             />
           </label>
@@ -506,41 +473,31 @@ export function MoneyEventPage() {
         </form>
       </section>
 
-      {detail.event.moneyTrackingEnabled ? (
+      {current.event.moneyTrackingEnabled ? (
         <>
           <section className="money-total-grid" aria-label="Cash closeout totals">
-            <article className="metric-card">
-              <span>Cash in</span>
-              <strong>{money(detail.totals.cashInCents)}</strong>
+            <article className="metric-card"><span>Cash in</span><strong>{formatMoney(current.totals.cashInCents)}</strong></article>
+            <article className="metric-card"><span>Cash out</span><strong>{formatMoney(current.totals.cashOutCents)}</strong></article>
+            <article className={`metric-card ${current.totals.balanced ? "is-balanced" : "is-unbalanced"}`}>
+              <span>Difference</span><strong>{formatMoney(current.totals.differenceCents)}</strong>
             </article>
-            <article className="metric-card">
-              <span>Cash out</span>
-              <strong>{money(detail.totals.cashOutCents)}</strong>
-            </article>
-            <article className={`metric-card ${detail.totals.balanced ? "is-balanced" : "is-unbalanced"}`}>
-              <span>Difference</span>
-              <strong>{money(detail.totals.differenceCents)}</strong>
-            </article>
-            <article className={`metric-card ${detail.totals.missingCashOutCount ? "is-unbalanced" : "is-balanced"}`}>
-              <span>Missing cash-outs</span>
-              <strong>{detail.totals.missingCashOutCount}</strong>
+            <article className={`metric-card ${current.totals.missingCashOutCount ? "is-unbalanced" : "is-balanced"}`}>
+              <span>Missing cash-outs</span><strong>{current.totals.missingCashOutCount}</strong>
             </article>
           </section>
 
-          <section className={`panel closeout-panel ${detail.closeoutReady ? "is-ready" : "has-issues"}`}>
+          <section className={`panel closeout-panel ${current.closeoutReady ? "is-ready" : "has-issues"}`}>
             <div>
               <p className="eyebrow">Closeout</p>
-              <h2>{detail.closeoutReady ? "Ready to close" : "Resolve before closing"}</h2>
+              <h2>{current.closeoutReady ? "Ready to close" : "Resolve before closing"}</h2>
             </div>
-            {detail.issues.length ? (
-              <ul>
-                {detail.issues.map((issue) => <li key={issue}>{issue}</li>)}
-              </ul>
+            {current.issues.length ? (
+              <ul>{current.issues.map((issue) => <li key={issue}>{issue}</li>)}</ul>
             ) : (
               <p>Cash in matches cash out, and every attending player has a recorded cash-out.</p>
             )}
-            {detail.event.status === "active" ? (
-              <Button disabled={saving || !detail.closeoutReady} onClick={() => void completeEvent()}>
+            {current.event.status === "active" ? (
+              <Button disabled={saving || !current.closeoutReady} onClick={() => void completeEvent()}>
                 Complete balanced event
               </Button>
             ) : null}
@@ -548,33 +505,28 @@ export function MoneyEventPage() {
 
           <section className="panel">
             <div className="section-heading-row">
-              <div>
-                <p className="eyebrow">Live Night</p>
-                <h2>Players</h2>
-              </div>
-              <span>{detail.players.length}</span>
+              <div><p className="eyebrow">Live Night</p><h2>Players</h2></div>
+              <span>{current.players.length}</span>
             </div>
             <div className="money-player-list">
-              {detail.players.map((player) => (
+              {current.players.map((player) => (
                 <article className={`money-player-card ${player.attended ? "is-attending" : ""}`} key={player.playerId}>
                   <div className="money-player-heading">
                     <div>
                       <strong>{player.displayName}</strong>
-                      <small>
-                        {player.attended ? "Checked in" : `RSVP: ${player.rsvpStatus}`} · {player.rebuyCount} rebuys
-                      </small>
+                      <small>{player.attended ? "Checked in" : `RSVP: ${player.rsvpStatus}`} · {player.rebuyCount} rebuys</small>
                     </div>
                     <NetAmount cents={player.netCents} />
                   </div>
                   <div className="money-player-totals">
-                    <span>In {money(player.cashInCents)}</span>
-                    <span>Out {player.hasCashOut ? money(player.cashOutCents) : "Not entered"}</span>
+                    <span>In {formatMoney(player.cashInCents)}</span>
+                    <span>Out {player.hasCashOut ? formatMoney(player.cashOutCents) : "Not entered"}</span>
                   </div>
                   <div className="money-action-grid">
-                    <Button disabled={editDisabled} onClick={() => void quickBuyIn(player, "buy_in")}>Buy in</Button>
-                    <Button variant="secondary" disabled={editDisabled} onClick={() => void quickBuyIn(player, "rebuy")}>Rebuy</Button>
-                    <Button variant="secondary" disabled={editDisabled} onClick={() => void quickCashOut(player)}>Cash out</Button>
-                    <Button variant="secondary" disabled={editDisabled} onClick={() => void quickAdjustment(player)}>Adjustment</Button>
+                    <Button disabled={editDisabled} onClick={() => void addBuyIn(player, "buy_in")}>Buy in</Button>
+                    <Button variant="secondary" disabled={editDisabled} onClick={() => void addBuyIn(player, "rebuy")}>Rebuy</Button>
+                    <Button variant="secondary" disabled={editDisabled} onClick={() => void addCashOut(player)}>Cash out</Button>
+                    <Button variant="secondary" disabled={editDisabled} onClick={() => void addAdjustment(player)}>Adjustment</Button>
                   </div>
                 </article>
               ))}
@@ -583,29 +535,20 @@ export function MoneyEventPage() {
 
           <section className="panel">
             <div className="section-heading-row">
-              <div>
-                <p className="eyebrow">Transactions</p>
-                <h2>Ledger entries</h2>
-              </div>
-              <span>{detail.entries.length}</span>
+              <div><p className="eyebrow">Transactions</p><h2>Ledger entries</h2></div>
+              <span>{current.entries.length}</span>
             </div>
-            <p className="ledger-help">
-              Positive adjustments add to cash in. Negative adjustments add their absolute value to cash out.
-            </p>
+            <p className="ledger-help">Positive adjustments add to cash in. Negative adjustments add to cash out.</p>
             <div className="ledger-entry-list">
-              {detail.entries.length ? (
-                detail.entries.map((entry) => (
-                  <LedgerEntryEditor
-                    key={entry.id}
-                    entry={entry}
-                    disabled={editDisabled}
-                    onSave={(entryId, body) => void saveEntry(entryId, body)}
-                    onDelete={(selected) => void deleteEntry(selected)}
-                  />
-                ))
-              ) : (
-                <div className="state-card">No money has been recorded yet.</div>
-              )}
+              {current.entries.length ? current.entries.map((entry) => (
+                <LedgerEntryEditor
+                  key={entry.id}
+                  entry={entry}
+                  disabled={editDisabled}
+                  onSave={(entryId, type, amountCents, note) => void saveEntry(entryId, type, amountCents, note)}
+                  onDelete={(selected) => void deleteEntry(selected)}
+                />
+              )) : <div className="state-card">No money has been recorded yet.</div>}
             </div>
           </section>
         </>
@@ -628,36 +571,31 @@ export function PlayerMoneyPage() {
   }, [id]);
 
   if (error) return <MoneyShell><ErrorPanel error={error} /></MoneyShell>;
-  if (!data) return <MoneyShell><Loading /></MoneyShell>;
+  if (!data) return <MoneyShell><div className="state-card">Loading money history…</div></MoneyShell>;
 
   const lifetimeNet = data.history.reduce((total, event) => total + event.netCents, 0);
-  const totalBuyIns = data.history.reduce((total, event) => total + event.cashInCents, 0);
-  const totalCashOuts = data.history.reduce((total, event) => total + event.cashOutCents, 0);
+  const totalIn = data.history.reduce((total, event) => total + event.cashInCents, 0);
+  const totalOut = data.history.reduce((total, event) => total + event.cashOutCents, 0);
 
   return (
     <MoneyShell>
       <div className="money-page-header">
-        <div>
-          <p className="eyebrow">Player money history</p>
-          <h1>{data.player.displayName}</h1>
-        </div>
+        <div><p className="eyebrow">Player money history</p><h1>{data.player.displayName}</h1></div>
         <Link className="button button-secondary" to={`/players/${id}`}>Player details</Link>
       </div>
       <section className="money-total-grid">
-        <article className="metric-card"><span>Total in</span><strong>{money(totalBuyIns)}</strong></article>
-        <article className="metric-card"><span>Total out</span><strong>{money(totalCashOuts)}</strong></article>
+        <article className="metric-card"><span>Total in</span><strong>{formatMoney(totalIn)}</strong></article>
+        <article className="metric-card"><span>Total out</span><strong>{formatMoney(totalOut)}</strong></article>
         <article className="metric-card"><span>Derived net</span><NetAmount cents={lifetimeNet} /></article>
         <article className="metric-card"><span>Tracked nights</span><strong>{data.history.length}</strong></article>
       </section>
       <section className="panel">
-        <div className="section-heading-row">
-          <div><p className="eyebrow">Completed events</p><h2>Financial record</h2></div>
-        </div>
+        <div className="section-heading-row"><div><p className="eyebrow">Completed events</p><h2>Financial record</h2></div></div>
         <div className="player-money-history">
           {data.history.length ? data.history.map((event) => (
             <Link to={`/money/events/${event.eventId}`} className="player-money-history-card" key={event.eventId}>
-              <div><strong>{event.title}</strong><span>{dateTime(event.startsAt)} · {event.location || "No location"}</span></div>
-              <div><span>In {money(event.cashInCents)}</span><span>Out {money(event.cashOutCents)}</span><NetAmount cents={event.netCents} /></div>
+              <div><strong>{event.title}</strong><span>{formatDate(event.startsAt)} · {event.location || "No location"}</span></div>
+              <div><span>In {formatMoney(event.cashInCents)}</span><span>Out {formatMoney(event.cashOutCents)}</span><NetAmount cents={event.netCents} /></div>
               <small>{event.rebuyCount} rebuys · {event.stakesNotes || "No stakes notes"}</small>
             </Link>
           )) : <div className="state-card">No completed money-tracked events yet.</div>}
@@ -672,11 +610,7 @@ export function MoneyShortcut() {
   const eventMatch = location.pathname.match(/^\/events\/([0-9a-f-]+)$/i);
   const playerMatch = location.pathname.match(/^\/players\/([0-9a-f-]+)$/i);
 
-  if (eventMatch) {
-    return <Link className="money-shortcut" to={`/money/events/${eventMatch[1]}`}>$ Money ledger</Link>;
-  }
-  if (playerMatch) {
-    return <Link className="money-shortcut" to={`/money/players/${playerMatch[1]}`}>$ Money history</Link>;
-  }
+  if (eventMatch) return <Link className="money-shortcut" to={`/money/events/${eventMatch[1]}`}>$ Money ledger</Link>;
+  if (playerMatch) return <Link className="money-shortcut" to={`/money/players/${playerMatch[1]}`}>$ Money history</Link>;
   return null;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { App } from "./App";
+import { MoneyEventPage, MoneyShortcut, PlayerMoneyPage } from "./Money";
 import "./styles.css";
 import "./editing.css";
+import "./money.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Application root was not found");
@@ -11,7 +13,19 @@ if (!root) throw new Error("Application root was not found");
 createRoot(root).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <Routes>
+        <Route path="/money/events/:id" element={<MoneyEventPage />} />
+        <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
+        <Route
+          path="*"
+          element={
+            <>
+              <App />
+              <MoneyShortcut />
+            </>
+          }
+        />
+      </Routes>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/src/money.css
+++ b/src/money.css
@@ -1,0 +1,380 @@
+.money-shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 90% 0, rgba(215, 178, 103, 0.12), transparent 28rem),
+    var(--bg);
+}
+
+.money-topbar {
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem max(1rem, calc((100vw - 1180px) / 2));
+  border-bottom: 1px solid var(--line);
+  background: rgba(10, 12, 9, 0.94);
+}
+
+.money-topbar > span {
+  color: var(--gold);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.money-page {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3.5rem) 0 6rem;
+}
+
+.money-page > * + * {
+  margin-top: 1rem;
+}
+
+.money-page-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.money-page-header h1 {
+  margin: 0;
+  font-size: clamp(2.3rem, 8vw, 5rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.money-page-header p:not(.eyebrow) {
+  max-width: 56rem;
+  margin: 0.7rem 0 0;
+  color: var(--muted);
+}
+
+.money-correction-panel,
+.closeout-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.7fr);
+  gap: 1rem;
+  align-items: end;
+}
+
+.money-correction-panel p,
+.closeout-panel p,
+.closeout-panel ul,
+.ledger-help {
+  color: var(--muted);
+}
+
+.money-correction-panel label {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.money-settings-form {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.7fr) minmax(180px, 0.45fr) minmax(0, 1.1fr) auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+.money-settings-form label {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.toggle-field {
+  min-height: 44px;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: #0d100c;
+}
+
+.toggle-field input {
+  width: 20px;
+  min-height: 20px;
+  margin: 0;
+}
+
+.money-settings-wide {
+  min-width: 0;
+}
+
+.money-total-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.money-total-grid .metric-card {
+  min-height: 125px;
+}
+
+.money-total-grid .metric-card strong {
+  font-size: clamp(1.45rem, 4vw, 2.4rem);
+}
+
+.metric-card.is-balanced {
+  border-color: rgba(150, 199, 136, 0.42);
+}
+
+.metric-card.is-unbalanced {
+  border-color: rgba(224, 121, 116, 0.55);
+}
+
+.closeout-panel.is-ready {
+  border-color: rgba(150, 199, 136, 0.5);
+}
+
+.closeout-panel.has-issues {
+  border-color: rgba(224, 121, 116, 0.55);
+}
+
+.closeout-panel ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.money-player-list,
+.ledger-entry-list,
+.player-money-history {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.money-player-card,
+.ledger-entry-card,
+.player-money-history-card {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.money-player-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.money-player-card.is-attending {
+  border-color: rgba(150, 199, 136, 0.45);
+  background: rgba(150, 199, 136, 0.065);
+}
+
+.money-player-heading,
+.ledger-entry-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.money-player-heading > div,
+.ledger-entry-heading > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.money-player-heading small,
+.ledger-entry-heading small,
+.player-money-history-card small {
+  color: var(--muted);
+}
+
+.money-player-heading > strong,
+.ledger-entry-heading > strong,
+.net-positive,
+.net-negative,
+.net-zero {
+  font-size: 1.2rem;
+}
+
+.net-positive {
+  color: var(--green);
+}
+
+.net-negative {
+  color: var(--red);
+}
+
+.net-zero {
+  color: var(--muted);
+}
+
+.money-player-totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.money-action-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.ledger-entry-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.ledger-edit-grid {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.35fr) minmax(140px, 0.35fr) minmax(0, 1fr);
+  gap: 0.7rem;
+}
+
+.ledger-edit-grid label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.ledger-entry-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.ledger-help {
+  margin: -0.2rem 0 1rem;
+  font-size: 0.9rem;
+}
+
+.player-money-history-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.6rem 1rem;
+  padding: 1rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.player-money-history-card:hover {
+  border-color: rgba(215, 178, 103, 0.55);
+}
+
+.player-money-history-card > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.player-money-history-card > div:nth-child(2) {
+  justify-items: end;
+}
+
+.player-money-history-card > div span {
+  color: var(--muted);
+}
+
+.player-money-history-card small {
+  grid-column: 1 / -1;
+}
+
+.money-shortcut {
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: 60;
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(215, 178, 103, 0.55);
+  border-radius: 999px;
+  background: var(--gold);
+  color: #171108;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.38);
+  font-weight: 900;
+  text-decoration: none;
+}
+
+@media (max-width: 900px) {
+  .money-settings-form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .money-settings-wide {
+    grid-column: 1 / -1;
+  }
+
+  .money-total-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .money-action-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ledger-edit-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ledger-note-field {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 620px) {
+  .money-page {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .money-page-header,
+  .money-correction-panel,
+  .closeout-panel {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .money-page-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .money-settings-form,
+  .money-total-grid,
+  .ledger-edit-grid,
+  .player-money-history-card {
+    grid-template-columns: 1fr;
+  }
+
+  .money-settings-wide,
+  .ledger-note-field,
+  .player-money-history-card small {
+    grid-column: auto;
+  }
+
+  .money-player-heading,
+  .ledger-entry-heading {
+    align-items: start;
+  }
+
+  .money-action-grid .button,
+  .ledger-entry-actions .button {
+    width: 100%;
+  }
+
+  .player-money-history-card > div:nth-child(2) {
+    justify-items: start;
+  }
+}

--- a/tests/money.test.ts
+++ b/tests/money.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateLedger,
+  ledgerEntryCreateSchema,
+  moneyEventPatchSchema,
+} from "../shared/money";
+
+describe("cash ledger calculations", () => {
+  it("balances buy-ins and cash-outs while deriving player net", () => {
+    const totals = calculateLedger([
+      { playerId: "a", entryType: "buy_in", amountCents: 2000 },
+      { playerId: "a", entryType: "rebuy", amountCents: 2000 },
+      { playerId: "a", entryType: "cash_out", amountCents: 5500 },
+      { playerId: "b", entryType: "buy_in", amountCents: 2000 },
+      { playerId: "b", entryType: "cash_out", amountCents: 500 },
+    ]);
+
+    expect(totals.cashInCents).toBe(6000);
+    expect(totals.cashOutCents).toBe(6000);
+    expect(totals.differenceCents).toBe(0);
+    expect(totals.playerSummaries.find((player) => player.playerId === "a")?.netCents).toBe(1500);
+    expect(totals.playerSummaries.find((player) => player.playerId === "b")?.netCents).toBe(-1500);
+    expect(totals.playerSummaries.find((player) => player.playerId === "a")?.rebuyCount).toBe(1);
+  });
+
+  it("treats positive adjustments as cash in and negative adjustments as cash out", () => {
+    const totals = calculateLedger([
+      { playerId: "a", entryType: "adjustment", amountCents: 300 },
+      { playerId: "b", entryType: "adjustment", amountCents: -300 },
+    ]);
+
+    expect(totals.cashInCents).toBe(300);
+    expect(totals.cashOutCents).toBe(300);
+    expect(totals.playerSummaries.find((player) => player.playerId === "a")?.netCents).toBe(-300);
+    expect(totals.playerSummaries.find((player) => player.playerId === "b")?.netCents).toBe(300);
+  });
+
+  it("counts a zero-dollar cash-out as recorded", () => {
+    const totals = calculateLedger([
+      { playerId: "a", entryType: "buy_in", amountCents: 2000 },
+      { playerId: "a", entryType: "cash_out", amountCents: 0 },
+    ]);
+
+    expect(totals.playerSummaries[0]?.hasCashOut).toBe(true);
+  });
+});
+
+describe("cash ledger validation", () => {
+  it("requires adjustment notes", () => {
+    expect(() =>
+      ledgerEntryCreateSchema.parse({
+        playerId: "f6f657f6-a73a-4ca3-9f82-e7cf192be428",
+        entryType: "adjustment",
+        amountCents: 100,
+      }),
+    ).toThrow();
+  });
+
+  it("allows a zero-dollar cash-out but not a zero-dollar buy-in", () => {
+    expect(
+      ledgerEntryCreateSchema.parse({
+        playerId: "f6f657f6-a73a-4ca3-9f82-e7cf192be428",
+        entryType: "cash_out",
+        amountCents: 0,
+      }).amountCents,
+    ).toBe(0);
+    expect(() =>
+      ledgerEntryCreateSchema.parse({
+        playerId: "f6f657f6-a73a-4ca3-9f82-e7cf192be428",
+        entryType: "buy_in",
+        amountCents: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("requires at least one event money setting", () => {
+    expect(() => moneyEventPatchSchema.parse({ correctionNote: "Fixing history" })).toThrow();
+    expect(moneyEventPatchSchema.parse({ moneyTrackingEnabled: true }).moneyTrackingEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

- Added an optional event-level cash ledger with default buy-in and stakes notes.
- Added buy-in, rebuy, cash-out, and signed adjustment entries stored as integer cents.
- Added one-tap mobile money controls for each rostered player.
- Added editable and removable ledger entries.
- Added completed-event money correction mode using the same required correction reason as attendance corrections.
- Added event totals for cash in, cash out, difference, missing cash-outs, and balance status.
- Added guarded event completion that blocks money-tracked nights until every attendee has a cash-out and the ledger balances.
- Added a database trigger so the normal event completion path cannot bypass financial closeout rules.
- Added event and player financial history with derived net results and rebuy counts.
- Added a floating Money ledger or Money history shortcut on event and player pages.
- Added validation and calculation tests.

## Database migration required before merge

Apply `migrations/0002_cash_ledger.sql` to the remote `brotm-poker` D1 database:

```bash
npm run db:migrate:remote
```

See `docs/CASH_LEDGER_ROLLOUT.md` for verification and production smoke testing.

## Closeout rules

For money-tracked events:

- Every attending player must have a cash-out entry, including a `$0` cash-out when they bust.
- Cash in must equal cash out.
- Positive adjustments add to cash in.
- Negative adjustments add their absolute value to cash out.
- Adjustments require a note.
- Completed-event edits require a correction note and create audit records.

Attendance-only events continue to work without money records.