### PR TITLE
Add private self-service RSVP links

### DIFF
--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -20,6 +20,7 @@ npm run db:migrate:remote
    - no missing tables
    - no missing columns
    - `schemaVersion` greater than or equal to `requiredSchemaVersion`
+8. When the release changes public RSVP behavior, verify the path-specific Access applications described in `PRIVATE_RSVP_ROLLOUT.md`.
 
 ## After merge
 
@@ -32,11 +33,13 @@ npm run db:migrate:remote
    - night creation
    - roster and attendance
    - invite and RSVP view
+   - private RSVP link generation and revocation
+   - public RSVP response from a browser without organizer access
    - money ledger
    - closeout
-   - history
+   - history and RSVP audit entry
    - settings
-5. On a phone-sized viewport, verify the bottom navigation, event workspace tabs, large money controls, and sticky closeout totals.
+5. On a phone-sized viewport, verify the bottom navigation, event workspace tabs, public RSVP controls, large money controls, and sticky closeout totals.
 
 ## Failure behavior
 

--- a/docs/PRIVATE_RSVP_ROLLOUT.md
+++ b/docs/PRIVATE_RSVP_ROLLOUT.md
@@ -1,0 +1,81 @@
+# Private RSVP rollout
+
+This release adds passwordless, player-specific RSVP links. The organizer application remains protected by Cloudflare Access. Only the public RSVP page and its narrowly scoped API are bypassed.
+
+## 1. Apply migration 0004
+
+From Codespaces with the Cloudflare API token exported:
+
+```bash
+npm run db:migrate:remote
+```
+
+Confirm that `0004_private_rsvp_links.sql` was applied. The migration adds:
+
+- `event_invites`
+- `events.rsvp_location_visibility`
+- the inactive `Public RSVP service` audit identity
+
+The production health banner remains active until schema version 4 is present.
+
+## 2. Add two path-specific Cloudflare Access applications
+
+In Zero Trust, create self-hosted Access applications for these exact paths:
+
+```text
+poker.skpfam.com/rsvp/*
+poker.skpfam.com/rsvp-api/*
+```
+
+For each application, add a policy with:
+
+```text
+Action: Bypass
+Selector: Everyone
+```
+
+Do not bypass any of these paths:
+
+```text
+/rsvp/events/*
+/rsvp-admin-api/*
+/api/*
+/ops-api/*
+/money-api/*
+```
+
+The path-specific applications must be more specific than the existing organizer application protecting `poker.skpfam.com`.
+
+## 3. Verify organizer controls
+
+Open an event and select **RSVP links**.
+
+1. Mark at least one rostered player as invited.
+2. Choose whether the address is always visible or shown only after a Yes response.
+3. Generate one link or generate all personalized links.
+4. Confirm the invitation text copies to the clipboard.
+5. Confirm link status, expiry, and last-response time appear.
+
+Raw tokens are returned only when generated. D1 stores SHA-256 token hashes, not reusable raw links. Regenerating a link invalidates the previous one.
+
+## 4. Verify public behavior
+
+Use an incognito window that is not logged into Cloudflare Access.
+
+1. Open a freshly generated `/rsvp/<token>` link.
+2. Confirm the page loads without an organizer login.
+3. Submit Yes, Maybe, or No.
+4. Confirm the organizer RSVP summary updates.
+5. Confirm the event audit history contains `public rsvp updated` by `Public RSVP service`.
+6. Revoke the link and confirm it no longer loads.
+7. For address privacy, verify the location appears only after a Yes response.
+
+## Security properties
+
+- Tokens contain 256 bits of randomness.
+- Only SHA-256 token hashes are stored.
+- Links expire 36 hours after the scheduled start time.
+- Cancelled, archived, and completed events reject new responses.
+- Valid links are throttled to one response change every five seconds.
+- Every public response creates an event audit entry.
+- The public API never returns the roster, contact information, financial history, or organizer records.

--- a/docs/PRIVATE_RSVP_ROLLOUT.md
+++ b/docs/PRIVATE_RSVP_ROLLOUT.md
@@ -40,12 +40,14 @@ The `/assets/*` bypass exposes only the compiled JavaScript and CSS needed to re
 Do not bypass any of these paths:
 
 ```text
-/rsvp/events/*
+/events/*
 /rsvp-admin-api/*
 /api/*
 /ops-api/*
 /money-api/*
 ```
+
+Organizer link management is located at `/events/<event-id>/rsvp-links`, outside the public `/rsvp/*` path.
 
 The path-specific applications must be more specific than the existing organizer application protecting `poker.skpfam.com`.
 

--- a/docs/PRIVATE_RSVP_ROLLOUT.md
+++ b/docs/PRIVATE_RSVP_ROLLOUT.md
@@ -1,6 +1,6 @@
 # Private RSVP rollout
 
-This release adds passwordless, player-specific RSVP links. The organizer application remains protected by Cloudflare Access. Only the public RSVP page and its narrowly scoped API are bypassed.
+This release adds passwordless, player-specific RSVP links. The organizer application remains protected by Cloudflare Access. Only the public RSVP page, its API, and static frontend assets are bypassed.
 
 ## 1. Apply migration 0004
 
@@ -18,13 +18,14 @@ Confirm that `0004_private_rsvp_links.sql` was applied. The migration adds:
 
 The production health banner remains active until schema version 4 is present.
 
-## 2. Add two path-specific Cloudflare Access applications
+## 2. Add three path-specific Cloudflare Access applications
 
 In Zero Trust, create self-hosted Access applications for these exact paths:
 
 ```text
 poker.skpfam.com/rsvp/*
 poker.skpfam.com/rsvp-api/*
+poker.skpfam.com/assets/*
 ```
 
 For each application, add a policy with:
