### PR TITLE
Unify organizer navigation and add deployment health

### DIFF
--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,43 @@
+# BroTM Poker production deployment checklist
+
+Use this checklist for every production merge that changes database-backed features.
+
+## Before merge
+
+1. Confirm the feature branch passes `npm run check`.
+2. Review every new file in `migrations/`.
+3. Export the Cloudflare API token and account ID in the current Codespaces terminal.
+4. Apply remote migrations from the feature branch:
+
+```bash
+npm run db:migrate:remote
+```
+
+5. Confirm Wrangler reports every pending migration as applied.
+6. Open `/api/health` while signed in through Cloudflare Access.
+7. Confirm the response reports:
+   - `ok: true`
+   - no missing tables
+   - no missing columns
+   - `schemaVersion` greater than or equal to `requiredSchemaVersion`
+
+## After merge
+
+1. Wait for the Cloudflare Pages production deployment to finish.
+2. Open `https://poker.skpfam.com` in a private browser window.
+3. Confirm the footer says `Database ready` and displays the deployed build identifier when available.
+4. Smoke-test:
+   - dashboard
+   - player directory and editing
+   - night creation
+   - roster and attendance
+   - invite and RSVP view
+   - money ledger
+   - closeout
+   - history
+   - settings
+5. On a phone-sized viewport, verify the bottom navigation, event workspace tabs, large money controls, and sticky closeout totals.
+
+## Failure behavior
+
+The application must show a deployment warning when the frontend expects tables, columns, or migrations that production D1 does not have. Do not treat a deployment as complete until `/api/health` reports `ok: true`.

