### PR TITLE
Add organizer operations, invites, search, and defaults

### DIFF
--- a/docs/ORGANIZER_OPERATIONS_ROLLOUT.md
+++ b/docs/ORGANIZER_OPERATIONS_ROLLOUT.md
@@ -1,0 +1,42 @@
+# Organizer operations rollout
+
+This release adds the organizer operations hub, event capacity, shared defaults, invite text, search, improved dashboard summaries, and organizer management.
+
+## Required database migration
+
+Apply the third migration to the one remote D1 database before merging or immediately before the production deployment:
+
+```bash
+npm run db:migrate:remote
+```
+
+Expected new migration:
+
+```text
+0003_organizer_operations.sql
+```
+
+The migration:
+
+- adds `events.capacity`
+- creates the single-row `app_settings` table
+- initializes safe empty defaults
+
+## Production verification
+
+After Cloudflare Pages deploys:
+
+1. Open `/ops` and confirm the organizer overview loads.
+2. Open **Settings** and save a default location, game text, stakes text, money-tracking preference, and buy-in.
+3. Create a new night from **Plan night** and confirm those defaults are pre-filled.
+4. Set a capacity and copy the generated invite text.
+5. Add players and RSVP states in the main event editor, then confirm the operations RSVP rollup updates.
+6. Search for a player by name or contact detail and an event by title, location, or host.
+7. As an admin, confirm organizer records can be added and updated.
+8. Confirm adding an organizer record does not imply Cloudflare Access permission. The same email must also be allowed by the Access policy.
+
+## Access model
+
+The operations API is protected by the same Cloudflare Access JWT validation and D1 organizer resolution as the existing API routes.
+
+Only active D1 organizers can use the operations hub. Only admins can add organizers or change another organizer's role and active status. The API prevents removal of the final active admin and prevents an admin from removing their own admin access.

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -4,7 +4,11 @@ import type { AppPagesFunction } from "./lib/types";
 
 export const onRequest: AppPagesFunction = async (context) => {
   const pathname = new URL(context.request.url).pathname;
-  if (!pathname.startsWith("/api/") && !pathname.startsWith("/money-api/")) {
+  if (
+    !pathname.startsWith("/api/") &&
+    !pathname.startsWith("/money-api/") &&
+    !pathname.startsWith("/ops-api/")
+  ) {
     return context.next();
   }
 

--- a/functions/ops-api/[[path]].ts
+++ b/functions/ops-api/[[path]].ts
@@ -1,0 +1,639 @@
+import { ZodError } from "zod";
+import {
+  buildInviteText,
+  operationsEventCreateSchema,
+  operationsEventPatchSchema,
+  operationsSettingsPatchSchema,
+  organizerCreateSchema,
+  organizerPatchSchema,
+  summarizeRsvps,
+  type OrganizerRole,
+} from "../../shared/operations";
+import { apiError, json, readJson, validationError } from "../lib/http";
+import type { AppPagesFunction, OrganizerIdentity } from "../lib/types";
+
+interface SettingsRow {
+  default_location: string;
+  default_game_notes: string | null;
+  default_stakes_notes: string | null;
+  default_money_tracking_enabled: number;
+  default_buy_in_cents: number;
+  updated_at: string;
+  updated_by_name: string | null;
+}
+
+interface OrganizerRow {
+  id: string;
+  email: string;
+  display_name: string;
+  role: OrganizerRole;
+  active: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface EventSummaryRow {
+  id: string;
+  title: string;
+  starts_at: string;
+  host_player_id: string | null;
+  host_name: string | null;
+  location: string;
+  game_notes: string | null;
+  stakes_notes: string | null;
+  notes: string | null;
+  capacity: number | null;
+  money_tracking_enabled: number;
+  default_buy_in_cents: number;
+  status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  player_count: number;
+  attendance_count: number;
+  invited_count: number;
+  yes_count: number;
+  maybe_count: number;
+  no_count: number;
+  pending_count: number;
+  cash_in_cents: number;
+  cash_out_cents: number;
+  missing_cash_outs: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+interface EventPlayerRow {
+  id: string;
+  player_id: string;
+  display_name: string;
+  invitation_status: "invited" | "not_invited";
+  rsvp_status: "pending" | "yes" | "maybe" | "no";
+  attended: number;
+  checked_in_at: string | null;
+}
+
+interface SearchPlayerRow {
+  id: string;
+  display_name: string;
+  email: string | null;
+  phone: string | null;
+  status: "active" | "archived";
+}
+
+interface SearchEventRow {
+  id: string;
+  title: string;
+  starts_at: string;
+  location: string;
+  status: EventSummaryRow["status"];
+  host_name: string | null;
+}
+
+function settingsJson(row: SettingsRow) {
+  return {
+    defaultLocation: row.default_location,
+    defaultGameNotes: row.default_game_notes,
+    defaultStakesNotes: row.default_stakes_notes,
+    defaultMoneyTrackingEnabled: Boolean(row.default_money_tracking_enabled),
+    defaultBuyInCents: Number(row.default_buy_in_cents),
+    updatedAt: row.updated_at,
+    updatedByName: row.updated_by_name,
+  };
+}
+
+function organizerJson(row: OrganizerRow) {
+  return {
+    id: row.id,
+    email: row.email,
+    displayName: row.display_name,
+    role: row.role,
+    active: Boolean(row.active),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function eventSummaryJson(row: EventSummaryRow) {
+  const cashInCents = Number(row.cash_in_cents ?? 0);
+  const cashOutCents = Number(row.cash_out_cents ?? 0);
+  const yes = Number(row.yes_count ?? 0);
+  const maybe = Number(row.maybe_count ?? 0);
+  return {
+    id: row.id,
+    title: row.title,
+    startsAt: row.starts_at,
+    hostPlayerId: row.host_player_id,
+    hostName: row.host_name,
+    location: row.location,
+    gameNotes: row.game_notes,
+    stakesNotes: row.stakes_notes,
+    notes: row.notes,
+    capacity: row.capacity,
+    moneyTrackingEnabled: Boolean(row.money_tracking_enabled),
+    defaultBuyInCents: Number(row.default_buy_in_cents ?? 0),
+    status: row.status,
+    playerCount: Number(row.player_count ?? 0),
+    attendanceCount: Number(row.attendance_count ?? 0),
+    rsvp: {
+      invited: Number(row.invited_count ?? 0),
+      yes,
+      maybe,
+      no: Number(row.no_count ?? 0),
+      pending: Number(row.pending_count ?? 0),
+      expected: yes + maybe,
+    },
+    cashInCents,
+    cashOutCents,
+    differenceCents: cashInCents - cashOutCents,
+    missingCashOuts: Number(row.missing_cash_outs ?? 0),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function eventPlayerJson(row: EventPlayerRow) {
+  return {
+    id: row.id,
+    playerId: row.player_id,
+    displayName: row.display_name,
+    invitationStatus: row.invitation_status,
+    rsvpStatus: row.rsvp_status,
+    attended: Boolean(row.attended),
+    checkedInAt: row.checked_in_at,
+  };
+}
+
+function auditStatement(
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+  action: string,
+  details: Record<string, unknown>,
+  createdAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO event_audit_log
+       (id, event_id, organizer_id, action, details_json, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(crypto.randomUUID(), eventId, organizer.id, action, JSON.stringify(details), createdAt);
+}
+
+async function getSettings(db: D1Database): Promise<SettingsRow> {
+  const row = await db
+    .prepare(
+      `SELECT s.*, o.display_name AS updated_by_name
+       FROM app_settings s
+       LEFT JOIN organizers o ON o.id = s.updated_by_organizer_id
+       WHERE s.id = 1`,
+    )
+    .first<SettingsRow>();
+  if (!row) throw new Response("Application settings are not initialized.", { status: 500 });
+  return row;
+}
+
+const eventSummarySelect = `
+  SELECT e.*, host.display_name AS host_name,
+    COUNT(DISTINCT ep.id) AS player_count,
+    COALESCE(SUM(CASE WHEN ep.attended = 1 THEN 1 ELSE 0 END), 0) AS attendance_count,
+    COALESCE(SUM(CASE WHEN ep.invitation_status = 'invited' THEN 1 ELSE 0 END), 0) AS invited_count,
+    COALESCE(SUM(CASE WHEN ep.invitation_status = 'invited' AND ep.rsvp_status = 'yes' THEN 1 ELSE 0 END), 0) AS yes_count,
+    COALESCE(SUM(CASE WHEN ep.invitation_status = 'invited' AND ep.rsvp_status = 'maybe' THEN 1 ELSE 0 END), 0) AS maybe_count,
+    COALESCE(SUM(CASE WHEN ep.invitation_status = 'invited' AND ep.rsvp_status = 'no' THEN 1 ELSE 0 END), 0) AS no_count,
+    COALESCE(SUM(CASE WHEN ep.invitation_status = 'invited' AND ep.rsvp_status = 'pending' THEN 1 ELSE 0 END), 0) AS pending_count,
+    COALESCE((
+      SELECT SUM(CASE
+        WHEN le.entry_type IN ('buy_in', 'rebuy') THEN le.amount_cents
+        WHEN le.entry_type = 'adjustment' AND le.amount_cents > 0 THEN le.amount_cents
+        ELSE 0 END)
+      FROM ledger_entries le WHERE le.event_id = e.id
+    ), 0) AS cash_in_cents,
+    COALESCE((
+      SELECT SUM(CASE
+        WHEN le.entry_type = 'cash_out' THEN le.amount_cents
+        WHEN le.entry_type = 'adjustment' AND le.amount_cents < 0 THEN -le.amount_cents
+        ELSE 0 END)
+      FROM ledger_entries le WHERE le.event_id = e.id
+    ), 0) AS cash_out_cents,
+    COALESCE((
+      SELECT COUNT(*) FROM event_players attended
+      WHERE attended.event_id = e.id
+        AND attended.attended = 1
+        AND NOT EXISTS (
+          SELECT 1 FROM ledger_entries cashout
+          WHERE cashout.event_id = e.id
+            AND cashout.player_id = attended.player_id
+            AND cashout.entry_type = 'cash_out'
+        )
+    ), 0) AS missing_cash_outs
+  FROM events e
+  LEFT JOIN players host ON host.id = e.host_player_id
+  LEFT JOIN event_players ep ON ep.event_id = e.id
+`;
+
+async function requireEvent(db: D1Database, id: string): Promise<EventSummaryRow> {
+  const row = await db
+    .prepare(`${eventSummarySelect} WHERE e.id = ?1 GROUP BY e.id`)
+    .bind(id)
+    .first<EventSummaryRow>();
+  if (!row) throw new Response("Event not found.", { status: 404 });
+  return row;
+}
+
+function requireAdmin(organizer: OrganizerIdentity): void {
+  if (organizer.role !== "admin") {
+    throw new Response("Admin access is required for organizer management.", { status: 403 });
+  }
+}
+
+async function dashboard(db: D1Database): Promise<Response> {
+  const [settings, activePlayers, currentRows, recentRows] = await Promise.all([
+    getSettings(db),
+    db.prepare("SELECT COUNT(*) AS count FROM players WHERE status = 'active'").first<{ count: number }>(),
+    db
+      .prepare(
+        `${eventSummarySelect}
+         WHERE e.status IN ('draft', 'open', 'active')
+         GROUP BY e.id
+         ORDER BY CASE e.status WHEN 'active' THEN 0 WHEN 'open' THEN 1 ELSE 2 END, e.starts_at ASC
+         LIMIT 12`,
+      )
+      .all<EventSummaryRow>(),
+    db
+      .prepare(
+        `${eventSummarySelect}
+         WHERE e.status = 'completed'
+         GROUP BY e.id
+         ORDER BY e.completed_at DESC
+         LIMIT 6`,
+      )
+      .all<EventSummaryRow>(),
+  ]);
+
+  const currentEvents = currentRows.results.map(eventSummaryJson);
+  const incompleteCloseouts = currentEvents.filter(
+    (event) =>
+      event.status === "active" &&
+      (!event.moneyTrackingEnabled || event.missingCashOuts > 0 || event.differenceCents !== 0),
+  );
+
+  return json({
+    settings: settingsJson(settings),
+    activePlayerCount: Number(activePlayers?.count ?? 0),
+    currentEvents,
+    nextEvent: currentEvents[0] ?? null,
+    incompleteCloseouts,
+    recentEvents: recentRows.results.map(eventSummaryJson),
+  });
+}
+
+async function search(request: Request, db: D1Database): Promise<Response> {
+  const url = new URL(request.url);
+  const query = (url.searchParams.get("q") ?? "").trim();
+  const scope = url.searchParams.get("scope") ?? "all";
+  if (!query) return json({ players: [], events: [] });
+  if (!['all', 'players', 'events'].includes(scope)) {
+    return apiError(400, "BAD_REQUEST", "Search scope is invalid.");
+  }
+  const pattern = `%${query.replaceAll("%", "").replaceAll("_", "")}%`;
+
+  const playersPromise =
+    scope === "events"
+      ? Promise.resolve({ results: [] as SearchPlayerRow[] })
+      : db
+          .prepare(
+            `SELECT id, display_name, email, phone, status
+             FROM players
+             WHERE display_name LIKE ?1 COLLATE NOCASE
+                OR COALESCE(email, '') LIKE ?1 COLLATE NOCASE
+                OR COALESCE(phone, '') LIKE ?1 COLLATE NOCASE
+             ORDER BY status, display_name COLLATE NOCASE
+             LIMIT 30`,
+          )
+          .bind(pattern)
+          .all<SearchPlayerRow>();
+
+  const eventsPromise =
+    scope === "players"
+      ? Promise.resolve({ results: [] as SearchEventRow[] })
+      : db
+          .prepare(
+            `SELECT e.id, e.title, e.starts_at, e.location, e.status,
+                    p.display_name AS host_name
+             FROM events e
+             LEFT JOIN players p ON p.id = e.host_player_id
+             WHERE e.title LIKE ?1 COLLATE NOCASE
+                OR e.location LIKE ?1 COLLATE NOCASE
+                OR COALESCE(p.display_name, '') LIKE ?1 COLLATE NOCASE
+             ORDER BY e.starts_at DESC
+             LIMIT 30`,
+          )
+          .bind(pattern)
+          .all<SearchEventRow>();
+
+  const [players, events] = await Promise.all([playersPromise, eventsPromise]);
+  return json({
+    players: players.results.map((row) => ({
+      id: row.id,
+      displayName: row.display_name,
+      email: row.email,
+      phone: row.phone,
+      status: row.status,
+    })),
+    events: events.results.map((row) => ({
+      id: row.id,
+      title: row.title,
+      startsAt: row.starts_at,
+      location: row.location,
+      status: row.status,
+      hostName: row.host_name,
+    })),
+  });
+}
+
+async function settings(db: D1Database): Promise<Response> {
+  const [settingsRow, organizers, players] = await Promise.all([
+    getSettings(db),
+    db.prepare("SELECT * FROM organizers ORDER BY active DESC, display_name COLLATE NOCASE").all<OrganizerRow>(),
+    db
+      .prepare("SELECT id, display_name FROM players WHERE status = 'active' ORDER BY display_name COLLATE NOCASE")
+      .all<{ id: string; display_name: string }>(),
+  ]);
+  return json({
+    settings: settingsJson(settingsRow),
+    organizers: organizers.results.map(organizerJson),
+    activePlayers: players.results.map((row) => ({ id: row.id, displayName: row.display_name })),
+  });
+}
+
+async function patchSettings(
+  request: Request,
+  db: D1Database,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const input = operationsSettingsPatchSchema.parse(await readJson(request));
+  const current = await getSettings(db);
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      `UPDATE app_settings
+       SET default_location = ?1,
+           default_game_notes = ?2,
+           default_stakes_notes = ?3,
+           default_money_tracking_enabled = ?4,
+           default_buy_in_cents = ?5,
+           updated_by_organizer_id = ?6,
+           updated_at = ?7
+       WHERE id = 1`,
+    )
+    .bind(
+      input.defaultLocation ?? current.default_location,
+      input.defaultGameNotes !== undefined ? input.defaultGameNotes : current.default_game_notes,
+      input.defaultStakesNotes !== undefined ? input.defaultStakesNotes : current.default_stakes_notes,
+      input.defaultMoneyTrackingEnabled !== undefined
+        ? input.defaultMoneyTrackingEnabled
+          ? 1
+          : 0
+        : current.default_money_tracking_enabled,
+      input.defaultBuyInCents ?? current.default_buy_in_cents,
+      organizer.id,
+      now,
+    )
+    .run();
+  return settings(db);
+}
+
+async function createOrganizer(
+  request: Request,
+  db: D1Database,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  requireAdmin(organizer);
+  const input = organizerCreateSchema.parse(await readJson(request));
+  const now = new Date().toISOString();
+  try {
+    await db
+      .prepare(
+        `INSERT INTO organizers
+         (id, email, display_name, role, active, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, 1, ?5, ?5)`,
+      )
+      .bind(crypto.randomUUID(), input.email, input.displayName, input.role, now)
+      .run();
+  } catch {
+    return apiError(409, "ALREADY_EXISTS", "An organizer with that email already exists.");
+  }
+  return settings(db);
+}
+
+async function patchOrganizer(
+  request: Request,
+  db: D1Database,
+  id: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  requireAdmin(organizer);
+  const current = await db.prepare("SELECT * FROM organizers WHERE id = ?1").bind(id).first<OrganizerRow>();
+  if (!current) return apiError(404, "NOT_FOUND", "Organizer not found.");
+  const input = organizerPatchSchema.parse(await readJson(request));
+
+  if (id === organizer.id && (input.active === false || input.role === "organizer")) {
+    return apiError(409, "SELF_LOCKOUT", "You cannot remove your own admin access.");
+  }
+
+  if (current.role === "admin" && current.active && (input.active === false || input.role === "organizer")) {
+    const adminCount = await db
+      .prepare("SELECT COUNT(*) AS count FROM organizers WHERE role = 'admin' AND active = 1")
+      .first<{ count: number }>();
+    if (Number(adminCount?.count ?? 0) <= 1) {
+      return apiError(409, "LAST_ADMIN", "At least one active admin is required.");
+    }
+  }
+
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      `UPDATE organizers
+       SET display_name = ?1, role = ?2, active = ?3, updated_at = ?4
+       WHERE id = ?5`,
+    )
+    .bind(
+      input.displayName ?? current.display_name,
+      input.role ?? current.role,
+      input.active !== undefined ? (input.active ? 1 : 0) : current.active,
+      now,
+      id,
+    )
+    .run();
+  return settings(db);
+}
+
+async function createEvent(
+  request: Request,
+  db: D1Database,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const input = operationsEventCreateSchema.parse(await readJson(request));
+  const defaults = await getSettings(db);
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  await db
+    .prepare(
+      `INSERT INTO events
+       (id, title, starts_at, host_player_id, location, game_notes, stakes_notes,
+        capacity, money_tracking_enabled, default_buy_in_cents, notes, status,
+        created_by_organizer_id, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'draft', ?12, ?13, ?13)`,
+    )
+    .bind(
+      id,
+      input.title,
+      input.startsAt,
+      input.hostPlayerId ?? null,
+      input.location ?? defaults.default_location,
+      input.gameNotes !== undefined ? input.gameNotes : defaults.default_game_notes,
+      input.stakesNotes !== undefined ? input.stakesNotes : defaults.default_stakes_notes,
+      input.capacity ?? null,
+      input.moneyTrackingEnabled !== undefined
+        ? input.moneyTrackingEnabled
+          ? 1
+          : 0
+        : defaults.default_money_tracking_enabled,
+      input.defaultBuyInCents ?? defaults.default_buy_in_cents,
+      input.notes ?? null,
+      organizer.id,
+      now,
+    )
+    .run();
+  await auditStatement(db, id, organizer, "event_created_from_defaults", {}, now).run();
+  const event = await requireEvent(db, id);
+  return json({ event: eventSummaryJson(event) }, { status: 201 });
+}
+
+async function eventDetail(db: D1Database, id: string): Promise<Response> {
+  const [event, players] = await Promise.all([
+    requireEvent(db, id),
+    db
+      .prepare(
+        `SELECT ep.id, ep.player_id, p.display_name, ep.invitation_status,
+                ep.rsvp_status, ep.attended, ep.checked_in_at
+         FROM event_players ep
+         JOIN players p ON p.id = ep.player_id
+         WHERE ep.event_id = ?1
+         ORDER BY
+           CASE ep.rsvp_status WHEN 'yes' THEN 0 WHEN 'maybe' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END,
+           p.display_name COLLATE NOCASE`,
+      )
+      .bind(id)
+      .all<EventPlayerRow>(),
+  ]);
+  const roster = players.results.map(eventPlayerJson);
+  const rsvp = summarizeRsvps(roster);
+  return json({
+    event: eventSummaryJson(event),
+    players: roster,
+    rsvp,
+    inviteText: buildInviteText({
+      title: event.title,
+      startsAt: event.starts_at,
+      hostName: event.host_name,
+      location: event.location,
+      gameNotes: event.game_notes,
+      stakesNotes: event.stakes_notes,
+      capacity: event.capacity,
+    }),
+  });
+}
+
+function validOperationsTransition(current: EventSummaryRow["status"], next: string): boolean {
+  if (next === "cancelled") return ["draft", "open"].includes(current);
+  if (next === "open") return current === "draft";
+  if (next === "archived") return ["draft", "cancelled", "completed"].includes(current);
+  return false;
+}
+
+async function patchEvent(
+  request: Request,
+  db: D1Database,
+  id: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, id);
+  const input = operationsEventPatchSchema.parse(await readJson(request));
+  const locked = ["completed", "cancelled", "archived"].includes(event.status);
+  if (locked && !input.correctionNote) {
+    return apiError(409, "LOCKED_EVENT", "A correction note is required for a locked event.");
+  }
+  if (input.status && !validOperationsTransition(event.status, input.status)) {
+    return apiError(409, "INVALID_TRANSITION", `Cannot move from ${event.status} to ${input.status}.`);
+  }
+
+  const capacity = input.capacity !== undefined ? input.capacity : event.capacity;
+  const status = input.status ?? event.status;
+  const notes = input.quickNote
+    ? [event.notes, `[${new Date().toLocaleString("en-US")}] ${input.quickNote}`].filter(Boolean).join("\n")
+    : event.notes;
+  const now = new Date().toISOString();
+  const details: Record<string, unknown> = {};
+  if (input.capacity !== undefined) details.capacity = { from: event.capacity, to: input.capacity };
+  if (input.status !== undefined) details.status = { from: event.status, to: input.status };
+  if (input.quickNote !== undefined) details.quickNote = input.quickNote;
+  if (input.correctionNote) details.correctionNote = input.correctionNote;
+
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE events
+         SET capacity = ?1, status = ?2, notes = ?3, updated_at = ?4
+         WHERE id = ?5`,
+      )
+      .bind(capacity, status, notes, now, id),
+    auditStatement(db, id, organizer, locked ? "operations_event_corrected" : "operations_event_updated", details, now),
+  ]);
+  return eventDetail(db, id);
+}
+
+export const onRequest: AppPagesFunction = async (context) => {
+  const request = context.request;
+  const method = request.method.toUpperCase();
+  const path = new URL(request.url).pathname.replace(/^\/ops-api\/?/, "");
+  const parts = path.split("/").filter(Boolean);
+
+  try {
+    if (method === "GET" && parts[0] === "dashboard" && parts.length === 1) {
+      return dashboard(context.env.DB);
+    }
+    if (method === "GET" && parts[0] === "search" && parts.length === 1) {
+      return search(request, context.env.DB);
+    }
+    if (parts[0] === "settings" && parts.length === 1) {
+      if (method === "GET") return settings(context.env.DB);
+      if (method === "PATCH") return patchSettings(request, context.env.DB, context.data.organizer);
+    }
+    if (method === "POST" && parts[0] === "organizers" && parts.length === 1) {
+      return createOrganizer(request, context.env.DB, context.data.organizer);
+    }
+    if (method === "PATCH" && parts[0] === "organizers" && parts[1] && parts.length === 2) {
+      return patchOrganizer(request, context.env.DB, parts[1], context.data.organizer);
+    }
+    if (parts[0] === "events" && parts.length === 1 && method === "POST") {
+      return createEvent(request, context.env.DB, context.data.organizer);
+    }
+    if (parts[0] === "events" && parts[1] && parts.length === 2) {
+      if (method === "GET") return eventDetail(context.env.DB, parts[1]);
+      if (method === "PATCH") {
+        return patchEvent(request, context.env.DB, parts[1], context.data.organizer);
+      }
+    }
+
+    return apiError(404, "NOT_FOUND", "Operations API route not found.");
+  } catch (error) {
+    if (error instanceof ZodError) return validationError(error);
+    if (error instanceof TypeError) return apiError(400, "BAD_REQUEST", error.message);
+    if (error instanceof Response) {
+      return apiError(error.status, "REQUEST_REJECTED", await error.text());
+    }
+    return apiError(500, "INTERNAL_ERROR", "The operations request could not be completed.");
+  }
+};

--- a/migrations/0003_organizer_operations.sql
+++ b/migrations/0003_organizer_operations.sql
@@ -1,0 +1,30 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE events
+ADD COLUMN capacity INTEGER
+CHECK (capacity IS NULL OR (capacity >= 1 AND capacity <= 200));
+
+CREATE TABLE app_settings (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  default_location TEXT NOT NULL DEFAULT '',
+  default_game_notes TEXT,
+  default_stakes_notes TEXT,
+  default_money_tracking_enabled INTEGER NOT NULL DEFAULT 0
+    CHECK (default_money_tracking_enabled IN (0, 1)),
+  default_buy_in_cents INTEGER NOT NULL DEFAULT 0
+    CHECK (default_buy_in_cents >= 0),
+  updated_by_organizer_id TEXT REFERENCES organizers(id),
+  updated_at TEXT NOT NULL
+);
+
+INSERT INTO app_settings (
+  id,
+  default_location,
+  default_game_notes,
+  default_stakes_notes,
+  default_money_tracking_enabled,
+  default_buy_in_cents,
+  updated_by_organizer_id,
+  updated_at
+)
+VALUES (1, '', NULL, NULL, 0, 0, NULL, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));

--- a/shared/operations.ts
+++ b/shared/operations.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+export const organizerRoles = ["admin", "organizer"] as const;
+export type OrganizerRole = (typeof organizerRoles)[number];
+
+const nullableText = (maximum: number) => z.string().trim().max(maximum).nullable().optional();
+
+export const operationsSettingsPatchSchema = z
+  .object({
+    defaultLocation: z.string().trim().max(240).optional(),
+    defaultGameNotes: nullableText(1200),
+    defaultStakesNotes: nullableText(500),
+    defaultMoneyTrackingEnabled: z.boolean().optional(),
+    defaultBuyInCents: z.number().int().min(0).max(10_000_000).optional(),
+  })
+  .refine(
+    (value) => Object.values(value).some((entry) => entry !== undefined),
+    "At least one default setting is required",
+  );
+
+export const organizerCreateSchema = z.object({
+  email: z.string().trim().email().max(200),
+  displayName: z.string().trim().min(1).max(120),
+  role: z.enum(organizerRoles).default("organizer"),
+});
+
+export const organizerPatchSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(120).optional(),
+    role: z.enum(organizerRoles).optional(),
+    active: z.boolean().optional(),
+  })
+  .refine(
+    (value) => value.displayName !== undefined || value.role !== undefined || value.active !== undefined,
+    "At least one organizer field is required",
+  );
+
+export const operationsEventCreateSchema = z.object({
+  title: z.string().trim().min(1).max(120).default("Poker Night"),
+  startsAt: z.string().datetime({ offset: true }),
+  hostPlayerId: z.string().uuid().nullable().optional(),
+  location: z.string().trim().max(240).optional(),
+  gameNotes: nullableText(1200),
+  stakesNotes: nullableText(500),
+  notes: nullableText(1200),
+  capacity: z.number().int().min(1).max(200).nullable().optional(),
+  moneyTrackingEnabled: z.boolean().optional(),
+  defaultBuyInCents: z.number().int().min(0).max(10_000_000).optional(),
+});
+
+export const operationsEventPatchSchema = z
+  .object({
+    capacity: z.number().int().min(1).max(200).nullable().optional(),
+    status: z.enum(["open", "cancelled", "archived"]).optional(),
+    quickNote: z.string().trim().min(1).max(500).optional(),
+    correctionNote: z.string().trim().min(3).max(500).optional(),
+  })
+  .refine(
+    (value) => value.capacity !== undefined || value.status !== undefined || value.quickNote !== undefined,
+    "At least one event operation is required",
+  );
+
+export interface RsvpLike {
+  invitationStatus: "invited" | "not_invited";
+  rsvpStatus: "pending" | "yes" | "maybe" | "no";
+  attended?: boolean;
+}
+
+export interface RsvpSummary {
+  invited: number;
+  yes: number;
+  maybe: number;
+  no: number;
+  pending: number;
+  attended: number;
+  expected: number;
+}
+
+export function summarizeRsvps(rows: RsvpLike[]): RsvpSummary {
+  const invitedRows = rows.filter((row) => row.invitationStatus === "invited");
+  return {
+    invited: invitedRows.length,
+    yes: invitedRows.filter((row) => row.rsvpStatus === "yes").length,
+    maybe: invitedRows.filter((row) => row.rsvpStatus === "maybe").length,
+    no: invitedRows.filter((row) => row.rsvpStatus === "no").length,
+    pending: invitedRows.filter((row) => row.rsvpStatus === "pending").length,
+    attended: rows.filter((row) => row.attended).length,
+    expected: invitedRows.filter((row) => row.rsvpStatus === "yes" || row.rsvpStatus === "maybe").length,
+  };
+}
+
+export interface InviteTextInput {
+  title: string;
+  startsAt: string;
+  hostName?: string | null;
+  location?: string | null;
+  gameNotes?: string | null;
+  stakesNotes?: string | null;
+  capacity?: number | null;
+}
+
+export function buildInviteText(input: InviteTextInput, locale = "en-US"): string {
+  const when = new Intl.DateTimeFormat(locale, {
+    dateStyle: "full",
+    timeStyle: "short",
+  }).format(new Date(input.startsAt));
+  const lines = [input.title, when];
+  if (input.hostName) lines.push(`Host: ${input.hostName}`);
+  if (input.location) lines.push(`Location: ${input.location}`);
+  if (input.gameNotes) lines.push(`Game: ${input.gameNotes}`);
+  if (input.stakesNotes) lines.push(`Stakes: ${input.stakesNotes}`);
+  if (input.capacity) lines.push(`Capacity: ${input.capacity} players`);
+  lines.push("Reply with yes, maybe, or no.");
+  return lines.join("\n");
+}

--- a/src/Operations.tsx
+++ b/src/Operations.tsx
@@ -1,0 +1,821 @@
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
+import {
+  Link,
+  NavLink,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import { api } from "./api";
+import type { Organizer } from "./types";
+
+type EventStatus = "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+
+interface OperationsSettings {
+  defaultLocation: string;
+  defaultGameNotes: string | null;
+  defaultStakesNotes: string | null;
+  defaultMoneyTrackingEnabled: boolean;
+  defaultBuyInCents: number;
+  updatedAt: string;
+  updatedByName: string | null;
+}
+
+interface OperationsOrganizer {
+  id: string;
+  email: string;
+  displayName: string;
+  role: "admin" | "organizer";
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface OperationsEvent {
+  id: string;
+  title: string;
+  startsAt: string;
+  hostPlayerId: string | null;
+  hostName: string | null;
+  location: string;
+  gameNotes: string | null;
+  stakesNotes: string | null;
+  notes: string | null;
+  capacity: number | null;
+  moneyTrackingEnabled: boolean;
+  defaultBuyInCents: number;
+  status: EventStatus;
+  playerCount: number;
+  attendanceCount: number;
+  rsvp: {
+    invited: number;
+    yes: number;
+    maybe: number;
+    no: number;
+    pending: number;
+    expected: number;
+  };
+  cashInCents: number;
+  cashOutCents: number;
+  differenceCents: number;
+  missingCashOuts: number;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+interface OperationsPlayer {
+  id: string;
+  playerId: string;
+  displayName: string;
+  invitationStatus: "invited" | "not_invited";
+  rsvpStatus: "pending" | "yes" | "maybe" | "no";
+  attended: boolean;
+  checkedInAt: string | null;
+}
+
+interface DashboardResponse {
+  settings: OperationsSettings;
+  activePlayerCount: number;
+  currentEvents: OperationsEvent[];
+  nextEvent: OperationsEvent | null;
+  incompleteCloseouts: OperationsEvent[];
+  recentEvents: OperationsEvent[];
+}
+
+interface SettingsResponse {
+  settings: OperationsSettings;
+  organizers: OperationsOrganizer[];
+  activePlayers: Array<{ id: string; displayName: string }>;
+}
+
+interface EventResponse {
+  event: OperationsEvent;
+  players: OperationsPlayer[];
+  rsvp: OperationsEvent["rsvp"] & { attended: number };
+  inviteText: string;
+}
+
+interface SearchResponse {
+  players: Array<{
+    id: string;
+    displayName: string;
+    email: string | null;
+    phone: string | null;
+    status: "active" | "archived";
+  }>;
+  events: Array<{
+    id: string;
+    title: string;
+    startsAt: string;
+    location: string;
+    status: EventStatus;
+    hostName: string | null;
+  }>;
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatMoney(cents: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+}
+
+function centsFromInput(value: string): number | null {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return null;
+  return Math.round(amount * 100);
+}
+
+function formValue(fields: FormData, name: string): string {
+  return String(fields.get(name) ?? "");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+function Status({ status }: { status: EventStatus }) {
+  return <span className={`status-badge status-${status}`}>{status}</span>;
+}
+
+function Button({
+  children,
+  variant = "primary",
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "danger";
+}) {
+  return (
+    <button className={`button button-${variant}`} {...props}>
+      {children}
+    </button>
+  );
+}
+
+function StateCard({ children, error = false }: { children: ReactNode; error?: boolean }) {
+  return <div className={`state-card ${error ? "state-error" : ""}`}>{children}</div>;
+}
+
+function PageTitle({ eyebrow, title, actions }: { eyebrow: string; title: string; actions?: ReactNode }) {
+  return (
+    <div className="page-header operations-page-header">
+      <div>
+        <p className="eyebrow">{eyebrow}</p>
+        <h1>{title}</h1>
+      </div>
+      {actions ? <div className="page-actions">{actions}</div> : null}
+    </div>
+  );
+}
+
+function OperationsShell({ children }: { children: ReactNode }) {
+  const [organizer, setOrganizer] = useState<Organizer>();
+  const [error, setError] = useState<unknown>();
+
+  useEffect(() => {
+    api<{ organizer: Organizer }>("/api/session")
+      .then((response) => setOrganizer(response.organizer))
+      .catch(setError);
+  }, []);
+
+  if (error) return <main className="auth-state"><StateCard error>{errorMessage(error)}</StateCard></main>;
+  if (!organizer) return <main className="auth-state">Verifying organizer access…</main>;
+
+  return (
+    <div className="app-shell operations-shell">
+      <header className="topbar">
+        <Link className="brand-lockup" to="/ops">
+          <span aria-hidden="true">♠</span>
+          <strong>BroTM Operations</strong>
+        </Link>
+        <div className="organizer-chip">
+          <span>{organizer.displayName}</span>
+          <small>{organizer.role}</small>
+        </div>
+      </header>
+      <nav className="primary-nav" aria-label="Operations navigation">
+        <NavLink to="/ops" end>Overview</NavLink>
+        <NavLink to="/ops/search">Search</NavLink>
+        <NavLink to="/ops/events/new">Plan night</NavLink>
+        <NavLink to="/ops/settings">Settings</NavLink>
+        <Link to="/">Main app</Link>
+      </nav>
+      <main className="page-container operations-container">{children}</main>
+    </div>
+  );
+}
+
+function RsvpGrid({ event }: { event: OperationsEvent }) {
+  return (
+    <div className="operations-stat-grid" aria-label="RSVP summary">
+      <div><span>Yes</span><strong>{event.rsvp.yes}</strong></div>
+      <div><span>Maybe</span><strong>{event.rsvp.maybe}</strong></div>
+      <div><span>Pending</span><strong>{event.rsvp.pending}</strong></div>
+      <div><span>No</span><strong>{event.rsvp.no}</strong></div>
+      <div><span>Expected</span><strong>{event.rsvp.expected}</strong></div>
+      <div><span>Capacity</span><strong>{event.capacity ?? "Open"}</strong></div>
+    </div>
+  );
+}
+
+function OperationsEventCard({ event }: { event: OperationsEvent }) {
+  const overCapacity = event.capacity !== null && event.rsvp.expected > event.capacity;
+  return (
+    <Link className="event-card operations-event-card" to={`/ops/events/${event.id}`}>
+      <div className="event-card-topline">
+        <strong>{event.title}</strong>
+        <Status status={event.status} />
+      </div>
+      <span>{formatDate(event.startsAt)}</span>
+      <span>{event.location || "Location not set"}</span>
+      <div className="event-card-metrics">
+        <span>{event.rsvp.expected} expected</span>
+        <span className={overCapacity ? "warning-text" : ""}>
+          {event.capacity ? `${event.capacity} capacity` : "No capacity limit"}
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+function OperationsDashboardPage() {
+  const [data, setData] = useState<DashboardResponse>();
+  const [error, setError] = useState<unknown>();
+
+  useEffect(() => {
+    api<DashboardResponse>("/ops-api/dashboard").then(setData).catch(setError);
+  }, []);
+
+  if (error) return <StateCard error>{errorMessage(error)}</StateCard>;
+  if (!data) return <StateCard>Loading organizer overview…</StateCard>;
+
+  return (
+    <>
+      <PageTitle
+        eyebrow="Organizer operations"
+        title="Run the whole night from one place."
+        actions={<Link className="button button-primary" to="/ops/events/new">Plan a night</Link>}
+      />
+
+      <section className="metric-grid operations-metrics">
+        <article className="metric-card"><span>Active players</span><strong>{data.activePlayerCount}</strong></article>
+        <article className="metric-card"><span>Open nights</span><strong>{data.currentEvents.length}</strong></article>
+        <article className="metric-card"><span>Closeouts needing attention</span><strong>{data.incompleteCloseouts.length}</strong></article>
+      </section>
+
+      <section className="content-section">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Current workflow</p><h2>Next or active night</h2></div>
+        </div>
+        {data.nextEvent ? (
+          <div className="operations-feature-card panel">
+            <div className="operations-feature-copy">
+              <Status status={data.nextEvent.status} />
+              <h2>{data.nextEvent.title}</h2>
+              <p>{formatDate(data.nextEvent.startsAt)}</p>
+              <p>{data.nextEvent.location || data.settings.defaultLocation || "Location not set"}</p>
+              <div className="page-actions">
+                <Link className="button button-primary" to={`/ops/events/${data.nextEvent.id}`}>Invite summary</Link>
+                <Link className="button button-secondary" to={`/events/${data.nextEvent.id}`}>Roster and attendance</Link>
+                {data.nextEvent.moneyTrackingEnabled ? (
+                  <Link className="button button-secondary" to={`/money/events/${data.nextEvent.id}`}>Money ledger</Link>
+                ) : null}
+              </div>
+            </div>
+            <RsvpGrid event={data.nextEvent} />
+          </div>
+        ) : (
+          <StateCard>No night is planned. Create one using the saved defaults.</StateCard>
+        )}
+      </section>
+
+      {data.incompleteCloseouts.length ? (
+        <section className="content-section">
+          <div className="section-heading-row">
+            <div><p className="eyebrow">Needs attention</p><h2>Incomplete closeouts</h2></div>
+          </div>
+          <div className="card-list event-grid">
+            {data.incompleteCloseouts.map((event) => (
+              <article className="panel closeout-card" key={event.id}>
+                <div className="event-card-topline"><strong>{event.title}</strong><Status status={event.status} /></div>
+                <p>{event.missingCashOuts} missing cash-outs</p>
+                <p>Difference: {formatMoney(event.differenceCents)}</p>
+                <div className="page-actions">
+                  <Link className="button button-primary" to={`/money/events/${event.id}`}>Resolve ledger</Link>
+                  <Link className="button button-secondary" to={`/events/${event.id}`}>Attendance</Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="content-section">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">All current nights</p><h2>Planning queue</h2></div>
+        </div>
+        {data.currentEvents.length ? (
+          <div className="card-list event-grid">
+            {data.currentEvents.map((event) => <OperationsEventCard event={event} key={event.id} />)}
+          </div>
+        ) : (
+          <StateCard>No draft, open, or active events.</StateCard>
+        )}
+      </section>
+    </>
+  );
+}
+
+function OperationsNewEventPage() {
+  const [data, setData] = useState<SettingsResponse>();
+  const [error, setError] = useState<unknown>();
+  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    api<SettingsResponse>("/ops-api/settings").then(setData).catch(setError);
+  }, []);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fields = new FormData(event.currentTarget);
+    const defaultBuyInCents = centsFromInput(formValue(fields, "defaultBuyIn"));
+    if (defaultBuyInCents === null || defaultBuyInCents < 0) {
+      setError(new Error("Enter a valid default buy-in."));
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      const response = await api<{ event: OperationsEvent }>("/ops-api/events", {
+        method: "POST",
+        body: JSON.stringify({
+          title: formValue(fields, "title"),
+          startsAt: new Date(formValue(fields, "startsAt")).toISOString(),
+          hostPlayerId: formValue(fields, "hostPlayerId") || null,
+          location: formValue(fields, "location"),
+          gameNotes: formValue(fields, "gameNotes") || null,
+          stakesNotes: formValue(fields, "stakesNotes") || null,
+          notes: formValue(fields, "notes") || null,
+          capacity: formValue(fields, "capacity") ? Number(formValue(fields, "capacity")) : null,
+          moneyTrackingEnabled: fields.get("moneyTrackingEnabled") === "on",
+          defaultBuyInCents,
+        }),
+      });
+      navigate(`/ops/events/${response.event.id}`);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (error && !data) return <StateCard error>{errorMessage(error)}</StateCard>;
+  if (!data) return <StateCard>Loading saved defaults…</StateCard>;
+
+  return (
+    <>
+      <PageTitle eyebrow="Night builder" title="Plan from saved defaults" />
+      {error ? <StateCard error>{errorMessage(error)}</StateCard> : null}
+      <section className="panel narrow-panel">
+        <form className="form-grid operations-form" onSubmit={submit}>
+          <label>Event title<input name="title" defaultValue="Poker Night" required maxLength={120} /></label>
+          <label>Date and start time<input name="startsAt" type="datetime-local" required /></label>
+          <label>
+            Host
+            <select name="hostPlayerId" defaultValue="">
+              <option value="">No host selected</option>
+              {data.activePlayers.map((player) => <option value={player.id} key={player.id}>{player.displayName}</option>)}
+            </select>
+          </label>
+          <label>Capacity<input name="capacity" type="number" min={1} max={200} inputMode="numeric" /></label>
+          <label className="form-grid-wide">Location<input name="location" defaultValue={data.settings.defaultLocation} maxLength={240} /></label>
+          <label className="form-grid-wide">Game and house rules<textarea name="gameNotes" rows={4} defaultValue={data.settings.defaultGameNotes ?? ""} maxLength={1200} /></label>
+          <label className="form-grid-wide">Stakes notes<textarea name="stakesNotes" rows={3} defaultValue={data.settings.defaultStakesNotes ?? ""} maxLength={500} /></label>
+          <label>Default buy-in<input name="defaultBuyIn" inputMode="decimal" defaultValue={(data.settings.defaultBuyInCents / 100).toFixed(2)} /></label>
+          <label className="checkbox-field"><input name="moneyTrackingEnabled" type="checkbox" defaultChecked={data.settings.defaultMoneyTrackingEnabled} /> Track money for this night</label>
+          <label className="form-grid-wide">Organizer notes<textarea name="notes" rows={3} maxLength={1200} /></label>
+          <Button className="form-grid-action" disabled={saving}>{saving ? "Creating…" : "Create draft"}</Button>
+        </form>
+      </section>
+    </>
+  );
+}
+
+function OperationsEventPage() {
+  const { id = "" } = useParams();
+  const [detail, setDetail] = useState<EventResponse>();
+  const [error, setError] = useState<unknown>();
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string>();
+  const [correctionNote, setCorrectionNote] = useState("");
+
+  const load = async () => {
+    try {
+      setDetail(await api<EventResponse>(`/ops-api/events/${id}`));
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
+
+  useEffect(() => { void load(); }, [id]);
+
+  async function patch(body: Record<string, unknown>, success: string) {
+    setSaving(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      const locked = detail ? ["completed", "cancelled", "archived"].includes(detail.event.status) : false;
+      const response = await api<EventResponse>(`/ops-api/events/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ ...body, ...(locked ? { correctionNote: correctionNote.trim() } : {}) }),
+      });
+      setDetail(response);
+      setMessage(success);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function copyInvite() {
+    if (!detail) return;
+    try {
+      await navigator.clipboard.writeText(detail.inviteText);
+      setMessage("Invite text copied.");
+    } catch {
+      setError(new Error("The browser could not copy the invite text. Select it manually."));
+    }
+  }
+
+  if (error && !detail) return <StateCard error>{errorMessage(error)}</StateCard>;
+  if (!detail) return <StateCard>Loading invitation summary…</StateCard>;
+  const event = detail.event;
+  const locked = ["completed", "cancelled", "archived"].includes(event.status);
+  const capacityRemaining = event.capacity === null ? null : event.capacity - event.rsvp.expected;
+
+  return (
+    <>
+      <PageTitle
+        eyebrow="Night builder"
+        title={event.title}
+        actions={
+          <>
+            <Status status={event.status} />
+            <Link className="button button-secondary" to={`/events/${event.id}`}>Edit roster</Link>
+          </>
+        }
+      />
+      {error ? <StateCard error>{errorMessage(error)}</StateCard> : null}
+      {message ? <StateCard>{message}</StateCard> : null}
+
+      <section className="operations-feature-card panel">
+        <div className="operations-feature-copy">
+          <p>{formatDate(event.startsAt)}</p>
+          <p>{event.hostName ? `Hosted by ${event.hostName}` : "No host selected"}</p>
+          <p>{event.location || "Location not set"}</p>
+          <div className="page-actions">
+            <Link className="button button-primary" to={`/events/${event.id}`}>Roster and attendance</Link>
+            {event.moneyTrackingEnabled ? <Link className="button button-secondary" to={`/money/events/${event.id}`}>Money ledger</Link> : null}
+          </div>
+        </div>
+        <RsvpGrid event={event} />
+      </section>
+
+      <div className="two-column-layout operations-event-layout">
+        <section className="panel invite-panel">
+          <div className="section-heading-row">
+            <div><p className="eyebrow">Copy and send</p><h2>Invite text</h2></div>
+            <Button type="button" onClick={() => void copyInvite()}>Copy invite</Button>
+          </div>
+          <textarea className="invite-text" readOnly value={detail.inviteText} rows={10} />
+          <div className="capacity-callout">
+            {capacityRemaining === null ? "No capacity limit is set." : capacityRemaining >= 0 ? `${capacityRemaining} expected seats remain.` : `${Math.abs(capacityRemaining)} expected players over capacity.`}
+          </div>
+        </section>
+
+        <aside className="panel">
+          <p className="eyebrow">RSVP rollup</p>
+          <h2>Invitation status</h2>
+          <div className="rsvp-list">
+            {detail.players.length ? detail.players.map((player) => (
+              <div key={player.id}>
+                <strong>{player.displayName}</strong>
+                <span>{player.invitationStatus === "not_invited" ? "Not invited" : player.rsvpStatus}</span>
+              </div>
+            )) : <StateCard>No players are on the roster.</StateCard>}
+          </div>
+        </aside>
+      </div>
+
+      <section className="panel content-section">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Operations</p><h2>Capacity, notes, and lifecycle</h2></div>
+        </div>
+        {locked ? (
+          <label className="correction-note-field">
+            Correction reason required
+            <textarea value={correctionNote} onChange={(change) => setCorrectionNote(change.target.value)} rows={2} maxLength={500} />
+          </label>
+        ) : null}
+        <div className="operations-control-grid">
+          <form onSubmit={(submitEvent) => {
+            submitEvent.preventDefault();
+            const fields = new FormData(submitEvent.currentTarget);
+            void patch({ capacity: formValue(fields, "capacity") ? Number(formValue(fields, "capacity")) : null }, "Capacity updated.");
+          }}>
+            <label>Capacity<input name="capacity" type="number" min={1} max={200} defaultValue={event.capacity ?? ""} /></label>
+            <Button disabled={saving || (locked && correctionNote.trim().length < 3)}>Save capacity</Button>
+          </form>
+          <form onSubmit={(submitEvent) => {
+            submitEvent.preventDefault();
+            const fields = new FormData(submitEvent.currentTarget);
+            const quickNote = formValue(fields, "quickNote");
+            if (quickNote) void patch({ quickNote }, "Event note added.");
+            submitEvent.currentTarget.reset();
+          }}>
+            <label>Quick organizer note<textarea name="quickNote" rows={2} maxLength={500} required /></label>
+            <Button disabled={saving || (locked && correctionNote.trim().length < 3)}>Add note</Button>
+          </form>
+        </div>
+        <div className="page-actions operations-danger-row">
+          {event.status === "draft" ? <Button disabled={saving} onClick={() => void patch({ status: "open" }, "Invitations opened.")}>Open invitations</Button> : null}
+          {["draft", "open"].includes(event.status) ? <Button variant="danger" disabled={saving} onClick={() => void patch({ status: "cancelled" }, "Event cancelled.")}>Cancel event</Button> : null}
+          {["draft", "cancelled", "completed"].includes(event.status) ? <Button variant="secondary" disabled={saving || (locked && correctionNote.trim().length < 3)} onClick={() => void patch({ status: "archived" }, "Event archived.")}>Archive event</Button> : null}
+        </div>
+      </section>
+    </>
+  );
+}
+
+function OperationsSearchPage() {
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState("all");
+  const [results, setResults] = useState<SearchResponse>({ players: [], events: [] });
+  const [error, setError] = useState<unknown>();
+  const [loading, setLoading] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!query.trim()) return;
+    setLoading(true);
+    setError(undefined);
+    try {
+      setResults(await api<SearchResponse>(`/ops-api/search?q=${encodeURIComponent(query.trim())}&scope=${scope}`));
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <PageTitle eyebrow="Find records" title="Search players and nights" />
+      {error ? <StateCard error>{errorMessage(error)}</StateCard> : null}
+      <section className="panel">
+        <form className="search-form" onSubmit={submit}>
+          <input value={query} onChange={(change) => setQuery(change.target.value)} placeholder="Name, email, phone, event, location, or host" />
+          <select value={scope} onChange={(change) => setScope(change.target.value)}>
+            <option value="all">Everything</option>
+            <option value="players">Players</option>
+            <option value="events">Events</option>
+          </select>
+          <Button disabled={loading || !query.trim()}>{loading ? "Searching…" : "Search"}</Button>
+        </form>
+      </section>
+
+      <div className="two-column-layout content-section">
+        <section className="panel">
+          <div className="section-heading-row"><h2>Players</h2><span>{results.players.length}</span></div>
+          <div className="person-list">
+            {results.players.map((player) => (
+              <Link className="person-row" to={`/players/${player.id}`} key={player.id}>
+                <span className="avatar">{player.displayName.slice(0, 1).toUpperCase()}</span>
+                <span><strong>{player.displayName}</strong><small>{player.email || player.phone || player.status}</small></span>
+              </Link>
+            ))}
+            {!results.players.length ? <StateCard>No matching players.</StateCard> : null}
+          </div>
+        </section>
+        <section className="panel">
+          <div className="section-heading-row"><h2>Events</h2><span>{results.events.length}</span></div>
+          <div className="card-list">
+            {results.events.map((event) => (
+              <Link className="event-card" to={`/ops/events/${event.id}`} key={event.id}>
+                <div className="event-card-topline"><strong>{event.title}</strong><Status status={event.status} /></div>
+                <span>{formatDate(event.startsAt)}</span>
+                <span>{event.location || event.hostName || "No location or host"}</span>
+              </Link>
+            ))}
+            {!results.events.length ? <StateCard>No matching events.</StateCard> : null}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}
+
+function OrganizerRow({ organizer, current, onSave }: { organizer: OperationsOrganizer; current: Organizer; onSave: (id: string, body: Record<string, unknown>) => Promise<void> }) {
+  const [displayName, setDisplayName] = useState(organizer.displayName);
+  const [role, setRole] = useState(organizer.role);
+  const [active, setActive] = useState(organizer.active);
+  const disabled = current.role !== "admin" || organizer.id === current.id;
+
+  useEffect(() => {
+    setDisplayName(organizer.displayName);
+    setRole(organizer.role);
+    setActive(organizer.active);
+  }, [organizer]);
+
+  return (
+    <article className="organizer-row">
+      <div><strong>{organizer.email}</strong><small>{organizer.id === current.id ? "Current organizer" : organizer.active ? "Active" : "Inactive"}</small></div>
+      <input value={displayName} onChange={(change) => setDisplayName(change.target.value)} disabled={current.role !== "admin"} />
+      <select value={role} onChange={(change) => setRole(change.target.value as OperationsOrganizer["role"])} disabled={disabled}>
+        <option value="organizer">Organizer</option>
+        <option value="admin">Admin</option>
+      </select>
+      <label className="checkbox-field"><input type="checkbox" checked={active} onChange={(change) => setActive(change.target.checked)} disabled={disabled} /> Active</label>
+      <Button variant="secondary" disabled={current.role !== "admin"} onClick={() => void onSave(organizer.id, { displayName, role, active })}>Save</Button>
+    </article>
+  );
+}
+
+function OperationsSettingsPage() {
+  const [data, setData] = useState<SettingsResponse>();
+  const [current, setCurrent] = useState<Organizer>();
+  const [error, setError] = useState<unknown>();
+  const [message, setMessage] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  const load = async () => {
+    try {
+      const [settingsResponse, session] = await Promise.all([
+        api<SettingsResponse>("/ops-api/settings"),
+        api<{ organizer: Organizer }>("/api/session"),
+      ]);
+      setData(settingsResponse);
+      setCurrent(session.organizer);
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  async function saveDefaults(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const fields = new FormData(event.currentTarget);
+    const cents = centsFromInput(formValue(fields, "defaultBuyIn"));
+    if (cents === null || cents < 0) {
+      setError(new Error("Enter a valid default buy-in."));
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      setData(await api<SettingsResponse>("/ops-api/settings", {
+        method: "PATCH",
+        body: JSON.stringify({
+          defaultLocation: formValue(fields, "defaultLocation"),
+          defaultGameNotes: formValue(fields, "defaultGameNotes") || null,
+          defaultStakesNotes: formValue(fields, "defaultStakesNotes") || null,
+          defaultMoneyTrackingEnabled: fields.get("defaultMoneyTrackingEnabled") === "on",
+          defaultBuyInCents: cents,
+        }),
+      }));
+      setMessage("Organizer defaults saved.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function addOrganizer(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const fields = new FormData(form);
+    setSaving(true);
+    setError(undefined);
+    try {
+      setData(await api<SettingsResponse>("/ops-api/organizers", {
+        method: "POST",
+        body: JSON.stringify({
+          email: formValue(fields, "email"),
+          displayName: formValue(fields, "displayName"),
+          role: formValue(fields, "role"),
+        }),
+      }));
+      form.reset();
+      setMessage("Organizer record added. Their email must also be allowed by Cloudflare Access.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveOrganizer(id: string, body: Record<string, unknown>) {
+    setSaving(true);
+    setError(undefined);
+    try {
+      setData(await api<SettingsResponse>(`/ops-api/organizers/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }));
+      setMessage("Organizer updated.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (error && (!data || !current)) return <StateCard error>{errorMessage(error)}</StateCard>;
+  if (!data || !current) return <StateCard>Loading settings…</StateCard>;
+
+  return (
+    <>
+      <PageTitle eyebrow="Configuration" title="Organizer settings" />
+      {error ? <StateCard error>{errorMessage(error)}</StateCard> : null}
+      {message ? <StateCard>{message}</StateCard> : null}
+
+      <section className="panel">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Night defaults</p><h2>Pre-fill new poker nights</h2></div>
+          <span>{data.settings.updatedByName ? `Updated by ${data.settings.updatedByName}` : "Not customized"}</span>
+        </div>
+        <form className="form-grid operations-form" onSubmit={saveDefaults}>
+          <label className="form-grid-wide">Default location<input name="defaultLocation" defaultValue={data.settings.defaultLocation} maxLength={240} /></label>
+          <label className="form-grid-wide">Default game and house rules<textarea name="defaultGameNotes" rows={4} defaultValue={data.settings.defaultGameNotes ?? ""} maxLength={1200} /></label>
+          <label className="form-grid-wide">Default stakes notes<textarea name="defaultStakesNotes" rows={3} defaultValue={data.settings.defaultStakesNotes ?? ""} maxLength={500} /></label>
+          <label>Default buy-in<input name="defaultBuyIn" inputMode="decimal" defaultValue={(data.settings.defaultBuyInCents / 100).toFixed(2)} /></label>
+          <label className="checkbox-field"><input name="defaultMoneyTrackingEnabled" type="checkbox" defaultChecked={data.settings.defaultMoneyTrackingEnabled} /> Track money by default</label>
+          <Button className="form-grid-action" disabled={saving}>{saving ? "Saving…" : "Save defaults"}</Button>
+        </form>
+      </section>
+
+      <section className="panel content-section">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Access records</p><h2>Organizers</h2></div>
+          <span>{current.role === "admin" ? "Admin controls enabled" : "Read only"}</span>
+        </div>
+        {current.role === "admin" ? (
+          <form className="organizer-create-form" onSubmit={addOrganizer}>
+            <input name="email" type="email" placeholder="Email" required maxLength={200} />
+            <input name="displayName" placeholder="Display name" required maxLength={120} />
+            <select name="role" defaultValue="organizer"><option value="organizer">Organizer</option><option value="admin">Admin</option></select>
+            <Button disabled={saving}>Add organizer</Button>
+          </form>
+        ) : null}
+        <div className="organizer-list">
+          {data.organizers.map((organizer) => (
+            <OrganizerRow organizer={organizer} current={current} onSave={saveOrganizer} key={organizer.id} />
+          ))}
+        </div>
+        <p className="settings-footnote">An organizer must exist here and be allowed by the Cloudflare Access policy. This screen does not change the Cloudflare policy.</p>
+      </section>
+    </>
+  );
+}
+
+function OperationsNotFound() {
+  return <StateCard>That operations page does not exist. <Link to="/ops">Return to the overview.</Link></StateCard>;
+}
+
+export function OperationsApp() {
+  return (
+    <OperationsShell>
+      <Routes>
+        <Route path="/ops" element={<OperationsDashboardPage />} />
+        <Route path="/ops/search" element={<OperationsSearchPage />} />
+        <Route path="/ops/events/new" element={<OperationsNewEventPage />} />
+        <Route path="/ops/events/:id" element={<OperationsEventPage />} />
+        <Route path="/ops/settings" element={<OperationsSettingsPage />} />
+        <Route path="*" element={<OperationsNotFound />} />
+      </Routes>
+    </OperationsShell>
+  );
+}
+
+export function OperationsShortcut() {
+  const location = useLocation();
+  const eventMatch = location.pathname.match(/^\/events\/([0-9a-f-]+)$/i);
+  const target = eventMatch ? `/ops/events/${eventMatch[1]}` : "/ops";
+  const label = eventMatch ? "Invite summary" : "Operations";
+
+  if (location.pathname.startsWith("/ops") || location.pathname.startsWith("/money")) return null;
+  return <Link className="operations-shortcut" to={target}>{label}</Link>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,11 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { App } from "./App";
 import { MoneyEventPage, MoneyShortcut, PlayerMoneyPage } from "./Money";
+import { OperationsApp, OperationsShortcut } from "./Operations";
 import "./styles.css";
 import "./editing.css";
 import "./money.css";
+import "./operations.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Application root was not found");
@@ -16,12 +18,14 @@ createRoot(root).render(
       <Routes>
         <Route path="/money/events/:id" element={<MoneyEventPage />} />
         <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
+        <Route path="/ops/*" element={<OperationsApp />} />
         <Route
           path="*"
           element={
             <>
               <App />
               <MoneyShortcut />
+              <OperationsShortcut />
             </>
           }
         />

--- a/src/operations.css
+++ b/src/operations.css
@@ -1,0 +1,287 @@
+.operations-container {
+  padding-bottom: 8rem;
+}
+
+.operations-page-header h1 {
+  max-width: 16ch;
+}
+
+.operations-metrics {
+  margin-bottom: 2rem;
+}
+
+.operations-feature-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 1.25rem;
+  align-items: stretch;
+}
+
+.operations-feature-copy {
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+}
+
+.operations-feature-copy h2,
+.operations-feature-copy p {
+  margin: 0;
+}
+
+.operations-feature-copy h2 {
+  font-size: clamp(1.8rem, 5vw, 3.4rem);
+}
+
+.operations-feature-copy p {
+  color: var(--muted);
+}
+
+.operations-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.operations-stat-grid > div {
+  display: grid;
+  gap: 0.35rem;
+  min-height: 92px;
+  align-content: space-between;
+  padding: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.operations-stat-grid span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.operations-stat-grid strong {
+  font-size: clamp(1.35rem, 4vw, 2rem);
+}
+
+.operations-event-card {
+  min-height: 175px;
+}
+
+.warning-text {
+  color: var(--red);
+  font-weight: 800;
+}
+
+.closeout-card {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.closeout-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.operations-form {
+  margin-top: 0;
+}
+
+.checkbox-field {
+  display: flex !important;
+  min-height: 44px;
+  align-items: center;
+  gap: 0.7rem !important;
+  padding: 0.65rem 0;
+}
+
+.checkbox-field input {
+  width: 20px;
+  min-height: 20px;
+  margin: 0;
+}
+
+.operations-event-layout {
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  margin-top: 1rem;
+}
+
+.invite-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.invite-text {
+  min-height: 260px;
+  line-height: 1.55;
+}
+
+.capacity-callout {
+  padding: 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(150, 199, 136, 0.08);
+  color: var(--green);
+  font-weight: 800;
+}
+
+.rsvp-list {
+  display: grid;
+  margin-top: 1rem;
+}
+
+.rsvp-list > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.rsvp-list span {
+  color: var(--muted);
+  text-transform: capitalize;
+}
+
+.correction-note-field {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+  color: var(--red);
+  font-weight: 800;
+}
+
+.operations-control-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.operations-control-grid form {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.operations-control-grid label {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.operations-danger-row {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.search-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(150px, 0.25fr) auto;
+  gap: 0.7rem;
+}
+
+.organizer-create-form {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) minmax(180px, 0.8fr) minmax(130px, 0.4fr) auto;
+  gap: 0.65rem;
+  margin-bottom: 1.25rem;
+}
+
+.organizer-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.organizer-row {
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) minmax(150px, 0.7fr) minmax(120px, 0.35fr) auto auto;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.organizer-row > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.organizer-row small,
+.settings-footnote {
+  color: var(--muted);
+}
+
+.settings-footnote {
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+}
+
+.operations-shortcut {
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: 50;
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(150, 199, 136, 0.55);
+  border-radius: 999px;
+  background: rgba(19, 23, 18, 0.96);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  color: var(--green);
+  font-weight: 850;
+  text-decoration: none;
+  backdrop-filter: blur(14px);
+}
+
+.operations-shortcut:hover {
+  background: var(--surface-3);
+}
+
+@media (max-width: 900px) {
+  .operations-feature-card,
+  .operations-event-layout,
+  .operations-control-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .organizer-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .organizer-row > div {
+    grid-column: 1 / -1;
+  }
+
+  .organizer-create-form {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .operations-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .search-form,
+  .organizer-create-form,
+  .organizer-row {
+    grid-template-columns: 1fr;
+  }
+
+  .operations-shortcut {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+  }
+}

--- a/src/operations.css
+++ b/src/operations.css
@@ -226,7 +226,8 @@
 
 .operations-shortcut {
   position: fixed;
-  right: max(1rem, env(safe-area-inset-right));
+  left: max(1rem, env(safe-area-inset-left));
+  right: auto;
   bottom: max(1rem, env(safe-area-inset-bottom));
   z-index: 50;
   display: inline-flex;
@@ -282,6 +283,6 @@
   .operations-shortcut {
     left: 0.75rem;
     right: 0.75rem;
-    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    bottom: calc(max(0.75rem, env(safe-area-inset-bottom)) + 4rem);
   }
 }

--- a/tests/operations.test.ts
+++ b/tests/operations.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInviteText,
+  operationsEventCreateSchema,
+  operationsSettingsPatchSchema,
+  organizerPatchSchema,
+  summarizeRsvps,
+} from "../shared/operations";
+
+describe("RSVP summaries", () => {
+  it("counts only invited players in RSVP totals", () => {
+    expect(
+      summarizeRsvps([
+        { invitationStatus: "invited", rsvpStatus: "yes", attended: true },
+        { invitationStatus: "invited", rsvpStatus: "maybe" },
+        { invitationStatus: "invited", rsvpStatus: "pending" },
+        { invitationStatus: "not_invited", rsvpStatus: "yes", attended: true },
+      ]),
+    ).toEqual({
+      invited: 3,
+      yes: 1,
+      maybe: 1,
+      no: 0,
+      pending: 1,
+      attended: 2,
+      expected: 2,
+    });
+  });
+});
+
+describe("invite text", () => {
+  it("includes the operational event details and RSVP instruction", () => {
+    const text = buildInviteText({
+      title: "Friday Poker",
+      startsAt: "2026-08-01T19:00:00-06:00",
+      hostName: "Sterling",
+      location: "Home",
+      gameNotes: "Texas Hold'em",
+      stakesNotes: "$10 buy-in",
+      capacity: 8,
+    });
+    expect(text).toContain("Friday Poker");
+    expect(text).toContain("Host: Sterling");
+    expect(text).toContain("Location: Home");
+    expect(text).toContain("Capacity: 8 players");
+    expect(text).toContain("Reply with yes, maybe, or no.");
+  });
+});
+
+describe("operations validation", () => {
+  it("accepts shared organizer defaults", () => {
+    expect(
+      operationsSettingsPatchSchema.parse({
+        defaultLocation: "Cimarron Hills",
+        defaultMoneyTrackingEnabled: true,
+        defaultBuyInCents: 1000,
+      }).defaultBuyInCents,
+    ).toBe(1000);
+  });
+
+  it("requires at least one organizer update", () => {
+    expect(() => organizerPatchSchema.parse({})).toThrow();
+  });
+
+  it("validates event capacity", () => {
+    expect(() =>
+      operationsEventCreateSchema.parse({
+        title: "Poker Night",
+        startsAt: "2026-08-01T19:00:00-06:00",
+        capacity: 0,
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## What changed

- Added a dedicated organizer operations overview at `/ops`.
- Added RSVP totals, expected attendance, capacity visibility, current-night shortcuts, and incomplete closeout warnings.
- Added a night builder that pre-fills shared location, game, stakes, money-tracking, and buy-in defaults.
- Added optional event capacity.
- Added generated, copyable invite text and a clean RSVP rollup.
- Added search across player names, contact details, events, locations, and hosts.
- Added quick event notes plus open, cancel, and archive operations.
- Added organizer settings and organizer-record management.
- Added admin safeguards against self-lockout and removal of the final active admin.
- Added a floating Operations shortcut from the existing application.
- Added validation, helper tests, and rollout documentation.

## Database migration required

Apply `migrations/0003_organizer_operations.sql` to the remote `brotm-poker` D1 database before production use:

```bash
npm run db:migrate:remote
```

The migration adds `events.capacity` and the single-row `app_settings` table.

## Access note

Adding an organizer record does not modify Cloudflare Access. The organizer email must also be allowed by the existing Access policy.

## Validation

CI runs formatting, source lint, TypeScript, Vitest, and the production build.