### PR TITLE
Fix operations route mounting

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
 import { App } from "./App";
 import { MoneyEventPage, MoneyShortcut, PlayerMoneyPage } from "./Money";
 import { OperationsApp, OperationsShortcut } from "./Operations";
@@ -9,27 +9,38 @@ import "./editing.css";
 import "./money.css";
 import "./operations.css";
 
+function RootRouter() {
+  const location = useLocation();
+
+  if (location.pathname === "/ops" || location.pathname.startsWith("/ops/")) {
+    return <OperationsApp />;
+  }
+
+  return (
+    <Routes>
+      <Route path="/money/events/:id" element={<MoneyEventPage />} />
+      <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
+      <Route
+        path="*"
+        element={
+          <>
+            <App />
+            <MoneyShortcut />
+            <OperationsShortcut />
+          </>
+        }
+      />
+    </Routes>
+  );
+}
+
 const root = document.getElementById("root");
 if (!root) throw new Error("Application root was not found");
 
 createRoot(root).render(
   <StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/money/events/:id" element={<MoneyEventPage />} />
-        <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
-        <Route path="/ops/*" element={<OperationsApp />} />
-        <Route
-          path="*"
-          element={
-            <>
-              <App />
-              <MoneyShortcut />
-              <OperationsShortcut />
-            </>
-          }
-        />
-      </Routes>
+      <RootRouter />
     </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
## Fix

The organizer operations shell was mounted as the element of `/ops/*`, then rendered another `<Routes>` tree containing absolute `/ops/...` paths. React Router evaluated the descendant routes relative to the already matched parent, so `/ops` fell through to the operations not-found screen.

This change mounts `OperationsApp` directly from a location-aware root router. Its existing absolute operations routes now resolve against the browser root as intended.

No database changes are required.