### PR TITLE
Fix shortcut icon cropping

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Plan, run, and close BroTM Poker nights." />
     <meta name="theme-color" content="#075b3b" />
-    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="/icon.svg?v=2" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>BroTM Poker</title>
   </head>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -8,7 +8,7 @@
   "background_color": "#075b3b",
   "theme_color": "#075b3b",
   "icons": [
-    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png", "purpose": "any maskable" },
-    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any" }
+    { "src": "/apple-touch-icon.png?v=2", "sizes": "180x180", "type": "image/png", "purpose": "any" },
+    { "src": "/icon.svg?v=2", "sizes": "any", "type": "image/svg+xml", "purpose": "any" }
   ]
 }


### PR DESCRIPTION
The previous branding PR was merged before the final shortcut-icon fixes were added. This follow-up removes the `maskable` hint that caused the spade and Bro wordmark to crop, corrects the icon dimensions, and version-busts the shortcut URLs so installed Chrome/Safari shortcuts fetch the corrected artwork.