@@ -33,6 +34,8 @@ For each application, add a policy with:
 Action: Bypass
 Selector: Everyone
 ```
+
+The `/assets/*` bypass exposes only the compiled JavaScript and CSS needed to render the public RSVP page. It does not bypass any API or expose organizer data.
 
 Do not bypass any of these paths:
 
@@ -63,7 +66,7 @@ Raw tokens are returned only when generated. D1 stores SHA-256 token hashes, not
 Use an incognito window that is not logged into Cloudflare Access.
 
 1. Open a freshly generated `/rsvp/<token>` link.
-2. Confirm the page loads without an organizer login.
+2. Confirm the page and its styling load without an organizer login.
 3. Submit Yes, Maybe, or No.
 4. Confirm the organizer RSVP summary updates.
 5. Confirm the event audit history contains `public rsvp updated` by `Public RSVP service`.

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -7,7 +7,8 @@ export const onRequest: AppPagesFunction = async (context) => {
   if (
     !pathname.startsWith("/api/") &&
     !pathname.startsWith("/money-api/") &&
-    !pathname.startsWith("/ops-api/")
+    !pathname.startsWith("/ops-api/") &&
+    !pathname.startsWith("/rsvp-admin-api/")
   ) {
     return context.next();
   }

--- a/functions/api/health.ts
+++ b/functions/api/health.ts
@@ -15,6 +15,7 @@ const requiredTables = [
   "event_audit_log",
   "ledger_entries",
   "app_settings",
+  "event_invites",
   "d1_migrations",
 ];
 
@@ -38,7 +39,10 @@ export const onRequestGet: AppPagesFunction = async (context) => {
       ? await context.env.DB.prepare("PRAGMA table_info(events)").all<NameRow>()
       : { results: [] as NameRow[] };
     const eventColumns = new Set(eventColumnsResult.results.map((row) => row.name));
-    const missingColumns = eventColumns.has("capacity") ? [] : ["events.capacity"];
+    const missingColumns = [
+      eventColumns.has("capacity") ? "" : "events.capacity",
+      eventColumns.has("rsvp_location_visibility") ? "" : "events.rsvp_location_visibility",
+    ].filter(Boolean);
 
     const migrationRow = tables.has("d1_migrations")
       ? await context.env.DB

--- a/functions/rsvp-admin-api/[[path]].ts
+++ b/functions/rsvp-admin-api/[[path]].ts
@@ -1,0 +1,416 @@
+import { ZodError } from "zod";
+import {
+  buildPersonalizedInviteText,
+  createRsvpToken,
+  hashRsvpToken,
+  invitationExpiresAt,
+  rsvpAdminEventPatchSchema,
+  type RsvpLocationVisibility,
+} from "../../shared/rsvp";
+import { apiError, json, readJson, validationError } from "../lib/http";
+import type { AppPagesFunction, OrganizerIdentity } from "../lib/types";
+
+interface RsvpEventRow {
+  id: string;
+  title: string;
+  starts_at: string;
+  host_name: string | null;
+  location: string;
+  game_notes: string | null;
+  stakes_notes: string | null;
+  status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  rsvp_location_visibility: RsvpLocationVisibility;
+}
+
+interface RsvpPlayerRow {
+  event_player_id: string;
+  player_id: string;
+  display_name: string;
+  invitation_status: "invited" | "not_invited";
+  rsvp_status: "pending" | "yes" | "maybe" | "no";
+  invite_id: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+  last_response_at: string | null;
+  response_count: number | null;
+  invite_created_at: string | null;
+}
+
+interface GeneratedInvite {
+  playerId: string;
+  playerName: string;
+  url: string;
+  inviteText: string;
+  expiresAt: string;
+}
+
+function auditStatement(
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+  action: string,
+  details: Record<string, unknown>,
+  createdAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO event_audit_log
+       (id, event_id, organizer_id, action, details_json, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(crypto.randomUUID(), eventId, organizer.id, action, JSON.stringify(details), createdAt);
+}
+
+async function getEvent(db: D1Database, eventId: string): Promise<RsvpEventRow | null> {
+  return db
+    .prepare(
+      `SELECT e.id, e.title, e.starts_at, host.display_name AS host_name,
+              e.location, e.game_notes, e.stakes_notes, e.status,
+              e.rsvp_location_visibility
+       FROM events e
+       LEFT JOIN players host ON host.id = e.host_player_id
+       WHERE e.id = ?1`,
+    )
+    .bind(eventId)
+    .first<RsvpEventRow>();
+}
+
+async function requireEvent(db: D1Database, eventId: string): Promise<RsvpEventRow> {
+  const event = await getEvent(db, eventId);
+  if (!event) throw new Response("Event not found.", { status: 404 });
+  return event;
+}
+
+function requireMutableEvent(event: RsvpEventRow): void {
+  if (["completed", "cancelled", "archived"].includes(event.status)) {
+    throw new Response("RSVP links cannot be changed for a locked event.", { status: 409 });
+  }
+}
+
+async function getPlayers(db: D1Database, eventId: string): Promise<RsvpPlayerRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT ep.id AS event_player_id, ep.player_id, p.display_name,
+              ep.invitation_status, ep.rsvp_status,
+              ei.id AS invite_id, ei.expires_at, ei.revoked_at,
+              ei.last_response_at, ei.response_count,
+              ei.created_at AS invite_created_at
+       FROM event_players ep
+       JOIN players p ON p.id = ep.player_id
+       LEFT JOIN event_invites ei ON ei.event_player_id = ep.id
+       WHERE ep.event_id = ?1
+       ORDER BY
+         CASE ep.invitation_status WHEN 'invited' THEN 0 ELSE 1 END,
+         CASE ep.rsvp_status WHEN 'yes' THEN 0 WHEN 'maybe' THEN 1 WHEN 'pending' THEN 2 ELSE 3 END,
+         p.display_name COLLATE NOCASE`,
+    )
+    .bind(eventId)
+    .all<RsvpPlayerRow>();
+  return rows.results;
+}
+
+function playerJson(player: RsvpPlayerRow) {
+  const now = Date.now();
+  const expired = player.expires_at ? new Date(player.expires_at).getTime() <= now : false;
+  const revoked = Boolean(player.revoked_at);
+  return {
+    eventPlayerId: player.event_player_id,
+    playerId: player.player_id,
+    displayName: player.display_name,
+    invitationStatus: player.invitation_status,
+    rsvpStatus: player.rsvp_status,
+    invite: player.invite_id
+      ? {
+          exists: true,
+          active: !expired && !revoked,
+          expired,
+          revoked,
+          expiresAt: player.expires_at,
+          revokedAt: player.revoked_at,
+          lastResponseAt: player.last_response_at,
+          responseCount: Number(player.response_count ?? 0),
+          createdAt: player.invite_created_at,
+        }
+      : {
+          exists: false,
+          active: false,
+          expired: false,
+          revoked: false,
+          expiresAt: null,
+          revokedAt: null,
+          lastResponseAt: null,
+          responseCount: 0,
+          createdAt: null,
+        },
+  };
+}
+
+async function detail(db: D1Database, eventId: string): Promise<Response> {
+  const [event, players] = await Promise.all([requireEvent(db, eventId), getPlayers(db, eventId)]);
+  return json({
+    event: {
+      id: event.id,
+      title: event.title,
+      startsAt: event.starts_at,
+      hostName: event.host_name,
+      location: event.location,
+      gameNotes: event.game_notes,
+      stakesNotes: event.stakes_notes,
+      status: event.status,
+      locationVisibility: event.rsvp_location_visibility,
+    },
+    players: players.map(playerJson),
+  });
+}
+
+async function requireInvitedPlayer(
+  db: D1Database,
+  eventId: string,
+  playerId: string,
+): Promise<RsvpPlayerRow> {
+  const player = (await getPlayers(db, eventId)).find((row) => row.player_id === playerId);
+  if (!player) throw new Response("Player is not on this event roster.", { status: 404 });
+  if (player.invitation_status !== "invited") {
+    throw new Response("Mark the player as invited before generating an RSVP link.", { status: 409 });
+  }
+  return player;
+}
+
+async function prepareInvite(
+  request: Request,
+  event: RsvpEventRow,
+  player: RsvpPlayerRow,
+): Promise<{ generated: GeneratedInvite; tokenHash: string }> {
+  const token = createRsvpToken();
+  const tokenHash = await hashRsvpToken(token);
+  const expiresAt = invitationExpiresAt(event.starts_at);
+  const url = `${new URL(request.url).origin}/rsvp/${token}`;
+  return {
+    tokenHash,
+    generated: {
+      playerId: player.player_id,
+      playerName: player.display_name,
+      url,
+      expiresAt,
+      inviteText: buildPersonalizedInviteText({
+        playerName: player.display_name,
+        title: event.title,
+        startsAt: event.starts_at,
+        hostName: event.host_name,
+        location: event.location,
+        locationVisibility: event.rsvp_location_visibility,
+        gameNotes: event.game_notes,
+        stakesNotes: event.stakes_notes,
+        rsvpUrl: url,
+      }),
+    },
+  };
+}
+
+function upsertInviteStatement(
+  db: D1Database,
+  player: RsvpPlayerRow,
+  organizer: OrganizerIdentity,
+  tokenHash: string,
+  expiresAt: string,
+  now: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO event_invites
+       (id, event_player_id, token_hash, expires_at, revoked_at,
+        last_response_at, response_count, created_by_organizer_id, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, NULL, NULL, 0, ?5, ?6, ?6)
+       ON CONFLICT(event_player_id) DO UPDATE SET
+         token_hash = excluded.token_hash,
+         expires_at = excluded.expires_at,
+         revoked_at = NULL,
+         created_by_organizer_id = excluded.created_by_organizer_id,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(
+      player.invite_id ?? crypto.randomUUID(),
+      player.event_player_id,
+      tokenHash,
+      expiresAt,
+      organizer.id,
+      now,
+    );
+}
+
+async function generateOne(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  playerId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  requireMutableEvent(event);
+  const player = await requireInvitedPlayer(db, eventId, playerId);
+  const prepared = await prepareInvite(request, event, player);
+  const now = new Date().toISOString();
+  await db.batch([
+    upsertInviteStatement(db, player, organizer, prepared.tokenHash, prepared.generated.expiresAt, now),
+    auditStatement(
+      db,
+      eventId,
+      organizer,
+      player.invite_id ? "rsvp_link_regenerated" : "rsvp_link_generated",
+      { playerId, playerName: player.display_name, expiresAt: prepared.generated.expiresAt },
+      now,
+    ),
+  ]);
+  return json({ generated: prepared.generated });
+}
+
+async function generateAll(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  requireMutableEvent(event);
+  const players = (await getPlayers(db, eventId)).filter((player) => player.invitation_status === "invited");
+  if (!players.length) return apiError(409, "NO_INVITEES", "Add invited players before generating links.");
+
+  const prepared = await Promise.all(players.map((player) => prepareInvite(request, event, player)));
+  const now = new Date().toISOString();
+  const statements: D1PreparedStatement[] = [];
+  for (let index = 0; index < players.length; index += 1) {
+    const player = players[index];
+    const invite = prepared[index];
+    statements.push(
+      upsertInviteStatement(db, player, organizer, invite.tokenHash, invite.generated.expiresAt, now),
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        player.invite_id ? "rsvp_link_regenerated" : "rsvp_link_generated",
+        {
+          playerId: player.player_id,
+          playerName: player.display_name,
+          expiresAt: invite.generated.expiresAt,
+          generatedAsBatch: true,
+        },
+        now,
+      ),
+    );
+  }
+  await db.batch(statements);
+  return json({ generated: prepared.map((item) => item.generated) });
+}
+
+async function revoke(
+  db: D1Database,
+  eventId: string,
+  playerId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  requireMutableEvent(event);
+  const player = await requireInvitedPlayer(db, eventId, playerId);
+  if (!player.invite_id) return apiError(409, "NO_LINK", "This player does not have an RSVP link.");
+  const now = new Date().toISOString();
+  await db.batch([
+    db
+      .prepare("UPDATE event_invites SET revoked_at = ?1, updated_at = ?1 WHERE id = ?2")
+      .bind(now, player.invite_id),
+    auditStatement(
+      db,
+      eventId,
+      organizer,
+      "rsvp_link_revoked",
+      { playerId, playerName: player.display_name },
+      now,
+    ),
+  ]);
+  return detail(db, eventId);
+}
+
+async function patchEvent(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  requireMutableEvent(event);
+  const input = rsvpAdminEventPatchSchema.parse(await readJson(request));
+  const now = new Date().toISOString();
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE events
+         SET rsvp_location_visibility = ?1, updated_at = ?2
+         WHERE id = ?3`,
+      )
+      .bind(input.locationVisibility, now, eventId),
+    auditStatement(
+      db,
+      eventId,
+      organizer,
+      "rsvp_location_visibility_updated",
+      { from: event.rsvp_location_visibility, to: input.locationVisibility },
+      now,
+    ),
+  ]);
+  return detail(db, eventId);
+}
+
+export const onRequest: AppPagesFunction = async (context) => {
+  const request = context.request;
+  const method = request.method.toUpperCase();
+  const path = new URL(request.url).pathname.replace(/^\/rsvp-admin-api\/?/u, "");
+  const parts = path.split("/").filter(Boolean);
+
+  try {
+    if (parts[0] === "events" && parts[1] && parts.length === 2) {
+      if (method === "GET") return detail(context.env.DB, parts[1]);
+      if (method === "PATCH") {
+        return patchEvent(request, context.env.DB, parts[1], context.data.organizer);
+      }
+    }
+    if (
+      method === "POST" &&
+      parts[0] === "events" &&
+      parts[1] &&
+      parts[2] === "generate-all" &&
+      parts.length === 3
+    ) {
+      return generateAll(request, context.env.DB, parts[1], context.data.organizer);
+    }
+    if (
+      method === "POST" &&
+      parts[0] === "events" &&
+      parts[1] &&
+      parts[2] === "players" &&
+      parts[3] &&
+      parts[4] === "generate" &&
+      parts.length === 5
+    ) {
+      return generateOne(request, context.env.DB, parts[1], parts[3], context.data.organizer);
+    }
+    if (
+      method === "POST" &&
+      parts[0] === "events" &&
+      parts[1] &&
+      parts[2] === "players" &&
+      parts[3] &&
+      parts[4] === "revoke" &&
+      parts.length === 5
+    ) {
+      return revoke(context.env.DB, parts[1], parts[3], context.data.organizer);
+    }
+    return apiError(404, "NOT_FOUND", "RSVP administration route not found.");
+  } catch (error) {
+    if (error instanceof ZodError) return validationError(error);
+    if (error instanceof TypeError) return apiError(400, "BAD_REQUEST", error.message);
+    if (error instanceof Response) {
+      return apiError(error.status, "REQUEST_REJECTED", await error.text());
+    }
+    return apiError(500, "INTERNAL_ERROR", "The RSVP administration request could not be completed.");
+  }
+};

--- a/functions/rsvp-api/[[path]].ts
+++ b/functions/rsvp-api/[[path]].ts
@@ -1,0 +1,189 @@
+import { ZodError } from "zod";
+import {
+  hashRsvpToken,
+  isPlausibleRsvpToken,
+  publicRsvpResponseSchema,
+  type RsvpLocationVisibility,
+} from "../../shared/rsvp";
+import { apiError, json, readJson, validationError } from "../lib/http";
+import type { AppPagesFunction } from "../lib/types";
+
+const PUBLIC_RSVP_ORGANIZER_ID = "public-rsvp-service";
+const RESPONSE_COOLDOWN_MS = 5_000;
+
+interface PublicInviteRow {
+  invite_id: string;
+  event_player_id: string;
+  player_id: string;
+  player_name: string;
+  rsvp_status: "pending" | "yes" | "maybe" | "no";
+  expires_at: string;
+  revoked_at: string | null;
+  last_response_at: string | null;
+  response_count: number;
+  event_id: string;
+  title: string;
+  starts_at: string;
+  host_name: string | null;
+  location: string;
+  game_notes: string | null;
+  stakes_notes: string | null;
+  event_status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  rsvp_location_visibility: RsvpLocationVisibility;
+}
+
+async function findInvite(db: D1Database, token: string): Promise<PublicInviteRow | null> {
+  if (!isPlausibleRsvpToken(token)) return null;
+  const tokenHash = await hashRsvpToken(token);
+  return db
+    .prepare(
+      `SELECT ei.id AS invite_id, ei.event_player_id, ep.player_id,
+              p.display_name AS player_name, ep.rsvp_status,
+              ei.expires_at, ei.revoked_at, ei.last_response_at, ei.response_count,
+              e.id AS event_id, e.title, e.starts_at,
+              host.display_name AS host_name, e.location, e.game_notes,
+              e.stakes_notes, e.status AS event_status,
+              e.rsvp_location_visibility
+       FROM event_invites ei
+       JOIN event_players ep ON ep.id = ei.event_player_id
+       JOIN players p ON p.id = ep.player_id
+       JOIN events e ON e.id = ep.event_id
+       LEFT JOIN players host ON host.id = e.host_player_id
+       WHERE ei.token_hash = ?1`,
+    )
+    .bind(tokenHash)
+    .first<PublicInviteRow>();
+}
+
+function isExpired(invite: PublicInviteRow): boolean {
+  return new Date(invite.expires_at).getTime() <= Date.now();
+}
+
+function publicJson(invite: PublicInviteRow) {
+  const expired = isExpired(invite);
+  const revoked = Boolean(invite.revoked_at);
+  const eventAllowsResponse = invite.event_status === "open" || invite.event_status === "active";
+  const canRespond = !expired && !revoked && eventAllowsResponse;
+  const locationVisible =
+    invite.rsvp_location_visibility === "always" || invite.rsvp_status === "yes";
+
+  let stateMessage = "Choose yes, maybe, or no.";
+  if (invite.event_status === "draft") stateMessage = "Invitations are not open yet.";
+  if (invite.event_status === "completed") stateMessage = "This poker night is complete. Your recorded RSVP is shown below.";
+  if (invite.event_status === "cancelled") stateMessage = "This poker night was cancelled.";
+  if (invite.event_status === "archived") stateMessage = "This invitation is no longer active.";
+  if (expired) stateMessage = "This invitation link has expired.";
+  if (revoked) stateMessage = "This invitation link has been revoked.";
+
+  return {
+    player: {
+      id: invite.player_id,
+      displayName: invite.player_name,
+    },
+    event: {
+      id: invite.event_id,
+      title: invite.title,
+      startsAt: invite.starts_at,
+      hostName: invite.host_name,
+      location: locationVisible ? invite.location : null,
+      locationHiddenUntilYes: !locationVisible && invite.rsvp_location_visibility === "after_yes",
+      gameNotes: invite.game_notes,
+      stakesNotes: invite.stakes_notes,
+      status: invite.event_status,
+    },
+    rsvpStatus: invite.rsvp_status,
+    canRespond,
+    expiresAt: invite.expires_at,
+    lastResponseAt: invite.last_response_at,
+    stateMessage,
+  };
+}
+
+function invalidInvite(): Response {
+  return apiError(404, "INVALID_INVITE", "This invitation link is invalid or no longer active.");
+}
+
+async function getPublicInvite(db: D1Database, token: string): Promise<Response> {
+  const invite = await findInvite(db, token);
+  if (!invite || invite.revoked_at || isExpired(invite)) return invalidInvite();
+  return json(publicJson(invite));
+}
+
+async function respond(request: Request, db: D1Database, token: string): Promise<Response> {
+  const invite = await findInvite(db, token);
+  if (!invite || invite.revoked_at || isExpired(invite)) return invalidInvite();
+  if (invite.event_status !== "open" && invite.event_status !== "active") {
+    return apiError(409, "RSVP_LOCKED", "Responses are closed for this poker night.");
+  }
+
+  if (
+    invite.last_response_at &&
+    Date.now() - new Date(invite.last_response_at).getTime() < RESPONSE_COOLDOWN_MS
+  ) {
+    return apiError(429, "RATE_LIMITED", "Wait a few seconds before changing this response again.");
+  }
+
+  const input = publicRsvpResponseSchema.parse(await readJson(request));
+  const now = new Date().toISOString();
+  const previousStatus = invite.rsvp_status;
+  await db.batch([
+    db
+      .prepare(
+        `UPDATE event_players
+         SET rsvp_status = ?1, updated_at = ?2
+         WHERE id = ?3`,
+      )
+      .bind(input.rsvpStatus, now, invite.event_player_id),
+    db
+      .prepare(
+        `UPDATE event_invites
+         SET last_response_at = ?1,
+             response_count = response_count + 1,
+             updated_at = ?1
+         WHERE id = ?2`,
+      )
+      .bind(now, invite.invite_id),
+    db
+      .prepare(
+        `INSERT INTO event_audit_log
+         (id, event_id, organizer_id, action, details_json, created_at)
+         VALUES (?1, ?2, ?3, 'public_rsvp_updated', ?4, ?5)`,
+      )
+      .bind(
+        crypto.randomUUID(),
+        invite.event_id,
+        PUBLIC_RSVP_ORGANIZER_ID,
+        JSON.stringify({
+          source: "self_service_rsvp",
+          playerId: invite.player_id,
+          playerName: invite.player_name,
+          from: previousStatus,
+          to: input.rsvpStatus,
+        }),
+        now,
+      ),
+  ]);
+
+  const updated = await findInvite(db, token);
+  if (!updated) return invalidInvite();
+  return json(publicJson(updated));
+}
+
+export const onRequest: AppPagesFunction = async (context) => {
+  const request = context.request;
+  const method = request.method.toUpperCase();
+  const path = new URL(request.url).pathname.replace(/^\/rsvp-api\/?/u, "");
+  const parts = path.split("/").filter(Boolean);
+  const token = parts[0];
+
+  try {
+    if (!token || parts.length !== 1) return invalidInvite();
+    if (method === "GET") return getPublicInvite(context.env.DB, token);
+    if (method === "POST") return respond(request, context.env.DB, token);
+    return apiError(405, "METHOD_NOT_ALLOWED", "This RSVP action is not supported.");
+  } catch (error) {
+    if (error instanceof ZodError) return validationError(error);
+    if (error instanceof TypeError) return apiError(400, "BAD_REQUEST", error.message);
+    return apiError(500, "INTERNAL_ERROR", "The RSVP request could not be completed.");
+  }
+};

--- a/migrations/0004_private_rsvp_links.sql
+++ b/migrations/0004_private_rsvp_links.sql
@@ -1,0 +1,27 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE events
+ADD COLUMN rsvp_location_visibility TEXT NOT NULL DEFAULT 'always'
+CHECK (rsvp_location_visibility IN ('always', 'after_yes'));
+
+CREATE TABLE event_invites (
+  id TEXT PRIMARY KEY,
+  event_player_id TEXT NOT NULL UNIQUE REFERENCES event_players(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL UNIQUE,
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  last_response_at TEXT,
+  response_count INTEGER NOT NULL DEFAULT 0 CHECK (response_count >= 0),
+  created_by_organizer_id TEXT NOT NULL REFERENCES organizers(id),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX event_invites_token_idx ON event_invites(token_hash);
+CREATE INDEX event_invites_expiry_idx ON event_invites(expires_at, revoked_at);
+
+INSERT OR IGNORE INTO organizers
+  (id, email, display_name, role, active, created_at, updated_at)
+VALUES
+  ('public-rsvp-service', 'public-rsvp@system.invalid', 'Public RSVP service', 'organizer', 0,
+   '2026-07-22T00:00:00.000Z', '2026-07-22T00:00:00.000Z');

--- a/shared/app-shell.ts
+++ b/shared/app-shell.ts
@@ -13,9 +13,7 @@ export interface HealthReport {
 }
 
 export function eventIdFromPath(pathname: string): string | null {
-  const match = pathname.match(
-    /^\/(?:events|ops\/events|money\/events|rsvp\/events)\/([0-9a-f-]+)(?:\/|$)/iu,
-  );
+  const match = pathname.match(/^\/(?:events|ops\/events|money\/events)\/([0-9a-f-]+)(?:\/|$)/iu);
   return match?.[1] ?? null;
 }
 

--- a/shared/app-shell.ts
+++ b/shared/app-shell.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "2.2.0";
-export const REQUIRED_SCHEMA_VERSION = 3;
+export const APP_VERSION = "2.3.0";
+export const REQUIRED_SCHEMA_VERSION = 4;
 
 export interface HealthReport {
   ok: boolean;
@@ -13,7 +13,9 @@ export interface HealthReport {
 }
 
 export function eventIdFromPath(pathname: string): string | null {
-  const match = pathname.match(/^\/(?:events|ops\/events|money\/events)\/([0-9a-f-]+)(?:\/|$)/i);
+  const match = pathname.match(
+    /^\/(?:events|ops\/events|money\/events|rsvp\/events)\/([0-9a-f-]+)(?:\/|$)/iu,
+  );
   return match?.[1] ?? null;
 }
 

--- a/shared/rsvp.ts
+++ b/shared/rsvp.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export const publicRsvpStatuses = ["yes", "maybe", "no"] as const;
+export type PublicRsvpStatus = (typeof publicRsvpStatuses)[number];
+
+export const rsvpLocationVisibilities = ["always", "after_yes"] as const;
+export type RsvpLocationVisibility = (typeof rsvpLocationVisibilities)[number];
+
+export const publicRsvpResponseSchema = z.object({
+  rsvpStatus: z.enum(publicRsvpStatuses),
+});
+
+export const rsvpAdminEventPatchSchema = z.object({
+  locationVisibility: z.enum(rsvpLocationVisibilities),
+});
+
+export interface PersonalizedInviteInput {
+  playerName: string;
+  title: string;
+  startsAt: string;
+  hostName: string | null;
+  location: string;
+  locationVisibility: RsvpLocationVisibility;
+  gameNotes: string | null;
+  stakesNotes: string | null;
+  rsvpUrl: string;
+}
+
+export function invitationExpiresAt(startsAt: string): string {
+  const starts = new Date(startsAt);
+  return new Date(starts.getTime() + 36 * 60 * 60 * 1000).toISOString();
+}
+
+export function buildPersonalizedInviteText(input: PersonalizedInviteInput, locale = "en-US"): string {
+  const when = new Intl.DateTimeFormat(locale, {
+    dateStyle: "full",
+    timeStyle: "short",
+  }).format(new Date(input.startsAt));
+  const lines = [`${input.playerName}, you are invited to ${input.title}.`, when];
+  if (input.hostName) lines.push(`Host: ${input.hostName}`);
+  if (input.locationVisibility === "always" && input.location) {
+    lines.push(`Location: ${input.location}`);
+  } else if (input.locationVisibility === "after_yes") {
+    lines.push("The address will appear after you RSVP yes.");
+  }
+  if (input.gameNotes) lines.push(`Game: ${input.gameNotes}`);
+  if (input.stakesNotes) lines.push(`Stakes: ${input.stakesNotes}`);
+  lines.push(`RSVP yes, maybe, or no: ${input.rsvpUrl}`);
+  return lines.join("\n");
+}
+
+export function createRsvpToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+export async function hashRsvpToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function isPlausibleRsvpToken(token: string): boolean {
+  return /^[A-Za-z0-9_-]{32,128}$/u.test(token);
+}

--- a/src/Rsvp.tsx
+++ b/src/Rsvp.tsx
@@ -1,0 +1,444 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import type { PublicRsvpStatus, RsvpLocationVisibility } from "../shared/rsvp";
+import { api } from "./api";
+
+interface PublicRsvpDetail {
+  player: { id: string; displayName: string };
+  event: {
+    id: string;
+    title: string;
+    startsAt: string;
+    hostName: string | null;
+    location: string | null;
+    locationHiddenUntilYes: boolean;
+    gameNotes: string | null;
+    stakesNotes: string | null;
+    status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+  };
+  rsvpStatus: "pending" | PublicRsvpStatus;
+  canRespond: boolean;
+  expiresAt: string;
+  lastResponseAt: string | null;
+  stateMessage: string;
+}
+
+interface AdminInviteState {
+  exists: boolean;
+  active: boolean;
+  expired: boolean;
+  revoked: boolean;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  lastResponseAt: string | null;
+  responseCount: number;
+  createdAt: string | null;
+}
+
+interface AdminRsvpPlayer {
+  eventPlayerId: string;
+  playerId: string;
+  displayName: string;
+  invitationStatus: "invited" | "not_invited";
+  rsvpStatus: "pending" | PublicRsvpStatus;
+  invite: AdminInviteState;
+}
+
+interface AdminRsvpDetail {
+  event: {
+    id: string;
+    title: string;
+    startsAt: string;
+    hostName: string | null;
+    location: string;
+    gameNotes: string | null;
+    stakesNotes: string | null;
+    status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
+    locationVisibility: RsvpLocationVisibility;
+  };
+  players: AdminRsvpPlayer[];
+}
+
+interface GeneratedInvite {
+  playerId: string;
+  playerName: string;
+  url: string;
+  inviteText: string;
+  expiresAt: string;
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "full",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatShortDate(value: string | null): string {
+  if (!value) return "Never";
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The request could not be completed.";
+}
+
+async function copyText(value: string): Promise<void> {
+  await navigator.clipboard.writeText(value);
+}
+
+function RsvpChoice({
+  status,
+  current,
+  disabled,
+  onSelect,
+}: {
+  status: PublicRsvpStatus;
+  current: PublicRsvpDetail["rsvpStatus"];
+  disabled: boolean;
+  onSelect: (status: PublicRsvpStatus) => void;
+}) {
+  const labels: Record<PublicRsvpStatus, string> = {
+    yes: "Yes, I’m in",
+    maybe: "Maybe",
+    no: "No",
+  };
+  return (
+    <button
+      className={`rsvp-choice rsvp-choice-${status} ${current === status ? "is-selected" : ""}`}
+      type="button"
+      disabled={disabled}
+      aria-pressed={current === status}
+      onClick={() => onSelect(status)}
+    >
+      {labels[status]}
+    </button>
+  );
+}
+
+export function PublicRsvpPage() {
+  const { token = "" } = useParams();
+  const [detail, setDetail] = useState<PublicRsvpDetail>();
+  const [error, setError] = useState<unknown>();
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string>();
+
+  const load = async () => {
+    try {
+      setDetail(await api<PublicRsvpDetail>(`/rsvp-api/${encodeURIComponent(token)}`));
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [token]);
+
+  async function respond(status: PublicRsvpStatus) {
+    setSaving(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      const next = await api<PublicRsvpDetail>(`/rsvp-api/${encodeURIComponent(token)}`, {
+        method: "POST",
+        body: JSON.stringify({ rsvpStatus: status }),
+      });
+      setDetail(next);
+      setMessage(`Your response is now ${status}.`);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (error && !detail) {
+    return (
+      <main className="public-rsvp-shell">
+        <section className="public-rsvp-card public-rsvp-error" role="alert">
+          <div className="public-rsvp-brand"><span aria-hidden="true">♠</span><strong>BroTM Poker</strong></div>
+          <h1>Invitation unavailable</h1>
+          <p>{errorMessage(error)}</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (!detail) {
+    return <main className="public-rsvp-shell"><div className="public-rsvp-card">Loading invitation…</div></main>;
+  }
+
+  return (
+    <main className="public-rsvp-shell">
+      <section className="public-rsvp-card">
+        <div className="public-rsvp-brand"><span aria-hidden="true">♠</span><strong>BroTM Poker</strong></div>
+        <p className="eyebrow">Private invitation for {detail.player.displayName}</p>
+        <h1>{detail.event.title}</h1>
+        <div className="public-rsvp-details">
+          <div><span>When</span><strong>{formatDate(detail.event.startsAt)}</strong></div>
+          {detail.event.hostName ? <div><span>Host</span><strong>{detail.event.hostName}</strong></div> : null}
+          <div>
+            <span>Location</span>
+            <strong>
+              {detail.event.location ??
+                (detail.event.locationHiddenUntilYes ? "Shown after you RSVP yes" : "Not provided")}
+            </strong>
+          </div>
+          {detail.event.gameNotes ? <div><span>Game</span><strong>{detail.event.gameNotes}</strong></div> : null}
+          {detail.event.stakesNotes ? <div><span>Stakes</span><strong>{detail.event.stakesNotes}</strong></div> : null}
+        </div>
+
+        <div className="public-rsvp-state">
+          <span>Current response</span>
+          <strong>{detail.rsvpStatus === "pending" ? "Not answered" : detail.rsvpStatus}</strong>
+          <p>{detail.stateMessage}</p>
+        </div>
+
+        {error ? <div className="state-card state-error" role="alert">{errorMessage(error)}</div> : null}
+        {message ? <div className="state-card state-success" role="status">{message}</div> : null}
+
+        <div className="rsvp-choice-grid" aria-label="RSVP response">
+          {(["yes", "maybe", "no"] as const).map((status) => (
+            <RsvpChoice
+              key={status}
+              status={status}
+              current={detail.rsvpStatus}
+              disabled={saving || !detail.canRespond}
+              onSelect={(next) => void respond(next)}
+            />
+          ))}
+        </div>
+        <p className="public-rsvp-footnote">
+          This private link expires after the poker night. Do not forward it to another person.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+function inviteStatus(player: AdminRsvpPlayer): string {
+  if (!player.invite.exists) return "No link generated";
+  if (player.invite.revoked) return "Revoked";
+  if (player.invite.expired) return "Expired";
+  if (player.invite.active) return "Active";
+  return "Inactive";
+}
+
+export function RsvpAdminPage() {
+  const { id = "" } = useParams();
+  const [detail, setDetail] = useState<AdminRsvpDetail>();
+  const [generated, setGenerated] = useState<Record<string, GeneratedInvite>>({});
+  const [error, setError] = useState<unknown>();
+  const [message, setMessage] = useState<string>();
+  const [saving, setSaving] = useState(false);
+
+  const load = async () => {
+    try {
+      setDetail(await api<AdminRsvpDetail>(`/rsvp-admin-api/events/${id}`));
+      setError(undefined);
+    } catch (caught) {
+      setError(caught);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [id]);
+
+  const invitedPlayers = useMemo(
+    () => detail?.players.filter((player) => player.invitationStatus === "invited") ?? [],
+    [detail],
+  );
+
+  async function generateOne(player: AdminRsvpPlayer) {
+    setSaving(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      const response = await api<{ generated: GeneratedInvite }>(
+        `/rsvp-admin-api/events/${id}/players/${player.playerId}/generate`,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      setGenerated((current) => ({ ...current, [player.playerId]: response.generated }));
+      await copyText(response.generated.inviteText);
+      setMessage(`A new private link for ${player.displayName} was generated and copied.`);
+      await load();
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function generateAll() {
+    setSaving(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      const response = await api<{ generated: GeneratedInvite[] }>(
+        `/rsvp-admin-api/events/${id}/generate-all`,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      const next = Object.fromEntries(response.generated.map((invite) => [invite.playerId, invite]));
+      setGenerated(next);
+      await copyText(response.generated.map((invite) => invite.inviteText).join("\n\n---\n\n"));
+      setMessage(`${response.generated.length} personalized invitations were generated and copied.`);
+      await load();
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function revoke(player: AdminRsvpPlayer) {
+    if (!window.confirm(`Revoke ${player.displayName}’s current RSVP link?`)) return;
+    setSaving(true);
+    setError(undefined);
+    try {
+      setDetail(
+        await api<AdminRsvpDetail>(
+          `/rsvp-admin-api/events/${id}/players/${player.playerId}/revoke`,
+          { method: "POST", body: JSON.stringify({}) },
+        ),
+      );
+      setGenerated((current) => {
+        const next = { ...current };
+        delete next[player.playerId];
+        return next;
+      });
+      setMessage(`${player.displayName}’s RSVP link was revoked.`);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveLocationVisibility(value: RsvpLocationVisibility) {
+    setSaving(true);
+    setError(undefined);
+    try {
+      setDetail(
+        await api<AdminRsvpDetail>(`/rsvp-admin-api/events/${id}`, {
+          method: "PATCH",
+          body: JSON.stringify({ locationVisibility: value }),
+        }),
+      );
+      setGenerated({});
+      setMessage("RSVP address visibility was updated. Regenerate links before sending invitations.");
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function recopy(player: AdminRsvpPlayer) {
+    const invite = generated[player.playerId];
+    if (!invite) return;
+    try {
+      await copyText(invite.inviteText);
+      setMessage(`${player.displayName}’s invitation was copied again.`);
+    } catch (caught) {
+      setError(caught);
+    }
+  }
+
+  if (error && !detail) return <div className="state-card state-error">{errorMessage(error)}</div>;
+  if (!detail) return <div className="state-card">Loading RSVP links…</div>;
+
+  const locked = ["completed", "cancelled", "archived"].includes(detail.event.status);
+
+  return (
+    <div className="rsvp-admin-page">
+      <div className="page-header">
+        <div>
+          <p className="eyebrow">Private self-service RSVP</p>
+          <h1>{detail.event.title}</h1>
+          <p className="rsvp-admin-subtitle">Generate personalized links without giving players organizer access.</p>
+        </div>
+        <div className="page-actions">
+          <Link className="button button-secondary" to={`/ops/events/${id}`}>Invite summary</Link>
+          <button className="button button-primary" type="button" disabled={saving || locked || !invitedPlayers.length} onClick={() => void generateAll()}>
+            Generate all and copy
+          </button>
+        </div>
+      </div>
+
+      {error ? <div className="state-card state-error" role="alert">{errorMessage(error)}</div> : null}
+      {message ? <div className="state-card state-success" role="status">{message}</div> : null}
+
+      <section className="panel rsvp-privacy-panel">
+        <div>
+          <p className="eyebrow">Address privacy</p>
+          <h2>When should players see the location?</h2>
+          <p>Changing this setting does not reveal existing token values. Regenerate invitation text after changing it.</p>
+        </div>
+        <select
+          value={detail.event.locationVisibility}
+          disabled={saving || locked}
+          onChange={(change) => void saveLocationVisibility(change.target.value as RsvpLocationVisibility)}
+        >
+          <option value="always">Always show the address</option>
+          <option value="after_yes">Show only after RSVP yes</option>
+        </select>
+      </section>
+
+      {locked ? (
+        <div className="state-card">This event is locked. Recorded responses remain visible, but links cannot be generated, regenerated, or revoked.</div>
+      ) : null}
+
+      <section className="panel">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Personalized invitations</p><h2>Invited players</h2></div>
+          <span>{invitedPlayers.length}</span>
+        </div>
+        <p className="rsvp-token-note">
+          Raw tokens are never stored. Generating a link replaces the player’s previous link, and the new invitation is available to copy during this browser session.
+        </p>
+        <div className="rsvp-admin-list">
+          {invitedPlayers.map((player) => {
+            const freshlyGenerated = generated[player.playerId];
+            return (
+              <article className="rsvp-admin-row" key={player.playerId}>
+                <div className="rsvp-admin-player">
+                  <strong>{player.displayName}</strong>
+                  <span>RSVP: {player.rsvpStatus}</span>
+                </div>
+                <div className="rsvp-admin-metadata">
+                  <span className={`rsvp-link-status ${player.invite.active ? "is-active" : ""}`}>{inviteStatus(player)}</span>
+                  <small>Last response: {formatShortDate(player.invite.lastResponseAt)}</small>
+                  {player.invite.expiresAt ? <small>Expires: {formatShortDate(player.invite.expiresAt)}</small> : null}
+                </div>
+                <div className="rsvp-admin-actions">
+                  <button className="button button-primary" type="button" disabled={saving || locked} onClick={() => void generateOne(player)}>
+                    {player.invite.exists ? "Regenerate and copy" : "Generate and copy"}
+                  </button>
+                  <button className="button button-secondary" type="button" disabled={!freshlyGenerated} onClick={() => void recopy(player)}>
+                    Copy again
+                  </button>
+                  <button className="button button-danger" type="button" disabled={saving || locked || !player.invite.active} onClick={() => void revoke(player)}>
+                    Revoke
+                  </button>
+                </div>
+                {freshlyGenerated ? (
+                  <div className="rsvp-generated-preview">
+                    <strong>Fresh link generated</strong>
+                    <code>{freshlyGenerated.url}</code>
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+          {!invitedPlayers.length ? <div className="state-card">Mark players as invited on the event roster first.</div> : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -28,7 +28,7 @@ function ViewRouter() {
     <Routes>
       <Route path="/money/events/:id" element={<MoneyEventPage />} />
       <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
-      <Route path="/rsvp/events/:id" element={<RsvpAdminPage />} />
+      <Route path="/events/:id/rsvp-links" element={<RsvpAdminPage />} />
       <Route path="*" element={<App />} />
     </Routes>
   );
@@ -131,7 +131,7 @@ export function UnifiedApp() {
         <nav className="event-workspace-nav" aria-label="Poker night sections">
           <Link className={location.pathname === `/events/${eventId}` ? "active" : ""} to={`/events/${eventId}`}>Details & live</Link>
           <Link className={location.pathname === `/ops/events/${eventId}` ? "active" : ""} to={`/ops/events/${eventId}`}>Invites & RSVP</Link>
-          <Link className={location.pathname === `/rsvp/events/${eventId}` ? "active" : ""} to={`/rsvp/events/${eventId}`}>RSVP links</Link>
+          <Link className={location.pathname === `/events/${eventId}/rsvp-links` ? "active" : ""} to={`/events/${eventId}/rsvp-links`}>RSVP links</Link>
           <Link className={location.pathname === `/money/events/${eventId}` ? "active" : ""} to={`/money/events/${eventId}`}>Money</Link>
         </nav>
       ) : null}

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -10,6 +10,7 @@ import { App } from "./App";
 import { api, ApiError } from "./api";
 import { MoneyEventPage, PlayerMoneyPage } from "./Money";
 import { OperationsApp } from "./Operations";
+import { RsvpAdminPage } from "./Rsvp";
 import type { Organizer } from "./types";
 
 function errorMessage(error: unknown): string {
@@ -27,6 +28,7 @@ function ViewRouter() {
     <Routes>
       <Route path="/money/events/:id" element={<MoneyEventPage />} />
       <Route path="/money/players/:id" element={<PlayerMoneyPage />} />
+      <Route path="/rsvp/events/:id" element={<RsvpAdminPage />} />
       <Route path="*" element={<App />} />
     </Routes>
   );
@@ -129,6 +131,7 @@ export function UnifiedApp() {
         <nav className="event-workspace-nav" aria-label="Poker night sections">
           <Link className={location.pathname === `/events/${eventId}` ? "active" : ""} to={`/events/${eventId}`}>Details & live</Link>
           <Link className={location.pathname === `/ops/events/${eventId}` ? "active" : ""} to={`/ops/events/${eventId}`}>Invites & RSVP</Link>
+          <Link className={location.pathname === `/rsvp/events/${eventId}` ? "active" : ""} to={`/rsvp/events/${eventId}`}>RSVP links</Link>
           <Link className={location.pathname === `/money/events/${eventId}` ? "active" : ""} to={`/money/events/${eventId}`}>Money</Link>
         </nav>
       ) : null}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { PublicRsvpPage } from "./Rsvp";
 import { UnifiedApp } from "./UnifiedApp";
 import "./styles.css";
 import "./editing.css";
 import "./money.css";
 import "./operations.css";
 import "./unified.css";
+import "./rsvp.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Application root was not found");
@@ -14,7 +16,10 @@ if (!root) throw new Error("Application root was not found");
 createRoot(root).render(
   <StrictMode>
     <BrowserRouter>
-      <UnifiedApp />
+      <Routes>
+        <Route path="/rsvp/:token" element={<PublicRsvpPage />} />
+        <Route path="*" element={<UnifiedApp />} />
+      </Routes>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/src/rsvp.css
+++ b/src/rsvp.css
@@ -1,0 +1,255 @@
+.public-rsvp-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background:
+    radial-gradient(circle at top right, rgba(215, 178, 103, 0.17), transparent 30rem),
+    radial-gradient(circle at bottom left, rgba(80, 130, 86, 0.15), transparent 28rem),
+    var(--bg);
+}
+
+.public-rsvp-card {
+  width: min(680px, 100%);
+  display: grid;
+  gap: 1.25rem;
+  padding: clamp(1.25rem, 5vw, 2.5rem);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: rgba(12, 15, 11, 0.97);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.42);
+}
+
+.public-rsvp-card h1 {
+  margin: -0.25rem 0 0;
+  font-size: clamp(2.25rem, 9vw, 4.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+}
+
+.public-rsvp-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--gold);
+}
+
+.public-rsvp-brand span {
+  font-size: 1.5rem;
+}
+
+.public-rsvp-details {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.public-rsvp-details > div {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.public-rsvp-details span,
+.public-rsvp-state span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.public-rsvp-state {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border: 1px solid rgba(215, 178, 103, 0.35);
+  border-radius: 14px;
+  background: rgba(215, 178, 103, 0.06);
+}
+
+.public-rsvp-state strong {
+  font-size: 1.4rem;
+  text-transform: capitalize;
+}
+
+.public-rsvp-state p,
+.public-rsvp-footnote,
+.rsvp-admin-subtitle,
+.rsvp-token-note,
+.rsvp-privacy-panel p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.rsvp-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.rsvp-choice {
+  min-height: 64px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.rsvp-choice:hover:not(:disabled),
+.rsvp-choice.is-selected {
+  border-color: var(--gold);
+  transform: translateY(-1px);
+}
+
+.rsvp-choice-yes.is-selected {
+  border-color: var(--green);
+  background: rgba(150, 199, 136, 0.12);
+}
+
+.rsvp-choice-maybe.is-selected {
+  background: rgba(215, 178, 103, 0.12);
+}
+
+.rsvp-choice-no.is-selected {
+  border-color: var(--red);
+  background: rgba(224, 121, 116, 0.1);
+}
+
+.rsvp-choice:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.public-rsvp-footnote {
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+.public-rsvp-error {
+  text-align: center;
+}
+
+.rsvp-admin-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.rsvp-privacy-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 0.45fr);
+  gap: 1rem;
+  align-items: end;
+}
+
+.rsvp-privacy-panel select {
+  width: 100%;
+}
+
+.rsvp-admin-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.rsvp-admin-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.75fr) minmax(180px, 0.7fr) minmax(300px, 1.25fr);
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.rsvp-admin-player,
+.rsvp-admin-metadata {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.rsvp-admin-player span,
+.rsvp-admin-metadata small {
+  color: var(--muted);
+}
+
+.rsvp-link-status {
+  width: fit-content;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.rsvp-link-status.is-active {
+  border-color: rgba(150, 199, 136, 0.5);
+  color: var(--green);
+}
+
+.rsvp-admin-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 0.85fr) minmax(0, 0.7fr);
+  gap: 0.55rem;
+}
+
+.rsvp-generated-preview {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(215, 178, 103, 0.35);
+  border-radius: 10px;
+  background: rgba(215, 178, 103, 0.055);
+}
+
+.rsvp-generated-preview code {
+  overflow-wrap: anywhere;
+  color: var(--gold);
+}
+
+@media (max-width: 900px) {
+  .rsvp-admin-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rsvp-admin-actions {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 620px) {
+  .public-rsvp-shell {
+    padding: 0.5rem;
+  }
+
+  .public-rsvp-card {
+    border-radius: 16px;
+  }
+
+  .public-rsvp-details > div,
+  .rsvp-privacy-panel,
+  .rsvp-admin-row,
+  .rsvp-admin-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .rsvp-choice-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .rsvp-choice {
+    min-height: 58px;
+  }
+
+  .rsvp-admin-actions {
+    grid-column: auto;
+  }
+}

--- a/tests/app-shell.test.ts
+++ b/tests/app-shell.test.ts
@@ -9,9 +9,9 @@ describe("event workspace routing", () => {
   it("finds the event id across unified event surfaces", () => {
     const id = "8d2f4b93-7dd5-4a3f-9a2d-91d1554e5b20";
     expect(eventIdFromPath(`/events/${id}`)).toBe(id);
+    expect(eventIdFromPath(`/events/${id}/rsvp-links`)).toBe(id);
     expect(eventIdFromPath(`/ops/events/${id}`)).toBe(id);
     expect(eventIdFromPath(`/money/events/${id}`)).toBe(id);
-    expect(eventIdFromPath(`/rsvp/events/${id}`)).toBe(id);
   });
 
   it("does not treat list, public RSVP, and settings pages as event workspaces", () => {

--- a/tests/app-shell.test.ts
+++ b/tests/app-shell.test.ts
@@ -11,12 +11,14 @@ describe("event workspace routing", () => {
     expect(eventIdFromPath(`/events/${id}`)).toBe(id);
     expect(eventIdFromPath(`/ops/events/${id}`)).toBe(id);
     expect(eventIdFromPath(`/money/events/${id}`)).toBe(id);
+    expect(eventIdFromPath(`/rsvp/events/${id}`)).toBe(id);
   });
 
-  it("does not treat list and settings pages as event workspaces", () => {
+  it("does not treat list, public RSVP, and settings pages as event workspaces", () => {
     expect(eventIdFromPath("/events")).toBeNull();
     expect(eventIdFromPath("/ops/settings")).toBeNull();
     expect(eventIdFromPath("/money/players/player-id")).toBeNull();
+    expect(eventIdFromPath("/rsvp/private-token-value")).toBeNull();
   });
 });
 
@@ -28,9 +30,9 @@ describe("deployment health messaging", () => {
   });
 
   it("names missing schema requirements", () => {
-    const message = healthMessage(2, ["app_settings"], ["events.capacity"]);
-    expect(message).toContain("app_settings");
-    expect(message).toContain("events.capacity");
+    const message = healthMessage(3, ["event_invites"], ["events.rsvp_location_visibility"]);
+    expect(message).toContain("event_invites");
+    expect(message).toContain("events.rsvp_location_visibility");
     expect(message).toContain(`migration ${REQUIRED_SCHEMA_VERSION}`);
   });
 });

--- a/tests/rsvp.test.ts
+++ b/tests/rsvp.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPersonalizedInviteText,
+  hashRsvpToken,
+  invitationExpiresAt,
+  isPlausibleRsvpToken,
+  publicRsvpResponseSchema,
+} from "../shared/rsvp";
+
+describe("private RSVP invitation helpers", () => {
+  it("omits the address when it is hidden until yes", () => {
+    const text = buildPersonalizedInviteText({
+      playerName: "Ryan",
+      title: "Friday Poker Night",
+      startsAt: "2026-07-24T19:00:00-06:00",
+      hostName: "Sterling",
+      location: "123 Private Street",
+      locationVisibility: "after_yes",
+      gameNotes: "Dealer's choice",
+      stakesNotes: "$10 buy-in",
+      rsvpUrl: "https://poker.skpfam.com/rsvp/example-token",
+    });
+
+    expect(text).not.toContain("123 Private Street");
+    expect(text).toContain("address will appear after you RSVP yes");
+    expect(text).toContain("/rsvp/example-token");
+  });
+
+  it("expires links 36 hours after the event starts", () => {
+    expect(invitationExpiresAt("2026-07-24T19:00:00.000Z")).toBe("2026-07-26T07:00:00.000Z");
+  });
+
+  it("accepts only yes, maybe, or no responses", () => {
+    expect(publicRsvpResponseSchema.parse({ rsvpStatus: "yes" })).toEqual({ rsvpStatus: "yes" });
+    expect(() => publicRsvpResponseSchema.parse({ rsvpStatus: "pending" })).toThrow();
+  });
+
+  it("validates token shape and hashes deterministically", async () => {
+    const token = "abcdefghijklmnopqrstuvwxyzABCDEFGH1234567890_-";
+    expect(isPlausibleRsvpToken(token)).toBe(true);
+    expect(isPlausibleRsvpToken("too-short")).toBe(false);
+    expect(await hashRsvpToken(token)).toBe(await hashRsvpToken(token));
+  });
+});


### PR DESCRIPTION
## What changed

- Added player-specific, passwordless RSVP links with Yes, Maybe, and No responses.
- Added a public mobile RSVP page that exposes only the invited player and event details.
- Added organizer controls to generate, regenerate, copy, batch-generate, and revoke links.
- Added optional address privacy until a player responds Yes.
- Stored only SHA-256 token hashes in D1. Raw tokens are returned only at generation time.
- Added link expiry, response cooldowns, last-response timestamps, and response counts.
- Added event audit entries for every public response and organizer link action.
- Added schema-aware deployment health checks and rollout documentation.

## Database

Requires `migrations/0004_private_rsvp_links.sql` before production use.

## Cloudflare Access

Production also requires narrowly scoped Bypass Everyone applications for:

- `poker.skpfam.com/rsvp/*`
- `poker.skpfam.com/rsvp-api/*`
- `poker.skpfam.com/assets/*`

The organizer routes and `/rsvp-admin-api/*` remain protected. Full steps are in `docs/PRIVATE_RSVP_ROLLOUT.md`.