--- a/functions/api/health.ts
+++ b/functions/api/health.ts
@@ -1,0 +1,79 @@
+import {
+  APP_VERSION,
+  REQUIRED_SCHEMA_VERSION,
+  healthMessage,
+  type HealthReport,
+} from "../../shared/app-shell";
+import { json } from "../lib/http";
+import type { AppPagesFunction } from "../lib/types";
+
+const requiredTables = [
+  "organizers",
+  "players",
+  "events",
+  "event_players",
+  "event_audit_log",
+  "ledger_entries",
+  "app_settings",
+  "d1_migrations",
+];
+
+interface NameRow {
+  name: string;
+}
+
+interface MigrationRow {
+  version: number;
+}
+
+export const onRequestGet: AppPagesFunction = async (context) => {
+  try {
+    const tablesResult = await context.env.DB
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all<NameRow>();
+    const tables = new Set(tablesResult.results.map((row) => row.name));
+    const missingTables = requiredTables.filter((table) => !tables.has(table));
+
+    const eventColumnsResult = tables.has("events")
+      ? await context.env.DB.prepare("PRAGMA table_info(events)").all<NameRow>()
+      : { results: [] as NameRow[] };
+    const eventColumns = new Set(eventColumnsResult.results.map((row) => row.name));
+    const missingColumns = eventColumns.has("capacity") ? [] : ["events.capacity"];
+
+    const migrationRow = tables.has("d1_migrations")
+      ? await context.env.DB
+          .prepare("SELECT COALESCE(MAX(id), 0) AS version FROM d1_migrations")
+          .first<MigrationRow>()
+      : null;
+    const schemaVersion = Number(migrationRow?.version ?? 0);
+    const ok =
+      missingTables.length === 0 &&
+      missingColumns.length === 0 &&
+      schemaVersion >= REQUIRED_SCHEMA_VERSION;
+
+    const report: HealthReport = {
+      ok,
+      appVersion: APP_VERSION,
+      commit: context.env.CF_PAGES_COMMIT_SHA ?? null,
+      schemaVersion,
+      requiredSchemaVersion: REQUIRED_SCHEMA_VERSION,
+      missingTables,
+      missingColumns,
+      message: healthMessage(schemaVersion, missingTables, missingColumns),
+    };
+
+    return json(report, { status: ok ? 200 : 503 });
+  } catch (error) {
+    const report: HealthReport = {
+      ok: false,
+      appVersion: APP_VERSION,
+      commit: context.env.CF_PAGES_COMMIT_SHA ?? null,
+      schemaVersion: 0,
+      requiredSchemaVersion: REQUIRED_SCHEMA_VERSION,
+      missingTables: [],
+      missingColumns: [],
+      message: `The database health check failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    };
+    return json(report, { status: 503 });
+  }
+};

--- a/functions/lib/types.ts
+++ b/functions/lib/types.ts
@@ -11,6 +11,7 @@ export interface Env {
   POLICY_AUD: string;
   ENVIRONMENT?: string;
   DEV_ORGANIZER_EMAIL?: string;
+  CF_PAGES_COMMIT_SHA?: string;
 }
 
 export interface FunctionData extends Record<string, unknown> {

--- a/shared/app-shell.ts
+++ b/shared/app-shell.ts
@@ -1,0 +1,38 @@
+export const APP_VERSION = "2.2.0";
+export const REQUIRED_SCHEMA_VERSION = 3;
+
+export interface HealthReport {
+  ok: boolean;
+  appVersion: string;
+  commit: string | null;
+  schemaVersion: number;
+  requiredSchemaVersion: number;
+  missingTables: string[];
+  missingColumns: string[];
+  message: string;
+}
+
+export function eventIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/(?:events|ops\/events|money\/events)\/([0-9a-f-]+)(?:\/|$)/i);
+  return match?.[1] ?? null;
+}
+
+export function healthMessage(
+  schemaVersion: number,
+  missingTables: string[],
+  missingColumns: string[],
+): string {
+  if (!missingTables.length && !missingColumns.length && schemaVersion >= REQUIRED_SCHEMA_VERSION) {
+    return "Application and database schema are ready.";
+  }
+
+  const details = [
+    missingTables.length ? `missing tables: ${missingTables.join(", ")}` : "",
+    missingColumns.length ? `missing columns: ${missingColumns.join(", ")}` : "",
+    schemaVersion < REQUIRED_SCHEMA_VERSION
+      ? `database migration ${REQUIRED_SCHEMA_VERSION} has not been recorded`
+      : "",
+  ].filter(Boolean);
+
+  return `Deployment is incomplete: ${details.join("; ")}. Run the remote D1 migrations before using the site.`;
+}

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Link, NavLink, Route, Routes, useLocation } from "react-router-dom";
+import { APP_VERSION, eventIdFromPath, type HealthReport } from "../shared/app-shell";
+import { App } from "./App";
+import { api, ApiError } from "./api";
+import { MoneyEventPage, PlayerMoneyPage } from "./Money";
+import { OperationsApp } from "./Operations";
+import type { Organizer } from "./types";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+function ViewRouter() {
+  const location = useLocation();
+
+  if (location.pathname === "/ops" || location.pathname.startsWith("/ops/")) {
+    return <OperationsApp />;
+  }
+
+  return (
+    <Routes>
+      <Route path="/money/events/:id" element={<MoneyEventPage />} />
+      <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
+      <Route path="*" element={<App />} />
+    </Routes>
+  );
+}
+
+function NavItem({ to, children, active }: { to: string; children: ReactNode; active?: boolean }) {
+  return (
+    <NavLink to={to} end={to === "/"} className={active ? "active" : undefined}>
+      {children}
+    </NavLink>
+  );
+}
+
+export function UnifiedApp() {
+  const location = useLocation();
+  const [organizer, setOrganizer] = useState<Organizer>();
+  const [sessionError, setSessionError] = useState<unknown>();
+  const [health, setHealth] = useState<HealthReport>();
+  const eventId = eventIdFromPath(location.pathname);
+
+  useEffect(() => {
+    api<{ organizer: Organizer }>("/api/session")
+      .then((response) => setOrganizer(response.organizer))
+      .catch(setSessionError);
+
+    fetch("/api/health", { headers: { Accept: "application/json" } })
+      .then(async (response) => {
+        const report = (await response.json()) as HealthReport;
+        setHealth(report);
+      })
+      .catch(() => {
+        setHealth({
+          ok: false,
+          appVersion: APP_VERSION,
+          commit: null,
+          schemaVersion: 0,
+          requiredSchemaVersion: 3,
+          missingTables: [],
+          missingColumns: [],
+          message: "The deployment health check could not be reached.",
+        });
+      });
+  }, []);
+
+  if (sessionError) {
+    const accessMessage =
+      sessionError instanceof ApiError && sessionError.status === 403
+        ? "Your Access identity is valid, but it is not enabled as an organizer."
+        : errorMessage(sessionError);
+    return (
+      <main className="auth-state">
+        <div className="brand-lockup"><span aria-hidden="true">♠</span><strong>BroTM Poker</strong></div>
+        <h1>Organizer access required</h1>
+        <p>{accessMessage}</p>
+      </main>
+    );
+  }
+
+  if (!organizer) return <main className="auth-state">Verifying organizer access…</main>;
+
+  const settingsActive = location.pathname.startsWith("/ops/settings");
+  const searchActive = location.pathname.startsWith("/ops/search");
+
+  return (
+    <div className="unified-shell">
+      <a className="skip-link" href="#unified-main">Skip to content</a>
+      <header className="unified-topbar">
+        <Link className="brand-lockup" to="/">
+          <span aria-hidden="true">♠</span>
+          <strong>BroTM Poker</strong>
+        </Link>
+        <div className="unified-topbar-actions">
+          <Link className="button button-primary unified-plan-button" to="/ops/events/new">Plan night</Link>
+          <div className="organizer-chip"><span>{organizer.displayName}</span><small>{organizer.role}</small></div>
+        </div>
+      </header>
+
+      <nav className="primary-nav unified-nav" aria-label="Main navigation">
+        <NavItem to="/">Dashboard</NavItem>
+        <NavItem to="/events">Nights</NavItem>
+        <NavItem to="/players">Players</NavItem>
+        <NavItem to="/history">History</NavItem>
+        <NavItem to="/ops/search" active={searchActive}>Search</NavItem>
+        <NavItem to="/ops/settings" active={settingsActive}>Settings</NavItem>
+      </nav>
+
+      {health && !health.ok ? (
+        <aside className="deployment-warning" role="alert">
+          <strong>Deployment needs attention.</strong>
+          <span>{health.message}</span>
+          <code>Schema {health.schemaVersion}/{health.requiredSchemaVersion}</code>
+        </aside>
+      ) : null}
+
+      {eventId ? (
+        <nav className="event-workspace-nav" aria-label="Poker night sections">
+          <Link className={location.pathname === `/events/${eventId}` ? "active" : ""} to={`/events/${eventId}`}>Details & live</Link>
+          <Link className={location.pathname === `/ops/events/${eventId}` ? "active" : ""} to={`/ops/events/${eventId}`}>Invites & RSVP</Link>
+          <Link className={location.pathname === `/money/events/${eventId}` ? "active" : ""} to={`/money/events/${eventId}`}>Money</Link>
+        </nav>
+      ) : null}
+
+      <main id="unified-main" className="unified-main">
+        <ViewRouter />
+      </main>
+
+      <footer className="unified-footer">
+        <span>BroTM Poker v{health?.appVersion ?? APP_VERSION}</span>
+        <span>{health?.commit ? `Build ${health.commit.slice(0, 7)}` : "Production organizer app"}</span>
+        <span className={health?.ok ? "health-ready" : "health-warning"}>{health?.ok ? "Database ready" : "Health warning"}</span>
+      </footer>
+    </div>
+  );
+}

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { Link, NavLink, Route, Routes, useLocation } from "react-router-dom";
-import { APP_VERSION, eventIdFromPath, type HealthReport } from "../shared/app-shell";
+import {
+  APP_VERSION,
+  REQUIRED_SCHEMA_VERSION,
+  eventIdFromPath,
+  type HealthReport,
+} from "../shared/app-shell";
 import { App } from "./App";
 import { api, ApiError } from "./api";
 import { MoneyEventPage, PlayerMoneyPage } from "./Money";
@@ -29,7 +34,11 @@ function ViewRouter() {
 
 function NavItem({ to, children, active }: { to: string; children: ReactNode; active?: boolean }) {
   return (
-    <NavLink to={to} end={to === "/"} className={active ? "active" : undefined}>
+    <NavLink
+      to={to}
+      end={to === "/"}
+      className={({ isActive }) => (active || isActive ? "active" : undefined)}
+    >
       {children}
     </NavLink>
   );
@@ -58,7 +67,7 @@ export function UnifiedApp() {
           appVersion: APP_VERSION,
           commit: null,
           schemaVersion: 0,
-          requiredSchemaVersion: 3,
+          requiredSchemaVersion: REQUIRED_SCHEMA_VERSION,
           missingTables: [],
           missingColumns: [],
           message: "The deployment health check could not be reached.",
@@ -124,9 +133,9 @@ export function UnifiedApp() {
         </nav>
       ) : null}
 
-      <main id="unified-main" className="unified-main">
+      <div id="unified-main" className="unified-main" role="main">
         <ViewRouter />
-      </main>
+      </div>
 
       <footer className="unified-footer">
         <span>BroTM Poker v{health?.appVersion ?? APP_VERSION}</span>

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,8 +11,8 @@ export class ApiError extends Error {
   readonly code: string;
   readonly fields: Record<string, string[]>;
 
-  constructor(status: number, body: ApiErrorBody) {
-    super(body.error?.message ?? "The request failed.");
+  constructor(status: number, body: ApiErrorBody, fallbackMessage?: string) {
+    super(body.error?.message ?? fallbackMessage ?? `The request failed with status ${status}.`);
     this.name = "ApiError";
     this.status = status;
     this.code = body.error?.code ?? "REQUEST_FAILED";
@@ -26,7 +26,30 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
   headers.set("Accept", "application/json");
 
   const response = await fetch(path, { ...init, headers });
-  const body = (await response.json().catch(() => ({}))) as T & ApiErrorBody;
-  if (!response.ok) throw new ApiError(response.status, body);
+  const rawBody = await response.text();
+  let body = {} as T & ApiErrorBody;
+
+  if (rawBody) {
+    try {
+      body = JSON.parse(rawBody) as T & ApiErrorBody;
+    } catch {
+      if (!response.ok) {
+        throw new ApiError(
+          response.status,
+          {},
+          rawBody.trim() || response.statusText || `The request failed with status ${response.status}.`,
+        );
+      }
+      throw new Error(`Expected JSON from ${path}, but the server returned an unreadable response.`);
+    }
+  }
+
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      body,
+      response.statusText || `The request failed with status ${response.status}.`,
+    );
+  }
   return body;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,38 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
-import { App } from "./App";
-import { MoneyEventPage, MoneyShortcut, PlayerMoneyPage } from "./Money";
-import { OperationsApp, OperationsShortcut } from "./Operations";
+import { BrowserRouter } from "react-router-dom";
+import { UnifiedApp } from "./UnifiedApp";
 import "./styles.css";
 import "./editing.css";
 import "./money.css";
 import "./operations.css";
-
-function RootRouter() {
-  const location = useLocation();
-
-  if (location.pathname === "/ops" || location.pathname.startsWith("/ops/")) {
-    return <OperationsApp />;
-  }
-
-  return (
-    <Routes>
-      <Route path="/money/events/:id" element={<MoneyEventPage />} />
-      <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
-      <Route
-        path="*"
-        element={
-          <>
-            <App />
-            <MoneyShortcut />
-            <OperationsShortcut />
-          </>
-        }
-      />
-    </Routes>
-  );
-}
+import "./unified.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Application root was not found");
@@ -40,7 +14,7 @@ if (!root) throw new Error("Application root was not found");
 createRoot(root).render(
   <StrictMode>
     <BrowserRouter>
-      <RootRouter />
+      <UnifiedApp />
     </BrowserRouter>
   </StrictMode>,
 );

--- a/src/unified.css
+++ b/src/unified.css
@@ -1,0 +1,221 @@
+.unified-shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 92% -10%, rgba(215, 178, 103, 0.11), transparent 32rem),
+    var(--bg);
+}
+
+.unified-topbar {
+  min-height: 74px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem max(1rem, calc((100vw - 1180px) / 2));
+  border-bottom: 1px solid var(--line);
+  background: rgba(9, 11, 8, 0.96);
+}
+
+.unified-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.unified-nav {
+  position: sticky;
+  top: 0;
+  z-index: 45;
+  padding-inline: max(1rem, calc((100vw - 1180px) / 2));
+  background: rgba(9, 11, 8, 0.96);
+  backdrop-filter: blur(16px);
+}
+
+.unified-main {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: clamp(1.25rem, 3vw, 2.5rem) 0 7rem;
+}
+
+/* Existing feature surfaces remain responsible for their content while the
+   unified shell owns branding, navigation, spacing, and deployment status. */
+.unified-main > .app-shell,
+.unified-main > .operations-shell,
+.unified-main > .money-shell,
+.unified-main .money-shell {
+  min-height: 0;
+  background: transparent;
+}
+
+.unified-main > .app-shell > .topbar,
+.unified-main > .app-shell > .primary-nav,
+.unified-main > .operations-shell > .topbar,
+.unified-main > .operations-shell > .primary-nav,
+.unified-main .money-shell > .money-topbar {
+  display: none;
+}
+
+.unified-main > .app-shell > .page-container,
+.unified-main > .operations-shell > .operations-container,
+.unified-main .money-shell > .money-page {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+.unified-main .money-page-header {
+  margin-top: 0;
+}
+
+.event-workspace-nav {
+  display: flex;
+  gap: 0.35rem;
+  width: min(1180px, calc(100% - 2rem));
+  margin: 1rem auto 0;
+  padding: 0.35rem;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.event-workspace-nav a {
+  min-height: 42px;
+  display: inline-flex;
+  flex: 1 0 max-content;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 0.9rem;
+  border-radius: 9px;
+  color: var(--muted);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.event-workspace-nav a:hover,
+.event-workspace-nav a.active {
+  background: var(--surface-strong, #1b2119);
+  color: var(--text);
+}
+
+.deployment-warning {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 1rem auto 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(224, 121, 116, 0.65);
+  border-radius: 12px;
+  background: rgba(224, 121, 116, 0.08);
+  color: var(--text);
+}
+
+.deployment-warning span {
+  color: var(--muted);
+}
+
+.deployment-warning code {
+  color: var(--red);
+}
+
+.unified-footer {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.6rem 1rem;
+  padding: 1.25rem 0 calc(1.25rem + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.health-ready {
+  color: var(--green);
+}
+
+.health-warning {
+  color: var(--red);
+}
+
+/* The old floating cross-app shortcuts are replaced by permanent navigation. */
+.unified-shell .money-shortcut,
+.unified-shell .operations-shortcut {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  .unified-topbar {
+    min-height: 64px;
+  }
+
+  .unified-plan-button,
+  .unified-topbar .organizer-chip small {
+    display: none;
+  }
+
+  .unified-nav {
+    position: fixed;
+    inset: auto 0 0;
+    z-index: 80;
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 0;
+    padding: 0.35rem max(0.35rem, env(safe-area-inset-right)) calc(0.35rem + env(safe-area-inset-bottom)) max(0.35rem, env(safe-area-inset-left));
+    border-top: 1px solid var(--line);
+    border-bottom: 0;
+  }
+
+  .unified-nav a {
+    min-width: 0;
+    min-height: 50px;
+    padding: 0.45rem 0.15rem;
+    font-size: 0.68rem;
+    text-align: center;
+  }
+
+  .unified-main {
+    width: min(100% - 1rem, 1180px);
+    padding-top: 1rem;
+    padding-bottom: 7.5rem;
+  }
+
+  .event-workspace-nav,
+  .deployment-warning,
+  .unified-footer {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .deployment-warning {
+    grid-template-columns: 1fr;
+  }
+
+  .money-total-grid {
+    position: sticky;
+    top: 0.5rem;
+    z-index: 30;
+    padding: 0.45rem;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: rgba(9, 11, 8, 0.94);
+    backdrop-filter: blur(16px);
+  }
+
+  .money-action-grid .button {
+    min-height: 54px;
+    font-size: 0.95rem;
+  }
+
+  .live-roster .event-player-editor,
+  .money-player-card {
+    scroll-margin-top: 7rem;
+  }
+
+  .unified-footer {
+    padding-bottom: 6.5rem;
+  }
+}

--- a/tests/app-shell.test.ts
+++ b/tests/app-shell.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  REQUIRED_SCHEMA_VERSION,
+  eventIdFromPath,
+  healthMessage,
+} from "../shared/app-shell";
+
+describe("event workspace routing", () => {
+  it("finds the event id across unified event surfaces", () => {
+    const id = "8d2f4b93-7dd5-4a3f-9a2d-91d1554e5b20";
+    expect(eventIdFromPath(`/events/${id}`)).toBe(id);
+    expect(eventIdFromPath(`/ops/events/${id}`)).toBe(id);
+    expect(eventIdFromPath(`/money/events/${id}`)).toBe(id);
+  });
+
+  it("does not treat list and settings pages as event workspaces", () => {
+    expect(eventIdFromPath("/events")).toBeNull();
+    expect(eventIdFromPath("/ops/settings")).toBeNull();
+    expect(eventIdFromPath("/money/players/player-id")).toBeNull();
+  });
+});
+
+describe("deployment health messaging", () => {
+  it("reports a ready schema", () => {
+    expect(healthMessage(REQUIRED_SCHEMA_VERSION, [], [])).toBe(
+      "Application and database schema are ready.",
+    );
+  });
+
+  it("names missing schema requirements", () => {
+    const message = healthMessage(2, ["app_settings"], ["events.capacity"]);
+    expect(message).toContain("app_settings");
+    expect(message).toContain("events.capacity");
+    expect(message).toContain(`migration ${REQUIRED_SCHEMA_VERSION}`);
+  });
+});


### PR DESCRIPTION
## What changed

- Replaced the separate main, operations, and money navigation surfaces with one persistent organizer shell.
- Added permanent Dashboard, Nights, Players, History, Search, and Settings navigation.
- Added event workspace tabs connecting details/live attendance, invites/RSVP, and money without floating shortcuts.
- Added a mobile bottom navigation, larger live money controls, and sticky closeout totals.
- Added `/api/health` to verify required D1 tables, the `events.capacity` column, and migration version before the app is considered ready.
- Added application version/build status in the footer and a visible deployment warning when production D1 is behind the frontend.
- Improved API error handling so non-JSON and server-provided failures are actionable.
- Added route and schema-health tests plus a production deployment checklist.

## Database

No new migration is required. Production must already have migrations 0001 through 0003 applied. The new health endpoint verifies that state.

## Deployment

This PR is intended to merge directly after CI passes so Cloudflare Pages deploys it to production.