### PR TITLE
Add email invitation delivery workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ npm run dev
 
 Create `.dev.vars` and seed a local organizer before starting the application. See [`docs/CLOUDFLARE_V2_SETUP.md`](docs/CLOUDFLARE_V2_SETUP.md).
 
+Local and preview construction use `AUTH_MODE=public` and `DELIVERY_MODE=log`, so organizer login and provider credentials do not block testing. The current delivery milestone sends manual email invitations through Resend; scheduled reminders and SMS remain follow-on work using the same delivery records and token behavior.
+
+The reminder worker is retained as follow-on work and is not required for the email-first release. If you are specifically developing that extension, run it locally with:
+
+```bash
+npm run dev:worker
+```
+
 ## Cloudflare Pages
 
 - Build command: `npm run build`
@@ -44,3 +52,5 @@ The Production environment needs one D1 binding named `DB`, pointing to `brotm-p
 - [`docs/PRODUCT_SPEC_V2.md`](docs/PRODUCT_SPEC_V2.md): approved product definition
 - [`docs/FIRST_SLICE_WORK_ORDER.md`](docs/FIRST_SLICE_WORK_ORDER.md): implementation scope and acceptance criteria
 - [`docs/DECISION_LOG.md`](docs/DECISION_LOG.md): durable product and architecture decisions
+- [`docs/MOBILE_FIRST_ROADMAP.md`](docs/MOBILE_FIRST_ROADMAP.md): phone-first features, automation, and follow-on work
+- [`wrangler.worker.jsonc`](wrangler.worker.jsonc): reminder Worker and Cron Trigger configuration

--- a/docs/APPROVAL_CHECKLIST.md
+++ b/docs/APPROVAL_CHECKLIST.md
@@ -6,7 +6,7 @@ Approve or revise these decisions before implementation begins.
 - [ ] The core workflow is plan, invite, run, close, and review.
 - [ ] The MVP supports trusted organizers only.
 - [ ] Players do not need accounts in the MVP.
-- [ ] The app prepares invitation information but does not send email or SMS initially.
+- [x] The app manually sends invitation email and records delivery results.
 - [ ] Attendance tracking is required.
 - [ ] Money tracking is optional by event.
 - [ ] The first vertical slice excludes money tracking.

--- a/docs/CLOUDFLARE_V2_SETUP.md
+++ b/docs/CLOUDFLARE_V2_SETUP.md
@@ -1,6 +1,6 @@
 # Cloudflare v2 setup
 
-This guide connects the first BroTM Poker application slice to one remote D1 database and Cloudflare Access without committing account identifiers or personal email addresses.
+This guide connects BroTM Poker to one remote D1 database, Cloudflare Access, provider-backed invitation delivery, and the reminder Cron Worker without committing account identifiers or personal email addresses.
 
 ## 1. Create one D1 database
 
@@ -81,8 +81,20 @@ For the **Production** environment, add:
 - `TEAM_DOMAIN`: the Zero Trust team domain without `https://`
 - `POLICY_AUD`: the Access application audience tag
 - `ENVIRONMENT`: `production`
+- `AUTH_MODE`: `access`
+- `DELIVERY_MODE`: `live`
+- `PUBLIC_APP_ORIGIN`: the public application origin
 
-For Preview, `ENVIRONMENT=preview` may be set, but no production D1 binding should be attached.
+Add these as encrypted Pages secrets for live delivery:
+
+- `RESEND_API_KEY`
+- `EMAIL_FROM`
+
+SMS provider secrets and the reminder Worker are intentionally not required for the email-first invitation release. They remain follow-on work and should not block the first live email test.
+
+Keep the application and Resend tracking DNS records separate. The application hostname `poker.skpfam.com` must continue pointing to the Cloudflare Pages project. If Resend tracking is enabled, use the separate `clicks-poker.skpfam.com` hostname for the Resend tracking CNAME; never replace the application `poker` record with the Resend tracking target.
+
+For local and preview construction, use `AUTH_MODE=public`, `ENVIRONMENT=development`, and `DEV_ORGANIZER_EMAIL=<ORGANIZER_EMAIL>`. Set `DELIVERY_MODE=log` to use the development delivery sink. No Cloudflare Access application is required for these test environments.
 
 ## 7. Local development identity
 
@@ -90,9 +102,12 @@ Create a `.dev.vars` file:
 
 ```text
 ENVIRONMENT=development
+AUTH_MODE=public
+DELIVERY_MODE=log
 DEV_ORGANIZER_EMAIL=<ORGANIZER_EMAIL>
 TEAM_DOMAIN=unused-locally
 POLICY_AUD=unused-locally
+PUBLIC_APP_ORIGIN=http://localhost:8788
 ```
 
 The local organizer email must exist in the local D1 database.
@@ -123,3 +138,7 @@ npm run dev
 - A player can be added and checked in.
 - The event can move from draft to open to active to completed.
 - The completed event appears in History.
+- A manual email send creates a delivery record and the message contains a working RSVP link.
+- The email-first Invite roster action creates a delivery record containing a working RSVP link.
+- A manual email batch returns a batch summary and can be retried without deleting the original attempt.
+- The development sink can exercise the full workflow without Resend credentials.

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -14,7 +14,7 @@ Sterling approved the following direction:
 - The primary workflow runs from planning through event closeout.
 - The MVP is organizer-only.
 - Players do not need accounts in the MVP.
-- Invitation delivery stays outside the application initially.
+- Initial delivery is organizer-triggered from within the application; automated reminders are an active follow-on phase.
 - Attendance is core.
 - Money tracking is optional by event and follows after the first vertical slice.
 - D1 is the authoritative relational database.
@@ -22,9 +22,24 @@ Sterling approved the following direction:
 - Cloudflare Access is the MVP authentication boundary.
 - API routes independently validate the Access JWT and organizer authorization.
 
+## 2026-08-02: Delivery is manual-first, automation-ready
+
+- Initial invitation sends remain an explicit organizer action so opening an event never accidentally messages the roster.
+- A player-level preferred channel determines scheduled delivery; the other contact method is a fallback.
+- Scheduled reminders run in a separate Cloudflare Cron Worker backed by D1.
+- Development uses the message sink and public organizer identity; production can later re-enable Access and live providers.
+
 ## 2026-07-22: One remote D1 database
 
 - Production uses one remote D1 database named `brotm-poker`.
 - Local development uses Wrangler local D1 storage and consumes no remote database slot.
 - Preview deployments do not bind to production data.
 - Pages bindings are managed in the Cloudflare dashboard rather than a deployed `wrangler.toml`.
+
+## 2026-08-02: Manual invitation delivery
+
+- The current workflow milestone includes manual email delivery for invited players; SMS follows on the same delivery contracts.
+- Resend is the default email provider and Twilio is the default SMS provider.
+- A development delivery sink allows local and preview testing without provider credentials.
+- Delivery is synchronous and organizer-triggered for initial invitations; scheduled reminders are now implemented as a follow-on Cron Worker workflow.
+- Build and preview environments may use `AUTH_MODE=public` with `DEV_ORGANIZER_EMAIL` so login setup does not block construction.

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -34,6 +34,8 @@ npm run db:migrate:remote
    - roster and attendance
    - invite and RSVP view
    - private RSVP link generation and revocation
+   - one-recipient email delivery using the live Resend provider secret
+   - delivery batch history and failed-delivery retry
    - public RSVP response from a browser without organizer access
    - money ledger
    - closeout

--- a/docs/PRIVATE_RSVP_ROLLOUT.md
+++ b/docs/PRIVATE_RSVP_ROLLOUT.md
@@ -75,6 +75,12 @@ Use an incognito window that is not logged into Cloudflare Access.
 6. Revoke the link and confirm it no longer loads.
 7. For address privacy, verify the location appears only after a Yes response.
 
+## 5. Configure manual delivery
+
+For local and preview testing, set `DELIVERY_MODE=log` and `AUTH_MODE=public`. The organizer identity is resolved from `DEV_ORGANIZER_EMAIL`, so no Access login is required.
+
+For the email-first release, set `DELIVERY_MODE=live`, configure `RESEND_API_KEY` and `EMAIL_FROM` as Pages secrets, open an event, choose **Invite roster by email**, review the recipient summary, and confirm the send. SMS and scheduled reminders remain follow-on work; their shared provider and batch contracts are retained for the next delivery milestone.
+
 ## Security properties
 
 - Tokens contain 256 bits of randomness.

--- a/docs/PRODUCT_PHASES.md
+++ b/docs/PRODUCT_PHASES.md
@@ -19,15 +19,25 @@
 - event balance validation
 - player net results
 
-## Phase 3: Invitation improvements
+## Phase 3: Invitation delivery
 
-- reusable invite templates
-- secure RSVP links
-- player response flow without full accounts
-- optional delivery integrations
+- player-specific RSVP links
+- manual email delivery through Resend
+- delivery history and failure reporting
+- development delivery sink for local and preview testing
+- email-first roster invite action with confirmation
+- delivery batches, idempotency, and failed-send retry
+- private RSVP token rotation and response tracking
+
+SMS delivery, preferred-channel fallback, and scheduled reminders remain the next delivery extensions using the same batch and token contracts.
+
+Recurring campaigns and general-purpose bulk messaging remain later features. Automated invitation delivery is now part of the active product roadmap rather than a deferred non-goal.
 
 ## Phase 4: Useful analytics
 
+- phone-first Live Night workspace and resilient installable shell
+- roster search, attendance filters, and live refresh state
+- local planning drafts and duplicate-night setup
 - attendance trends
 - hosting frequency
 - RSVP conversion

--- a/docs/PRODUCT_SPEC_V2.md
+++ b/docs/PRODUCT_SPEC_V2.md
@@ -68,7 +68,7 @@ An organizer creates a poker night with:
 
 Initial status: `draft`.
 
-### Phase B: Invite
+### Phase B: Invite and deliver
 
 The organizer selects players from the directory and assigns an invitation state:
 
@@ -82,7 +82,7 @@ Each invited player can then receive an RSVP state:
 - `maybe`
 - `no`
 
-The MVP does not need to send messages. It should provide a clean invite summary and copyable invite text. Automatic email, SMS, and player RSVP links belong to a later phase.
+The organizer can manually send a personalized invitation by email. Each message contains a player-specific RSVP link, and the application records the delivery attempt and result. Copyable invite text remains available as a fallback. SMS uses the same delivery contracts as a follow-on channel.
 
 When the invite list is ready, the event becomes `open`.
 
@@ -151,6 +151,8 @@ No player-level totals are manually stored.
 - player directory
 - create and edit poker night
 - invite roster and RSVP states
+- email-first manual invitations
+- delivery history and provider errors
 - mobile Live Night mode
 - attendance check-in
 - optional cash ledger
@@ -165,8 +167,8 @@ No player-level totals are manually stored.
 ### Explicitly later
 
 - player accounts
-- self-service RSVP links
-- automated email or text delivery
+- player accounts
+- recurring delivery campaigns beyond the invitation and reminder workflow
 - public leaderboards
 - achievements or badges
 - poker strategy tools
@@ -310,6 +312,22 @@ Money is stored as integer cents.
 - `details_json`
 - `created_at`
 
+### `invite_deliveries`
+
+- `id`
+- `event_invite_id`
+- `channel`: `email` or `sms`
+- `destination`
+- `provider`
+- `status`: `sending`, `sent`, or `failed`
+- `provider_message_id`, nullable
+- `error_message`, nullable
+- `token_hash`
+- `requested_by_organizer_id`
+- `created_at`
+- `completed_at`, nullable
+- `updated_at`
+
 ## 9. Derived values
 
 The application derives these values rather than storing competing copies:
@@ -349,6 +367,8 @@ The application derives these values rather than storing competing copies:
 ### Authentication
 
 For the MVP, protect the organizer application with Cloudflare Access using approved organizer email addresses.
+
+During construction and preview testing, `AUTH_MODE=public` may resolve the organizer from `DEV_ORGANIZER_EMAIL` without requiring an Access login. Production can use `AUTH_MODE=access` when the application is ready for hardening.
 
 Pages Functions must still validate the signed Access JWT for API requests and use the verified email identity to resolve an active organizer record.
 
@@ -397,7 +417,7 @@ The first implementation should prove one complete path rather than build discon
 ### Excluded from the first slice
 
 - cash ledger
-- automatic invitations
+- live provider delivery
 - player accounts
 - analytics dashboards
 - public pages
@@ -409,7 +429,7 @@ This specification is approved when the following are accepted:
 - organizer-first scope
 - planning through closeout as the core workflow
 - players do not need accounts in the MVP
-- invitation delivery remains outside the app initially
+- email-first manual invitation delivery is included; SMS, scheduled reminders, and recurring campaigns remain later
 - attendance is required and money tracking is optional
 - D1 is the authoritative data store
 - Cloudflare Access protects the organizer application

--- a/docs/REVIEW_NOTES.md
+++ b/docs/REVIEW_NOTES.md
@@ -5,7 +5,7 @@ The proposed v2 direction deliberately favors an organizer-first operating tool 
 The most consequential choices for Sterling to review are:
 
 1. Organizer-only MVP versus player accounts immediately.
-2. Invitation preparation versus automated delivery immediately.
+2. Email-first manual invitation delivery; scheduled reminders remain a later automation phase.
 3. Attendance as the first operational record.
 4. Money tracking as the second product phase rather than the first vertical slice.
 5. Cloudflare Access plus D1 versus custom authentication.

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -22,6 +22,7 @@ interface PlayerRow {
   display_name: string;
   email: string | null;
   phone: string | null;
+  preferred_channel: "email" | "sms";
   notes: string | null;
   status: "active" | "archived";
   created_at: string;
@@ -50,6 +51,8 @@ interface EventPlayerRow {
   event_id: string;
   player_id: string;
   display_name: string;
+  email: string | null;
+  phone: string | null;
   invitation_status: "invited" | "not_invited";
   rsvp_status: "pending" | "yes" | "maybe" | "no";
   attended: number;
@@ -73,6 +76,7 @@ function playerJson(row: PlayerRow) {
     displayName: row.display_name,
     email: row.email,
     phone: row.phone,
+    preferredChannel: row.preferred_channel,
     notes: row.notes,
     status: row.status,
     createdAt: row.created_at,
@@ -105,6 +109,7 @@ function eventPlayerJson(row: EventPlayerRow) {
     eventId: row.event_id,
     playerId: row.player_id,
     displayName: row.display_name,
+    contact: { email: row.email, phone: row.phone },
     invitationStatus: row.invitation_status,
     rsvpStatus: row.rsvp_status,
     attended: Boolean(row.attended),
@@ -255,8 +260,8 @@ async function createPlayer(request: Request, db: D1Database): Promise<Response>
   await db
     .prepare(
       `INSERT INTO players
-       (id, first_name, last_name, display_name, email, phone, notes, status, created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, NULLIF(?5, ''), NULLIF(?6, ''), NULLIF(?7, ''), 'active', ?8, ?8)`,
+       (id, first_name, last_name, display_name, email, phone, preferred_channel, notes, status, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, NULLIF(?5, ''), NULLIF(?6, ''), ?7, NULLIF(?8, ''), 'active', ?9, ?9)`,
     )
     .bind(
       id,
@@ -265,6 +270,7 @@ async function createPlayer(request: Request, db: D1Database): Promise<Response>
       displayName,
       input.email ?? "",
       input.phone ?? "",
+      input.preferredChannel,
       input.notes ?? "",
       now,
     )
@@ -308,6 +314,7 @@ async function patchPlayer(request: Request, db: D1Database, id: string): Promis
       : current.display_name;
   const email = input.email !== undefined ? input.email : (current.email ?? "");
   const phone = input.phone !== undefined ? input.phone : (current.phone ?? "");
+  const preferredChannel = input.preferredChannel ?? current.preferred_channel;
   const notes = input.notes !== undefined ? input.notes : (current.notes ?? "");
   const status = input.status ?? current.status;
   const now = new Date().toISOString();
@@ -316,11 +323,11 @@ async function patchPlayer(request: Request, db: D1Database, id: string): Promis
     .prepare(
       `UPDATE players
        SET first_name = ?1, last_name = ?2, display_name = ?3,
-           email = NULLIF(?4, ''), phone = NULLIF(?5, ''), notes = NULLIF(?6, ''),
-           status = ?7, updated_at = ?8
-       WHERE id = ?9`,
+           email = NULLIF(?4, ''), phone = NULLIF(?5, ''), preferred_channel = ?6,
+           notes = NULLIF(?7, ''), status = ?8, updated_at = ?9
+       WHERE id = ?10`,
     )
-    .bind(firstName, lastName, displayName, email, phone, notes, status, now, id)
+    .bind(firstName, lastName, displayName, email, phone, preferredChannel, notes, status, now, id)
     .run();
 
   const row = await db.prepare("SELECT * FROM players WHERE id = ?1").bind(id).first<PlayerRow>();
@@ -383,7 +390,7 @@ async function eventDetail(db: D1Database, id: string): Promise<Response> {
     getEvent(db, id),
     db
       .prepare(
-        `SELECT ep.*, p.display_name
+        `SELECT ep.*, p.display_name, p.email, p.phone
          FROM event_players ep
          JOIN players p ON p.id = ep.player_id
          WHERE ep.event_id = ?1
@@ -540,7 +547,7 @@ async function patchEventPlayer(
   const correction = requireCorrectionNote(event, input.correctionNote);
   const current = await db
     .prepare(
-      `SELECT ep.*, p.display_name
+      `SELECT ep.*, p.display_name, p.email, p.phone
        FROM event_players ep
        JOIN players p ON p.id = ep.player_id
        WHERE ep.event_id = ?1 AND ep.player_id = ?2`,
@@ -626,7 +633,7 @@ async function removeEventPlayer(
   const correction = requireCorrectionNote(event, input.correctionNote);
   const current = await db
     .prepare(
-      `SELECT ep.*, p.display_name
+      `SELECT ep.*, p.display_name, p.email, p.phone
        FROM event_players ep
        JOIN players p ON p.id = ep.player_id
        WHERE ep.event_id = ?1 AND ep.player_id = ?2`,

--- a/functions/api/health.ts
+++ b/functions/api/health.ts
@@ -16,6 +16,9 @@ const requiredTables = [
   "ledger_entries",
   "app_settings",
   "event_invites",
+  "invite_deliveries",
+  "delivery_batches",
+  "invite_delivery_results",
   "d1_migrations",
 ];
 
@@ -39,9 +42,14 @@ export const onRequestGet: AppPagesFunction = async (context) => {
       ? await context.env.DB.prepare("PRAGMA table_info(events)").all<NameRow>()
       : { results: [] as NameRow[] };
     const eventColumns = new Set(eventColumnsResult.results.map((row) => row.name));
+    const playersColumnsResult = tables.has("players")
+      ? await context.env.DB.prepare("PRAGMA table_info(players)").all<NameRow>()
+      : { results: [] as NameRow[] };
+    const playersColumns = new Set(playersColumnsResult.results.map((row) => row.name));
     const missingColumns = [
       eventColumns.has("capacity") ? "" : "events.capacity",
       eventColumns.has("rsvp_location_visibility") ? "" : "events.rsvp_location_visibility",
+      playersColumns.has("preferred_channel") ? "" : "players.preferred_channel",
     ].filter(Boolean);
 
     const migrationRow = tables.has("d1_migrations")

--- a/functions/lib/auth.ts
+++ b/functions/lib/auth.ts
@@ -65,6 +65,8 @@ async function verifyAccessToken(token: string, env: Env): Promise<string> {
 
   if (header.alg !== "RS256" || !header.kid) throw new Error("Unsupported Access token");
 
+  if (!env.TEAM_DOMAIN || !env.POLICY_AUD) throw new Error("Access configuration is incomplete");
+
   const expectedIssuer = `https://${env.TEAM_DOMAIN}`;
   const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -104,10 +106,13 @@ export async function resolveOrganizer(
   const token = request.headers.get("Cf-Access-Jwt-Assertion");
   let email: string;
 
-  if (token) {
-    email = await verifyAccessToken(token, env);
-  } else if (env.ENVIRONMENT === "development" && env.DEV_ORGANIZER_EMAIL) {
+  const publicMode = env.AUTH_MODE === "public" || (!env.AUTH_MODE && env.ENVIRONMENT === "development");
+
+  if (publicMode) {
+    if (!env.DEV_ORGANIZER_EMAIL) throw new Error("Public auth mode requires DEV_ORGANIZER_EMAIL");
     email = env.DEV_ORGANIZER_EMAIL.toLowerCase();
+  } else if (token) {
+    email = await verifyAccessToken(token, env);
   } else {
     throw new Error("Authentication required");
   }

--- a/functions/lib/delivery.ts
+++ b/functions/lib/delivery.ts
@@ -1,0 +1,100 @@
+import type {
+  DeliveryMessage,
+  ProviderDeliveryResult,
+} from "../../shared/delivery";
+import type { Env } from "./types";
+
+export class DeliveryProviderError extends Error {
+  readonly provider: string;
+
+  constructor(provider: string, message: string) {
+    super(message);
+    this.name = "DeliveryProviderError";
+    this.provider = provider;
+  }
+}
+
+function isLive(env: Env): boolean {
+  return env.DELIVERY_MODE === "live";
+}
+
+function developmentResult(message: DeliveryMessage): ProviderDeliveryResult {
+  return {
+    provider: "development",
+    providerMessageId: `dev-${message.channel}-${crypto.randomUUID()}`,
+  };
+}
+
+async function sendEmail(env: Env, message: DeliveryMessage): Promise<ProviderDeliveryResult> {
+  if (!isLive(env)) return developmentResult(message);
+  if (!env.RESEND_API_KEY || !env.EMAIL_FROM) {
+    throw new DeliveryProviderError("resend", "RESEND_API_KEY and EMAIL_FROM are required for live email delivery.");
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    signal: AbortSignal.timeout(15_000),
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": message.idempotencyKey,
+    },
+    body: JSON.stringify({
+      from: env.EMAIL_FROM,
+      to: [message.destination],
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    }),
+  });
+
+  const body = (await response.json().catch(() => ({}))) as { id?: string; message?: string };
+  if (!response.ok) {
+    throw new DeliveryProviderError("resend", body.message ?? `Resend returned HTTP ${response.status}.`);
+  }
+  return { provider: "resend", providerMessageId: body.id ?? null };
+}
+
+async function sendSms(env: Env, message: DeliveryMessage): Promise<ProviderDeliveryResult> {
+  if (!isLive(env)) return developmentResult(message);
+  if (!env.TWILIO_ACCOUNT_SID || !env.TWILIO_AUTH_TOKEN || !env.TWILIO_FROM_NUMBER) {
+    throw new DeliveryProviderError(
+      "twilio",
+      "TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_FROM_NUMBER are required for live SMS delivery.",
+    );
+  }
+
+  const credentials = btoa(`${env.TWILIO_ACCOUNT_SID}:${env.TWILIO_AUTH_TOKEN}`);
+  const response = await fetch(
+    `https://api.twilio.com/2010-04-01/Accounts/${encodeURIComponent(env.TWILIO_ACCOUNT_SID)}/Messages.json`,
+    {
+      method: "POST",
+      signal: AbortSignal.timeout(15_000),
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        To: message.destination,
+        From: env.TWILIO_FROM_NUMBER,
+        Body: message.text,
+      }),
+    },
+  );
+
+  const body = (await response.json().catch(() => ({}))) as { sid?: string; message?: string; code?: number };
+  if (!response.ok) {
+    const code = body.code ? ` (${body.code})` : "";
+    throw new DeliveryProviderError("twilio", body.message ?? `Twilio returned HTTP ${response.status}${code}.`);
+  }
+  return { provider: "twilio", providerMessageId: body.sid ?? null };
+}
+
+export function providerName(channel: DeliveryMessage["channel"], env: Env): string {
+  if (!isLive(env)) return "development";
+  return channel === "email" ? "resend" : "twilio";
+}
+
+export function sendDelivery(env: Env, message: DeliveryMessage): Promise<ProviderDeliveryResult> {
+  return message.channel === "email" ? sendEmail(env, message) : sendSms(env, message);
+}

--- a/functions/lib/types.ts
+++ b/functions/lib/types.ts
@@ -7,10 +7,19 @@ export interface OrganizerIdentity {
 
 export interface Env {
   DB: D1Database;
-  TEAM_DOMAIN: string;
-  POLICY_AUD: string;
+  TEAM_DOMAIN?: string;
+  POLICY_AUD?: string;
   ENVIRONMENT?: string;
+  AUTH_MODE?: "public" | "access";
   DEV_ORGANIZER_EMAIL?: string;
+  DELIVERY_MODE?: "log" | "live";
+  PUBLIC_APP_ORIGIN?: string;
+  RESEND_API_KEY?: string;
+  EMAIL_FROM?: string;
+  TWILIO_ACCOUNT_SID?: string;
+  TWILIO_AUTH_TOKEN?: string;
+  TWILIO_FROM_NUMBER?: string;
+  CRON_SECRET?: string;
   CF_PAGES_COMMIT_SHA?: string;
 }
 

--- a/functions/rsvp-admin-api/[[path]].ts
+++ b/functions/rsvp-admin-api/[[path]].ts
@@ -1,5 +1,12 @@
 import { ZodError } from "zod";
 import {
+  sendInvitesSchema,
+  type DeliveryChannel,
+  type DeliveryStatus,
+} from "../../shared/delivery";
+import {
+  buildPersonalizedInviteEmail,
+  buildPersonalizedInviteSms,
   buildPersonalizedInviteText,
   createRsvpToken,
   hashRsvpToken,
@@ -7,8 +14,9 @@ import {
   rsvpAdminEventPatchSchema,
   type RsvpLocationVisibility,
 } from "../../shared/rsvp";
+import { DeliveryProviderError, providerName, sendDelivery } from "../lib/delivery";
 import { apiError, json, readJson, validationError } from "../lib/http";
-import type { AppPagesFunction, OrganizerIdentity } from "../lib/types";
+import type { AppPagesFunction, Env, OrganizerIdentity } from "../lib/types";
 
 interface RsvpEventRow {
   id: string;
@@ -26,6 +34,9 @@ interface RsvpPlayerRow {
   event_player_id: string;
   player_id: string;
   display_name: string;
+  email: string | null;
+  phone: string | null;
+  preferred_channel: "email" | "sms";
   invitation_status: "invited" | "not_invited";
   rsvp_status: "pending" | "yes" | "maybe" | "no";
   invite_id: string | null;
@@ -34,6 +45,14 @@ interface RsvpPlayerRow {
   last_response_at: string | null;
   response_count: number | null;
   invite_created_at: string | null;
+  email_delivery_status: DeliveryStatus | null;
+  email_delivery_provider: string | null;
+  email_delivery_at: string | null;
+  email_delivery_error: string | null;
+  sms_delivery_status: DeliveryStatus | null;
+  sms_delivery_provider: string | null;
+  sms_delivery_at: string | null;
+  sms_delivery_error: string | null;
 }
 
 interface GeneratedInvite {
@@ -42,6 +61,35 @@ interface GeneratedInvite {
   url: string;
   inviteText: string;
   expiresAt: string;
+}
+
+interface DeliveryRow {
+  id: string;
+  player_id: string;
+  display_name: string;
+  channel: DeliveryChannel;
+  destination: string;
+  provider: string;
+  status: DeliveryStatus;
+  provider_message_id: string | null;
+  error_message: string | null;
+  created_at: string;
+  completed_at: string | null;
+  batch_id: string | null;
+  attempt: number;
+  provider_status: string | null;
+  provider_status_at: string | null;
+}
+
+interface DeliveryResult {
+  deliveryId: string | null;
+  playerId: string;
+  playerName: string;
+  channel: DeliveryChannel;
+  destination: string | null;
+  provider: string | null;
+  status: "sent" | "failed" | "skipped";
+  errorMessage: string | null;
 }
 
 function auditStatement(
@@ -90,11 +138,36 @@ function requireMutableEvent(event: RsvpEventRow): void {
 async function getPlayers(db: D1Database, eventId: string): Promise<RsvpPlayerRow[]> {
   const rows = await db
     .prepare(
-      `SELECT ep.id AS event_player_id, ep.player_id, p.display_name,
+      `SELECT ep.id AS event_player_id, ep.player_id, p.display_name, p.email, p.phone,
+              p.preferred_channel,
               ep.invitation_status, ep.rsvp_status,
               ei.id AS invite_id, ei.expires_at, ei.revoked_at,
               ei.last_response_at, ei.response_count,
-              ei.created_at AS invite_created_at
+              ei.created_at AS invite_created_at,
+              (SELECT d.status FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'email'
+               ORDER BY d.created_at DESC LIMIT 1) AS email_delivery_status,
+              (SELECT d.provider FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'email'
+               ORDER BY d.created_at DESC LIMIT 1) AS email_delivery_provider,
+              (SELECT COALESCE(d.completed_at, d.created_at) FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'email'
+               ORDER BY d.created_at DESC LIMIT 1) AS email_delivery_at,
+              (SELECT d.error_message FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'email'
+               ORDER BY d.created_at DESC LIMIT 1) AS email_delivery_error,
+              (SELECT d.status FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'sms'
+               ORDER BY d.created_at DESC LIMIT 1) AS sms_delivery_status,
+              (SELECT d.provider FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'sms'
+               ORDER BY d.created_at DESC LIMIT 1) AS sms_delivery_provider,
+              (SELECT COALESCE(d.completed_at, d.created_at) FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'sms'
+               ORDER BY d.created_at DESC LIMIT 1) AS sms_delivery_at,
+              (SELECT d.error_message FROM invite_deliveries d
+               WHERE d.event_invite_id = ei.id AND d.channel = 'sms'
+               ORDER BY d.created_at DESC LIMIT 1) AS sms_delivery_error
        FROM event_players ep
        JOIN players p ON p.id = ep.player_id
        LEFT JOIN event_invites ei ON ei.event_player_id = ep.id
@@ -117,6 +190,8 @@ function playerJson(player: RsvpPlayerRow) {
     eventPlayerId: player.event_player_id,
     playerId: player.player_id,
     displayName: player.display_name,
+    contact: { email: player.email, phone: player.phone },
+    preferredChannel: player.preferred_channel,
     invitationStatus: player.invitation_status,
     rsvpStatus: player.rsvp_status,
     invite: player.invite_id
@@ -142,7 +217,38 @@ function playerJson(player: RsvpPlayerRow) {
           responseCount: 0,
           createdAt: null,
         },
+    latestDelivery: {
+      email: player.email_delivery_status
+        ? {
+            status: player.email_delivery_status,
+            provider: player.email_delivery_provider,
+            at: player.email_delivery_at,
+            errorMessage: player.email_delivery_error,
+          }
+        : null,
+      sms: player.sms_delivery_status
+        ? {
+            status: player.sms_delivery_status,
+            provider: player.sms_delivery_provider,
+            at: player.sms_delivery_at,
+            errorMessage: player.sms_delivery_error,
+          }
+        : null,
+    },
   };
+}
+
+function requireSendableEvent(event: RsvpEventRow): void {
+  if (event.status !== "open" && event.status !== "active") {
+    throw new Response("Invitations can only be sent for open or active events.", { status: 409 });
+  }
+  if (new Date(invitationExpiresAt(event.starts_at)).getTime() <= Date.now()) {
+    throw new Response("This event's RSVP invitation window has expired.", { status: 409 });
+  }
+}
+
+function publicOrigin(request: Request, env: Env): string {
+  return env.PUBLIC_APP_ORIGIN?.trim() || new URL(request.url).origin;
 }
 
 async function detail(db: D1Database, eventId: string): Promise<Response> {
@@ -177,16 +283,17 @@ async function requireInvitedPlayer(
 }
 
 async function prepareInvite(
-  request: Request,
   event: RsvpEventRow,
   player: RsvpPlayerRow,
-): Promise<{ generated: GeneratedInvite; tokenHash: string }> {
+  origin: string,
+): Promise<{ generated: GeneratedInvite; tokenHash: string; inviteId: string }> {
   const token = createRsvpToken();
   const tokenHash = await hashRsvpToken(token);
   const expiresAt = invitationExpiresAt(event.starts_at);
-  const url = `${new URL(request.url).origin}/rsvp/${token}`;
+  const url = `${origin.replace(/\/+$/u, "")}/rsvp/${token}`;
   return {
     tokenHash,
+    inviteId: player.invite_id ?? crypto.randomUUID(),
     generated: {
       playerId: player.player_id,
       playerName: player.display_name,
@@ -209,7 +316,8 @@ async function prepareInvite(
 
 function upsertInviteStatement(
   db: D1Database,
-  player: RsvpPlayerRow,
+  eventPlayerId: string,
+  inviteId: string,
   organizer: OrganizerIdentity,
   tokenHash: string,
   expiresAt: string,
@@ -230,8 +338,8 @@ function upsertInviteStatement(
          updated_at = excluded.updated_at`,
     )
     .bind(
-      player.invite_id ?? crypto.randomUUID(),
-      player.event_player_id,
+      inviteId,
+      eventPlayerId,
       tokenHash,
       expiresAt,
       organizer.id,
@@ -245,14 +353,23 @@ async function generateOne(
   eventId: string,
   playerId: string,
   organizer: OrganizerIdentity,
+  origin: string,
 ): Promise<Response> {
   const event = await requireEvent(db, eventId);
   requireMutableEvent(event);
   const player = await requireInvitedPlayer(db, eventId, playerId);
-  const prepared = await prepareInvite(request, event, player);
+  const prepared = await prepareInvite(event, player, origin);
   const now = new Date().toISOString();
   await db.batch([
-    upsertInviteStatement(db, player, organizer, prepared.tokenHash, prepared.generated.expiresAt, now),
+    upsertInviteStatement(
+      db,
+      player.event_player_id,
+      prepared.inviteId,
+      organizer,
+      prepared.tokenHash,
+      prepared.generated.expiresAt,
+      now,
+    ),
     auditStatement(
       db,
       eventId,
@@ -266,24 +383,34 @@ async function generateOne(
 }
 
 async function generateAll(
-  request: Request,
   db: D1Database,
   eventId: string,
   organizer: OrganizerIdentity,
+  origin: string,
 ): Promise<Response> {
   const event = await requireEvent(db, eventId);
   requireMutableEvent(event);
   const players = (await getPlayers(db, eventId)).filter((player) => player.invitation_status === "invited");
   if (!players.length) return apiError(409, "NO_INVITEES", "Add invited players before generating links.");
 
-  const prepared = await Promise.all(players.map((player) => prepareInvite(request, event, player)));
+  const prepared = await Promise.all(
+    players.map((player) => prepareInvite(event, player, origin)),
+  );
   const now = new Date().toISOString();
   const statements: D1PreparedStatement[] = [];
   for (let index = 0; index < players.length; index += 1) {
     const player = players[index];
     const invite = prepared[index];
     statements.push(
-      upsertInviteStatement(db, player, organizer, invite.tokenHash, invite.generated.expiresAt, now),
+      upsertInviteStatement(
+        db,
+        player.event_player_id,
+        invite.inviteId,
+        organizer,
+        invite.tokenHash,
+        invite.generated.expiresAt,
+        now,
+      ),
       auditStatement(
         db,
         eventId,
@@ -301,6 +428,672 @@ async function generateAll(
   }
   await db.batch(statements);
   return json({ generated: prepared.map((item) => item.generated) });
+}
+
+type DestinationCheck =
+  | { kind: "ready"; destination: string }
+  | { kind: "skipped" | "failed"; message: string; destination: string | null };
+
+function destinationFor(channel: DeliveryChannel, player: RsvpPlayerRow): DestinationCheck {
+  if (channel === "email") {
+    const destination = player.email?.trim() ?? "";
+    if (!destination) return { kind: "skipped", message: "No email address is saved for this player.", destination: null };
+    if (!/^\S+@\S+\.\S+$/u.test(destination)) {
+      return { kind: "failed", message: "The saved email address is invalid.", destination };
+    }
+    return { kind: "ready", destination };
+  }
+
+  const destination = (player.phone?.trim() ?? "").replace(/[()\s.-]/gu, "");
+  if (!destination) return { kind: "skipped", message: "No phone number is saved for this player.", destination: null };
+  if (!/^\+[1-9]\d{7,14}$/u.test(destination)) {
+    return { kind: "failed", message: "SMS numbers must use E.164 format, such as +15551234567.", destination };
+  }
+  return { kind: "ready", destination };
+}
+
+function deliveryMessage(
+  event: RsvpEventRow,
+  player: RsvpPlayerRow,
+  channel: DeliveryChannel,
+  destination: string,
+  url: string,
+  deliveryId: string,
+) {
+  const input = {
+    playerName: player.display_name,
+    title: event.title,
+    startsAt: event.starts_at,
+    hostName: event.host_name,
+    location: event.location,
+    locationVisibility: event.rsvp_location_visibility,
+    gameNotes: event.game_notes,
+    stakesNotes: event.stakes_notes,
+    rsvpUrl: url,
+  };
+  if (channel === "email") {
+    const email = buildPersonalizedInviteEmail(input);
+    return {
+      channel,
+      destination,
+      subject: email.subject,
+      text: email.text,
+      html: email.html,
+      idempotencyKey: deliveryId,
+    };
+  }
+  return {
+    channel,
+    destination,
+    text: buildPersonalizedInviteSms(input),
+    idempotencyKey: deliveryId,
+  };
+}
+
+function insertDeliveryStatement(
+  db: D1Database,
+  values: {
+    id: string;
+    batchId: string;
+    inviteId: string;
+    channel: DeliveryChannel;
+    destination: string;
+    provider: string;
+    status: DeliveryStatus;
+    tokenHash: string;
+    organizerId: string;
+    createdAt: string;
+      completedAt: string | null;
+      errorMessage: string | null;
+    idempotencyKey: string;
+  },
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO invite_deliveries
+       (id, event_invite_id, channel, destination, provider, status,
+        provider_message_id, error_message, token_hash,
+        requested_by_organizer_id, created_at, completed_at, updated_at,
+        batch_id, attempt, idempotency_key)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8, ?9, ?10, ?11, ?10, ?12, 1, ?13)`,
+    )
+    .bind(
+      values.id,
+      values.inviteId,
+      values.channel,
+      values.destination,
+      values.provider,
+      values.status,
+      values.errorMessage,
+      values.tokenHash,
+      values.organizerId,
+      values.createdAt,
+      values.completedAt,
+      values.batchId,
+      values.idempotencyKey,
+    );
+}
+
+function insertDeliveryResultStatement(
+  db: D1Database,
+  values: {
+    id: string;
+    batchId: string;
+    eventPlayerId: string;
+    channel: DeliveryChannel;
+    destination: string | null;
+    status: "sent" | "failed" | "skipped";
+    deliveryId: string | null;
+    errorMessage: string | null;
+    tokenHash: string;
+    now: string;
+  },
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO invite_delivery_results
+       (id, batch_id, event_player_id, channel, destination, status,
+        delivery_id, error_message, token_hash, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)`,
+    )
+    .bind(
+      values.id,
+      values.batchId,
+      values.eventPlayerId,
+      values.channel,
+      values.destination,
+      values.status,
+      values.deliveryId,
+      values.errorMessage,
+      values.tokenHash,
+      values.now,
+    );
+}
+
+function updateDeliveryResultStatement(
+  db: D1Database,
+  resultId: string,
+  status: "sent" | "failed" | "skipped",
+  errorMessage: string | null,
+  deliveryId: string | null,
+  now: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `UPDATE invite_delivery_results
+       SET status = ?1, error_message = ?2, delivery_id = ?3, updated_at = ?4
+       WHERE id = ?5`,
+    )
+    .bind(status, errorMessage, deliveryId, now, resultId);
+}
+
+function updateDeliveryStatement(
+  db: D1Database,
+  deliveryId: string,
+  status: DeliveryStatus,
+  providerMessageId: string | null,
+  errorMessage: string | null,
+  completedAt: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `UPDATE invite_deliveries
+       SET status = ?1, provider_message_id = ?2, error_message = ?3,
+           completed_at = ?4, updated_at = ?4
+       WHERE id = ?5`,
+    )
+    .bind(status, providerMessageId, errorMessage, completedAt, deliveryId);
+}
+
+async function deliveries(db: D1Database, eventId: string): Promise<Response> {
+  await requireEvent(db, eventId);
+  const [rows, batchRows] = await Promise.all([
+    db
+      .prepare(
+        `SELECT d.id, ep.player_id, p.display_name, d.channel, d.destination,
+                d.provider, d.status, d.provider_message_id, d.error_message,
+                d.created_at, d.completed_at, d.batch_id, d.attempt,
+                d.provider_status, d.provider_status_at
+         FROM invite_deliveries d
+         JOIN event_invites ei ON ei.id = d.event_invite_id
+         JOIN event_players ep ON ep.id = ei.event_player_id
+         JOIN players p ON p.id = ep.player_id
+         WHERE ep.event_id = ?1
+         ORDER BY d.created_at DESC
+         LIMIT 200`,
+      )
+      .bind(eventId)
+      .all<DeliveryRow>(),
+    db
+      .prepare(
+        `SELECT id, policy, source, status, requested_count, sent_count,
+                failed_count, skipped_count, created_at, completed_at
+         FROM delivery_batches
+         WHERE event_id = ?1
+         ORDER BY created_at DESC
+         LIMIT 50`,
+      )
+      .bind(eventId)
+      .all<DeliveryBatchRow>(),
+  ]);
+  return json({
+    deliveries: rows.results.map((row) => ({
+      id: row.id,
+      playerId: row.player_id,
+      playerName: row.display_name,
+      channel: row.channel,
+      destination: row.destination,
+      provider: row.provider,
+      status: row.status,
+      providerMessageId: row.provider_message_id,
+      errorMessage: row.error_message,
+      createdAt: row.created_at,
+      completedAt: row.completed_at,
+      batchId: row.batch_id,
+      attempt: Number(row.attempt ?? 1),
+      providerStatus: row.provider_status,
+      providerStatusAt: row.provider_status_at,
+    })),
+    batches: batchRows.results.map((batch) => ({
+      id: batch.id,
+      policy: batch.policy,
+      source: batch.source,
+      status: batch.status,
+      summary: {
+        requested: Number(batch.requested_count),
+        sent: Number(batch.sent_count),
+        failed: Number(batch.failed_count),
+        skipped: Number(batch.skipped_count),
+      },
+      createdAt: batch.created_at,
+      completedAt: batch.completed_at,
+    })),
+  });
+}
+
+interface DeliveryBatchRow {
+  id: string;
+  requested_channels_json: string;
+  policy: "requested_channels" | "preferred_with_fallback";
+  source: "manual" | "scheduled";
+  status: "sending" | "completed" | "partial" | "failed";
+  requested_count: number;
+  sent_count: number;
+  failed_count: number;
+  skipped_count: number;
+  created_at: string;
+  completed_at: string | null;
+}
+
+interface DeliveryBatchResultRow {
+  id: string;
+  player_id: string;
+  display_name: string;
+  channel: DeliveryChannel;
+  destination: string | null;
+  status: "sent" | "failed" | "skipped";
+  delivery_id: string | null;
+  provider: string | null;
+  error_message: string | null;
+}
+
+async function batchResponse(db: D1Database, batchId: string): Promise<Response> {
+  const [batch, resultRows] = await Promise.all([
+    db.prepare("SELECT * FROM delivery_batches WHERE id = ?1").bind(batchId).first<DeliveryBatchRow>(),
+    db
+      .prepare(
+        `SELECT r.id, ep.player_id, p.display_name, r.channel, r.destination,
+                r.status, r.delivery_id, d.provider, r.error_message
+         FROM invite_delivery_results r
+         JOIN event_players ep ON ep.id = r.event_player_id
+         JOIN players p ON p.id = ep.player_id
+         LEFT JOIN invite_deliveries d ON d.id = r.delivery_id
+         WHERE r.batch_id = ?1
+         ORDER BY p.display_name COLLATE NOCASE, r.channel`,
+      )
+      .bind(batchId)
+      .all<DeliveryBatchResultRow>(),
+  ]);
+  if (!batch) return apiError(404, "BATCH_NOT_FOUND", "Delivery batch not found.");
+
+  return json({
+    batchId: batch.id,
+    policy: batch.policy,
+    source: batch.source,
+    summary: {
+      requested: Number(batch.requested_count),
+      sent: Number(batch.sent_count),
+      failed: Number(batch.failed_count),
+      skipped: Number(batch.skipped_count),
+    },
+    results: resultRows.results.map((row) => ({
+      deliveryId: row.delivery_id,
+      playerId: row.player_id,
+      playerName: row.display_name,
+      channel: row.channel,
+      destination: row.destination,
+      provider: row.provider,
+      status: row.status,
+      errorMessage: row.error_message,
+    })),
+    createdAt: batch.created_at,
+    completedAt: batch.completed_at,
+  });
+}
+
+function channelsForPlayer(
+  player: RsvpPlayerRow,
+  channels: DeliveryChannel[],
+  policy: "requested_channels" | "preferred_with_fallback",
+): DeliveryChannel[] {
+  if (policy === "requested_channels") return channels;
+  const ordered = [player.preferred_channel, ...channels.filter((channel) => channel !== player.preferred_channel)];
+  return Array.from(new Set(ordered)).filter((channel) => channels.includes(channel));
+}
+
+async function sendInvites(
+  request: Request,
+  db: D1Database,
+  eventId: string,
+  organizer: OrganizerIdentity,
+  env: Env,
+): Promise<Response> {
+  const event = await requireEvent(db, eventId);
+  requireSendableEvent(event);
+  const input = sendInvitesSchema.parse(await readJson(request));
+  if (input.requestId) {
+    const existing = await db.prepare("SELECT id FROM delivery_batches WHERE id = ?1").bind(input.requestId).first<{ id: string }>();
+    if (existing) return batchResponse(db, existing.id);
+  }
+  const allPlayers = await getPlayers(db, eventId);
+  const invitedPlayers = allPlayers.filter((player) => player.invitation_status === "invited");
+  if (!invitedPlayers.length) return apiError(409, "NO_INVITEES", "Add invited players before sending invitations.");
+
+  const selectedIds = input.playerIds ? Array.from(new Set(input.playerIds)) : undefined;
+  const selectedPlayers = selectedIds
+    ? selectedIds.map((playerId) => {
+        const player = allPlayers.find((candidate) => candidate.player_id === playerId);
+        if (!player) throw new Response("A selected player is not on this event roster.", { status: 404 });
+        if (player.invitation_status !== "invited") {
+          throw new Response("Only invited players can receive invitations.", { status: 409 });
+        }
+        return player;
+      })
+    : invitedPlayers;
+  if (selectedPlayers.length > 50) {
+    return apiError(400, "BATCH_TOO_LARGE", "Send invitations to no more than 50 players at a time.");
+  }
+
+  const origin = publicOrigin(request, env);
+  const now = new Date().toISOString();
+  const batchId = input.requestId ?? crypto.randomUUID();
+  const setupStatements: D1PreparedStatement[] = [];
+  const results: DeliveryResult[] = [];
+  const jobs: Array<{
+    deliveryId: string;
+    resultId: string;
+    resultIndex: number;
+    message: ReturnType<typeof deliveryMessage>;
+    player: RsvpPlayerRow;
+    provider: string;
+  }> = [];
+
+  setupStatements.push(
+    db
+      .prepare(
+        `INSERT INTO delivery_batches
+         (id, event_id, requested_by_organizer_id, requested_channels_json,
+          policy, source, status, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'manual', 'sending', ?6)`,
+      )
+      .bind(batchId, eventId, organizer.id, JSON.stringify(input.channels), input.policy, now),
+  );
+
+  for (const player of selectedPlayers) {
+    const prepared = await prepareInvite(event, player, origin);
+    setupStatements.push(
+      upsertInviteStatement(
+        db,
+        player.event_player_id,
+        prepared.inviteId,
+        organizer,
+        prepared.tokenHash,
+        prepared.generated.expiresAt,
+        now,
+      ),
+      auditStatement(
+        db,
+        eventId,
+        organizer,
+        player.invite_id ? "rsvp_link_regenerated_for_delivery" : "rsvp_link_generated_for_delivery",
+        { playerId: player.player_id, playerName: player.display_name },
+        now,
+      ),
+    );
+
+    const playerChannels = channelsForPlayer(player, input.channels, input.policy);
+    for (const channel of playerChannels) {
+      const destination = destinationFor(channel, player);
+      if (destination.kind === "skipped") {
+        const resultId = crypto.randomUUID();
+        results.push({
+          deliveryId: null,
+          playerId: player.player_id,
+          playerName: player.display_name,
+          channel,
+          destination: null,
+          provider: null,
+          status: "skipped",
+          errorMessage: destination.message,
+        });
+        setupStatements.push(
+          insertDeliveryResultStatement(db, {
+            id: resultId,
+            batchId,
+            eventPlayerId: player.event_player_id,
+            channel,
+            destination: null,
+            status: "skipped",
+            deliveryId: null,
+            errorMessage: destination.message,
+            tokenHash: prepared.tokenHash,
+            now,
+          }),
+          auditStatement(
+            db,
+            eventId,
+            organizer,
+            "invite_delivery_skipped",
+            { playerId: player.player_id, playerName: player.display_name, channel, reason: destination.message },
+            now,
+          ),
+        );
+        continue;
+      }
+
+      const deliveryId = crypto.randomUUID();
+      const resultId = crypto.randomUUID();
+      const provider = destination.kind === "failed" ? "validation" : providerName(channel, env);
+      if (destination.kind === "failed") {
+        results.push({
+          deliveryId,
+          playerId: player.player_id,
+          playerName: player.display_name,
+          channel,
+          destination: destination.destination,
+          provider,
+          status: "failed",
+          errorMessage: destination.message,
+        });
+        setupStatements.push(
+          insertDeliveryStatement(db, {
+            id: deliveryId,
+            batchId,
+            inviteId: prepared.inviteId,
+            channel,
+            destination: destination.destination ?? "",
+            provider,
+            status: "failed",
+            tokenHash: prepared.tokenHash,
+            organizerId: organizer.id,
+            createdAt: now,
+            completedAt: now,
+            errorMessage: destination.message,
+            idempotencyKey: `${batchId}:${deliveryId}`,
+          }),
+          insertDeliveryResultStatement(db, {
+            id: resultId,
+            batchId,
+            eventPlayerId: player.event_player_id,
+            channel,
+            destination: destination.destination,
+            status: "failed",
+            deliveryId,
+            errorMessage: destination.message,
+            tokenHash: prepared.tokenHash,
+            now,
+          }),
+          auditStatement(
+            db,
+            eventId,
+            organizer,
+            "invite_delivery_failed",
+            { playerId: player.player_id, playerName: player.display_name, channel, reason: destination.message },
+            now,
+          ),
+        );
+        continue;
+      }
+
+      results.push({
+        deliveryId,
+        playerId: player.player_id,
+        playerName: player.display_name,
+        channel,
+        destination: destination.destination,
+        provider,
+        status: "failed",
+        errorMessage: null,
+      });
+      const destinationValue = destination.destination;
+      if (!destinationValue) continue;
+      setupStatements.push(
+        insertDeliveryStatement(db, {
+          id: deliveryId,
+          batchId,
+          inviteId: prepared.inviteId,
+          channel,
+          destination: destinationValue,
+          provider,
+          status: "sending",
+          tokenHash: prepared.tokenHash,
+          organizerId: organizer.id,
+          createdAt: now,
+          completedAt: null,
+          errorMessage: null,
+          idempotencyKey: `${batchId}:${deliveryId}`,
+        }),
+        insertDeliveryResultStatement(db, {
+          id: resultId,
+          batchId,
+          eventPlayerId: player.event_player_id,
+          channel,
+          destination: destinationValue,
+          status: "failed",
+          deliveryId,
+          errorMessage: null,
+          tokenHash: prepared.tokenHash,
+          now,
+        }),
+        auditStatement(
+          db,
+          eventId,
+          organizer,
+          "invite_delivery_requested",
+          { playerId: player.player_id, playerName: player.display_name, channel, provider },
+          now,
+        ),
+      );
+      jobs.push({
+        deliveryId,
+        resultId,
+        resultIndex: results.length - 1,
+        message: deliveryMessage(event, player, channel, destinationValue, prepared.generated.url, deliveryId),
+        player,
+        provider,
+      });
+    }
+  }
+
+  await db.batch(setupStatements);
+  for (const job of jobs) {
+    const completedAt = new Date().toISOString();
+    try {
+      const sent = await sendDelivery(env, job.message);
+      await db.batch([
+        updateDeliveryStatement(db, job.deliveryId, "sent", sent.providerMessageId, null, completedAt),
+        updateDeliveryResultStatement(db, job.resultId, "sent", null, job.deliveryId, completedAt),
+        auditStatement(
+          db,
+          eventId,
+          organizer,
+          "invite_delivery_sent",
+          {
+            playerId: job.player.player_id,
+            playerName: job.player.display_name,
+            channel: job.message.channel,
+            provider: sent.provider,
+            providerMessageId: sent.providerMessageId,
+          },
+          completedAt,
+        ),
+      ]);
+      results[job.resultIndex] = {
+        ...results[job.resultIndex],
+        provider: sent.provider,
+        status: "sent",
+        errorMessage: null,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "The delivery provider failed.";
+      const failedProvider = error instanceof DeliveryProviderError ? error.provider : job.provider;
+      await db.batch([
+        updateDeliveryStatement(db, job.deliveryId, "failed", null, message, completedAt),
+        updateDeliveryResultStatement(db, job.resultId, "failed", message, job.deliveryId, completedAt),
+        auditStatement(
+          db,
+          eventId,
+          organizer,
+          "invite_delivery_failed",
+          {
+            playerId: job.player.player_id,
+            playerName: job.player.display_name,
+            channel: job.message.channel,
+            provider: failedProvider,
+            reason: message,
+          },
+          completedAt,
+        ),
+      ]);
+      results[job.resultIndex] = {
+        ...results[job.resultIndex],
+        provider: failedProvider,
+        status: "failed",
+        errorMessage: message,
+      };
+    }
+  }
+
+  const summary = {
+    requested: results.length,
+    sent: results.filter((result) => result.status === "sent").length,
+    failed: results.filter((result) => result.status === "failed").length,
+    skipped: results.filter((result) => result.status === "skipped").length,
+  };
+  const batchStatus = summary.failed === 0 ? "completed" : summary.sent > 0 ? "partial" : "failed";
+  await db
+    .prepare(
+      `UPDATE delivery_batches
+       SET status = ?1, requested_count = ?2, sent_count = ?3,
+           failed_count = ?4, skipped_count = ?5, completed_at = ?6
+       WHERE id = ?7`,
+    )
+    .bind(batchStatus, summary.requested, summary.sent, summary.failed, summary.skipped, new Date().toISOString(), batchId)
+    .run();
+
+  return json({ batchId, summary, results });
+}
+
+async function retryDelivery(
+  request: Request,
+  db: D1Database,
+  deliveryId: string,
+  organizer: OrganizerIdentity,
+  env: Env,
+): Promise<Response> {
+  const row = await db
+    .prepare(
+      `SELECT d.status, d.channel, ep.event_id, ep.player_id
+       FROM invite_deliveries d
+       JOIN event_invites ei ON ei.id = d.event_invite_id
+       JOIN event_players ep ON ep.id = ei.event_player_id
+       WHERE d.id = ?1`,
+    )
+    .bind(deliveryId)
+    .first<{ status: DeliveryStatus; channel: DeliveryChannel; event_id: string; player_id: string }>();
+  if (!row) return apiError(404, "DELIVERY_NOT_FOUND", "Delivery attempt not found.");
+  if (row.status !== "failed") return apiError(409, "DELIVERY_NOT_FAILED", "Only failed deliveries can be retried.");
+
+  const retryRequest = new Request(request.url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      playerIds: [row.player_id],
+      channels: [row.channel],
+      policy: "requested_channels",
+    }),
+  });
+  return sendInvites(retryRequest, db, row.event_id, organizer, env);
 }
 
 async function revoke(
@@ -377,10 +1170,41 @@ export const onRequest: AppPagesFunction = async (context) => {
       method === "POST" &&
       parts[0] === "events" &&
       parts[1] &&
+      parts[2] === "send-invites" &&
+      parts.length === 3
+    ) {
+      return sendInvites(request, context.env.DB, parts[1], context.data.organizer, context.env);
+    }
+    if (
+      method === "GET" &&
+      parts[0] === "events" &&
+      parts[1] &&
+      parts[2] === "deliveries" &&
+      parts.length === 3
+    ) {
+      return deliveries(context.env.DB, parts[1]);
+    }
+    if (
+      method === "POST" &&
+      parts[0] === "deliveries" &&
+      parts[1] &&
+      parts.length === 2
+    ) {
+      return retryDelivery(request, context.env.DB, parts[1], context.data.organizer, context.env);
+    }
+    if (
+      method === "POST" &&
+      parts[0] === "events" &&
+      parts[1] &&
       parts[2] === "generate-all" &&
       parts.length === 3
     ) {
-      return generateAll(request, context.env.DB, parts[1], context.data.organizer);
+      return generateAll(
+        context.env.DB,
+        parts[1],
+        context.data.organizer,
+        publicOrigin(request, context.env),
+      );
     }
     if (
       method === "POST" &&
@@ -391,7 +1215,14 @@ export const onRequest: AppPagesFunction = async (context) => {
       parts[4] === "generate" &&
       parts.length === 5
     ) {
-      return generateOne(request, context.env.DB, parts[1], parts[3], context.data.organizer);
+      return generateOne(
+        request,
+        context.env.DB,
+        parts[1],
+        parts[3],
+        context.data.organizer,
+        publicOrigin(request, context.env),
+      );
     }
     if (
       method === "POST" &&

--- a/index.html
+++ b/index.html
@@ -5,9 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Plan, run, and close BroTM Poker nights." />
     <meta name="theme-color" content="#075b3b" />
-    <link rel="icon" href="/icon.svg?v=2" type="image/svg+xml" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2" />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icon.svg?v=2" type="image/svg+xml" />
     <title>BroTM Poker</title>
   </head>
   <body>

--- a/migrations/0005_invite_delivery.sql
+++ b/migrations/0005_invite_delivery.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE invite_deliveries (
+  id TEXT PRIMARY KEY,
+  event_invite_id TEXT NOT NULL REFERENCES event_invites(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL CHECK (channel IN ('email', 'sms')),
+  destination TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('sending', 'sent', 'failed')),
+  provider_message_id TEXT,
+  error_message TEXT,
+  token_hash TEXT NOT NULL,
+  requested_by_organizer_id TEXT NOT NULL REFERENCES organizers(id),
+  created_at TEXT NOT NULL,
+  completed_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX invite_deliveries_invite_created_idx
+ON invite_deliveries(event_invite_id, created_at);
+
+CREATE INDEX invite_deliveries_channel_status_idx
+ON invite_deliveries(channel, status, created_at);

--- a/migrations/0006_delivery_batches.sql
+++ b/migrations/0006_delivery_batches.sql
@@ -1,0 +1,66 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE players
+ADD COLUMN preferred_channel TEXT NOT NULL DEFAULT 'email'
+CHECK (preferred_channel IN ('email', 'sms'));
+
+CREATE TABLE delivery_batches (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  requested_by_organizer_id TEXT NOT NULL REFERENCES organizers(id),
+  requested_channels_json TEXT NOT NULL,
+  policy TEXT NOT NULL CHECK (policy IN ('requested_channels', 'preferred_with_fallback')),
+  source TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual', 'scheduled')),
+  status TEXT NOT NULL CHECK (status IN ('sending', 'completed', 'partial', 'failed')),
+  requested_count INTEGER NOT NULL DEFAULT 0,
+  sent_count INTEGER NOT NULL DEFAULT 0,
+  failed_count INTEGER NOT NULL DEFAULT 0,
+  skipped_count INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  completed_at TEXT
+);
+
+CREATE INDEX delivery_batches_event_created_idx
+ON delivery_batches(event_id, created_at DESC);
+
+CREATE TABLE invite_delivery_results (
+  id TEXT PRIMARY KEY,
+  batch_id TEXT NOT NULL REFERENCES delivery_batches(id) ON DELETE CASCADE,
+  event_player_id TEXT NOT NULL REFERENCES event_players(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL CHECK (channel IN ('email', 'sms')),
+  destination TEXT,
+  status TEXT NOT NULL CHECK (status IN ('sent', 'failed', 'skipped')),
+  delivery_id TEXT,
+  error_message TEXT,
+  token_hash TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(batch_id, event_player_id, channel)
+);
+
+CREATE INDEX invite_delivery_results_batch_idx
+ON invite_delivery_results(batch_id, created_at);
+
+CREATE INDEX invite_delivery_results_player_idx
+ON invite_delivery_results(event_player_id, created_at DESC);
+
+ALTER TABLE invite_deliveries
+ADD COLUMN batch_id TEXT REFERENCES delivery_batches(id) ON DELETE SET NULL;
+
+ALTER TABLE invite_deliveries
+ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE invite_deliveries
+ADD COLUMN idempotency_key TEXT;
+
+ALTER TABLE invite_deliveries
+ADD COLUMN provider_status TEXT;
+
+ALTER TABLE invite_deliveries
+ADD COLUMN provider_status_at TEXT;
+
+CREATE INDEX invite_deliveries_batch_idx
+ON invite_deliveries(batch_id, created_at);
+
+CREATE INDEX invite_deliveries_idempotency_idx
+ON invite_deliveries(idempotency_key);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3271 @@
+{
+  "name": "brotm-poker",
+  "version": "2.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "brotm-poker",
+      "version": "2.1.0",
+      "dependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.18.0",
+        "zod": "^4.4.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "latest",
+        "@types/react": "latest",
+        "@types/react-dom": "latest",
+        "@vitejs/plugin-react": "latest",
+        "typescript": "latest",
+        "vite": "latest",
+        "vitest": "latest",
+        "wrangler": "latest"
+      },
+      "engines": {
+        "node": ">=22.12"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260801.1.tgz",
+      "integrity": "sha512-XCv5xWi47WQOK0LpLa6997Mrpz8Ct+nZmp/M5Xp8Z4BFsarf7nYjkznGOcOoYK5m1GfbMFEEuQ2OIZnbIWoe9A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.23.tgz",
+      "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260730.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260730.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260730.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260730.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Private organizer application for BroTM Poker nights.",
   "scripts": {
-    "dev": "wrangler pages dev dist --d1=DB --compatibility-date=2026-07-21",
+    "dev": "wrangler pages dev dist --d1=DB=local-brotm-poker --compatibility-date=2026-07-21 --binding AUTH_MODE=public --binding DEV_ORGANIZER_EMAIL=dev@example.com --binding DELIVERY_MODE=log --binding PUBLIC_APP_ORIGIN=http://localhost:8788 --show-interactive-dev-session false",
+    "dev:worker": "wrangler dev worker.ts --config wrangler.worker.jsonc",
     "dev:web": "vite",
     "build": "vite build",
     "format:check": "node scripts/format-check.mjs",
@@ -14,7 +15,8 @@
     "test": "vitest run",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build",
     "db:migrate:local": "wrangler d1 migrations apply brotm-poker --local --config wrangler.local.jsonc",
-    "db:migrate:remote": "wrangler d1 migrations apply brotm-poker --remote --config wrangler.local.jsonc"
+    "db:migrate:remote": "wrangler d1 migrations apply brotm-poker --remote --config wrangler.local.jsonc",
+    "deploy:worker": "wrangler deploy --config wrangler.worker.jsonc"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,33 @@
+const CACHE = "brotm-shell-v1";
+const SHELL = ["/", "/index.html", "/manifest.webmanifest", "/icon.svg", "/icon-1024.png", "/apple-touch-icon.png"];
+const API_PREFIXES = ["/api/", "/rsvp-api/", "/rsvp-admin-api/", "/ops-api/", "/money-api/"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(SHELL)));
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)))),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  if (request.method !== "GET" || new URL(request.url).origin !== self.location.origin) return;
+  const url = new URL(request.url);
+  if (API_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))) return;
+
+  if (request.mode === "navigate") {
+    event.respondWith(fetch(request).catch(() => caches.match("/index.html")));
+    return;
+  }
+
+  event.respondWith(caches.match(request).then((cached) => cached || fetch(request).then((response) => {
+    const copy = response.clone();
+    void caches.open(CACHE).then((cache) => cache.put(request, copy));
+    return response;
+  })));
+});

--- a/shared/app-shell.ts
+++ b/shared/app-shell.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "2.3.0";
-export const REQUIRED_SCHEMA_VERSION = 4;
+export const APP_VERSION = "2.4.0";
+export const REQUIRED_SCHEMA_VERSION = 6;
 
 export interface HealthReport {
   ok: boolean;

--- a/shared/delivery.ts
+++ b/shared/delivery.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export const deliveryChannels = ["email", "sms"] as const;
+export type DeliveryChannel = (typeof deliveryChannels)[number];
+
+export const deliveryStatuses = ["sending", "sent", "failed"] as const;
+export type DeliveryStatus = (typeof deliveryStatuses)[number];
+
+export const deliveryPolicies = ["requested_channels", "preferred_with_fallback"] as const;
+export type DeliveryPolicy = (typeof deliveryPolicies)[number];
+
+export const deliverySources = ["manual", "scheduled"] as const;
+export type DeliverySource = (typeof deliverySources)[number];
+
+export const deliveryResultStatuses = ["sent", "failed", "skipped"] as const;
+export type DeliveryResultStatus = (typeof deliveryResultStatuses)[number];
+
+export const sendInvitesSchema = z
+  .object({
+    playerIds: z.array(z.string().uuid()).max(50).optional(),
+    channels: z.array(z.enum(deliveryChannels)).min(1).max(2),
+    policy: z.enum(deliveryPolicies).default("requested_channels"),
+    requestId: z.string().uuid().optional(),
+  })
+  .refine(
+    (value) => new Set(value.channels).size === value.channels.length,
+    "Each delivery channel may only be requested once",
+  );
+
+export type SendInvitesRequest = z.infer<typeof sendInvitesSchema>;
+
+export interface DeliveryBatchSummary {
+  requested: number;
+  sent: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface DeliveryResult {
+  deliveryId: string | null;
+  playerId: string;
+  playerName: string;
+  channel: DeliveryChannel;
+  destination: string | null;
+  provider: string | null;
+  status: DeliveryResultStatus;
+  errorMessage: string | null;
+}
+
+export interface SendInvitesResponse {
+  batchId: string;
+  summary: DeliveryBatchSummary;
+  results: DeliveryResult[];
+}
+
+export interface DeliveryMessage {
+  channel: DeliveryChannel;
+  destination: string;
+  subject?: string;
+  text: string;
+  html?: string;
+  idempotencyKey: string;
+}
+
+export interface ProviderDeliveryResult {
+  provider: string;
+  providerMessageId: string | null;
+}

--- a/shared/domain.ts
+++ b/shared/domain.ts
@@ -16,6 +16,9 @@ export type RsvpStatus = (typeof rsvpStatuses)[number];
 export const invitationStatuses = ["invited", "not_invited"] as const;
 export type InvitationStatus = (typeof invitationStatuses)[number];
 
+export const preferredChannels = ["email", "sms"] as const;
+export type PreferredChannel = (typeof preferredChannels)[number];
+
 const optionalEmail = z.string().trim().email().max(200).optional().or(z.literal(""));
 const correctionNote = z.string().trim().min(3).max(500).optional();
 
@@ -25,6 +28,7 @@ export const playerCreateSchema = z.object({
   displayName: z.string().trim().min(1).max(120).optional(),
   email: optionalEmail,
   phone: z.string().trim().max(40).optional(),
+  preferredChannel: z.enum(preferredChannels).default("email"),
   notes: z.string().trim().max(1000).optional(),
 });
 
@@ -35,6 +39,7 @@ export const playerPatchSchema = z
     displayName: z.string().trim().max(120).optional(),
     email: optionalEmail,
     phone: z.string().trim().max(40).optional(),
+    preferredChannel: z.enum(preferredChannels).optional(),
     notes: z.string().trim().max(1000).optional(),
     status: z.enum(["active", "archived"]).optional(),
   })

--- a/shared/rsvp.ts
+++ b/shared/rsvp.ts
@@ -49,6 +49,44 @@ export function buildPersonalizedInviteText(input: PersonalizedInviteInput, loca
   return lines.join("\n");
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function formattedInviteTime(startsAt: string, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "full",
+    timeStyle: "short",
+  }).format(new Date(startsAt));
+}
+
+export function buildPersonalizedInviteEmail(
+  input: PersonalizedInviteInput,
+  locale = "en-US",
+): { subject: string; text: string; html: string } {
+  const text = buildPersonalizedInviteText(input, locale);
+  const lines = text.split("\n");
+  const escapedLines = lines.map((line) => `<p>${escapeHtml(line)}</p>`).join("");
+  const subject = `BroTM Poker: ${input.title} — RSVP`;
+  const html = `${escapedLines}<p><a href="${escapeHtml(input.rsvpUrl)}">RSVP yes, maybe, or no</a></p>`;
+  return { subject, text, html };
+}
+
+export function buildPersonalizedInviteSms(input: PersonalizedInviteInput, locale = "en-US"): string {
+  const lines = [`BroTM Poker: ${input.title}`, formattedInviteTime(input.startsAt, locale)];
+  if (input.hostName) lines.push(`Host: ${input.hostName}`);
+  if (input.locationVisibility === "always" && input.location) lines.push(`Location: ${input.location}`);
+  if (input.locationVisibility === "after_yes") lines.push("Address appears after a Yes RSVP.");
+  lines.push(`RSVP: ${input.rsvpUrl}`);
+  const message = lines.join(" | ");
+  return message.length <= 480 ? message : `${message.slice(0, 477)}...`;
+}
+
 export function createRsvpToken(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-router-dom";
 import { api, ApiError } from "./api";
 import { BrandMark } from "./BrandMark";
+import { useLocalDraft } from "./useLocalDraft";
 import type {
   DashboardData,
   EventAuditEntry,
@@ -28,6 +29,15 @@ interface EventDetailResponse {
   players: EventPlayer[];
   audits: EventAuditEntry[];
 }
+
+const newEventInitialDraft = {
+  title: "Poker Night",
+  startsAt: "",
+  hostPlayerId: "",
+  location: "",
+  gameNotes: "",
+  notes: "",
+};
 
 function formatDate(value: string): string {
   return new Intl.DateTimeFormat("en-US", {
@@ -232,6 +242,7 @@ function DashboardPage() {
 function PlayersPage() {
   const [players, setPlayers] = useState<Player[]>();
   const [filter, setFilter] = useState<"active" | "archived" | "all">("active");
+  const [query, setQuery] = useState("");
   const [error, setError] = useState<unknown>();
   const [saving, setSaving] = useState(false);
 
@@ -248,6 +259,16 @@ function PlayersPage() {
   useEffect(() => {
     void load(filter);
   }, [filter]);
+
+  const visiblePlayers = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return players ?? [];
+    return (players ?? []).filter((player) =>
+      [player.displayName, player.email ?? "", player.phone ?? ""].some((value) =>
+        value.toLowerCase().includes(normalized),
+      ),
+    );
+  }, [players, query]);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -330,13 +351,22 @@ function PlayersPage() {
                 ))}
               </div>
             </div>
-            <span>{players?.length ?? 0}</span>
+            <span>{visiblePlayers.length} shown</span>
           </div>
+          <label className="search-field directory-search">
+            <span className="sr-only">Search players</span>
+            <input
+              type="search"
+              placeholder="Search by name, email, or phone"
+              value={query}
+              onChange={(change) => setQuery(change.target.value)}
+            />
+          </label>
           {!players ? (
             <Loading label="Loading players" />
-          ) : players.length ? (
+          ) : visiblePlayers.length ? (
             <div className="person-list">
-              {players.map((player) => (
+              {visiblePlayers.map((player) => (
                 <Link className="person-row" to={`/players/${player.id}`} key={player.id}>
                   <span className="avatar" aria-hidden="true">
                     {player.displayName.slice(0, 1).toUpperCase()}
@@ -346,7 +376,11 @@ function PlayersPage() {
                       <strong>{player.displayName}</strong>
                       <PlayerStatusBadge status={player.status} />
                     </span>
-                    <small>{player.email || player.phone || "No contact details"}</small>
+                    <small>
+                      {player.email ? <span className="contact-chip">Email</span> : null}
+                      {player.phone ? <span className="contact-chip">Text</span> : null}
+                      {!player.email && !player.phone ? "No contact details" : null}
+                    </small>
                   </span>
                 </Link>
               ))}
@@ -520,6 +554,7 @@ function NewEventPage() {
   const [error, setError] = useState<unknown>();
   const [saving, setSaving] = useState(false);
   const navigate = useNavigate();
+  const draft = useLocalDraft("brotm:new-event", newEventInitialDraft);
 
   useEffect(() => {
     api<{ players: Player[] }>("/api/players")
@@ -529,22 +564,22 @@ function NewEventPage() {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const fields = new FormData(event.currentTarget);
     setSaving(true);
     setError(undefined);
     try {
-      const startsAt = new Date(formValue(fields, "startsAt")).toISOString();
+      const startsAt = new Date(draft.value.startsAt).toISOString();
       const response = await api<{ event: PokerEvent }>("/api/events", {
         method: "POST",
         body: JSON.stringify({
-          title: formValue(fields, "title"),
+          title: draft.value.title,
           startsAt,
-          hostPlayerId: formValue(fields, "hostPlayerId") || null,
-          location: formValue(fields, "location"),
-          gameNotes: formValue(fields, "gameNotes") || undefined,
-          notes: formValue(fields, "notes") || undefined,
+          hostPlayerId: draft.value.hostPlayerId || null,
+          location: draft.value.location,
+          gameNotes: draft.value.gameNotes || undefined,
+          notes: draft.value.notes || undefined,
         }),
       });
+      draft.clear();
       navigate(`/events/${response.event.id}`);
     } catch (caught) {
       setError(caught);
@@ -557,19 +592,20 @@ function NewEventPage() {
     <>
       <PageHeader eyebrow="Plan" title="New poker night" />
       {error ? <ErrorPanel error={error} /> : null}
+      {draft.savedAt ? <p className="draft-status">Draft saved on this device.</p> : null}
       <section className="panel narrow-panel">
         <form className="form-stack" onSubmit={submit}>
           <label>
             Event title
-            <input name="title" defaultValue="Poker Night" required maxLength={120} />
+            <input name="title" value={draft.value.title} onChange={(change) => draft.setValue((current) => ({ ...current, title: change.target.value }))} required maxLength={120} />
           </label>
           <label>
             Date and start time
-            <input name="startsAt" type="datetime-local" required />
+            <input name="startsAt" type="datetime-local" value={draft.value.startsAt} onChange={(change) => draft.setValue((current) => ({ ...current, startsAt: change.target.value }))} required />
           </label>
           <label>
             Host <span className="field-hint">optional</span>
-            <select name="hostPlayerId" defaultValue="">
+            <select name="hostPlayerId" value={draft.value.hostPlayerId} onChange={(change) => draft.setValue((current) => ({ ...current, hostPlayerId: change.target.value }))}>
               <option value="">No host selected</option>
               {players.map((player) => (
                 <option value={player.id} key={player.id}>
@@ -580,15 +616,15 @@ function NewEventPage() {
           </label>
           <label>
             Location or address
-            <input name="location" maxLength={240} />
+            <input name="location" value={draft.value.location} onChange={(change) => draft.setValue((current) => ({ ...current, location: change.target.value }))} maxLength={240} />
           </label>
           <label>
             Game and house-rule notes <span className="field-hint">optional</span>
-            <textarea name="gameNotes" rows={4} maxLength={1200} />
+            <textarea name="gameNotes" value={draft.value.gameNotes} onChange={(change) => draft.setValue((current) => ({ ...current, gameNotes: change.target.value }))} rows={4} maxLength={1200} />
           </label>
           <label>
             General event notes <span className="field-hint">optional</span>
-            <textarea name="notes" rows={4} maxLength={1200} />
+            <textarea name="notes" value={draft.value.notes} onChange={(change) => draft.setValue((current) => ({ ...current, notes: change.target.value }))} rows={4} maxLength={1200} />
           </label>
           <Button disabled={saving}>{saving ? "Creating…" : "Create draft"}</Button>
         </form>
@@ -630,6 +666,7 @@ function EventPlayerEditor({
         <div>
           <strong>{player.displayName}</strong>
           <small>{player.attended ? "Attended" : "Not checked in"}</small>
+          <small>{player.contact.email || "No email saved"}</small>
         </div>
       </div>
       <div className="roster-field-grid">
@@ -704,6 +741,7 @@ function EventPlayerEditor({
 
 function EventDetailPage() {
   const { id = "" } = useParams();
+  const navigate = useNavigate();
   const [event, setEvent] = useState<PokerEvent>();
   const [eventPlayers, setEventPlayers] = useState<EventPlayer[]>([]);
   const [audits, setAudits] = useState<EventAuditEntry[]>([]);
@@ -714,14 +752,23 @@ function EventDetailPage() {
   const [error, setError] = useState<unknown>();
   const [saving, setSaving] = useState(false);
   const [savedMessage, setSavedMessage] = useState<string>();
+  const [lastUpdated, setLastUpdated] = useState<string>();
+  const [stale, setStale] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [rosterQuery, setRosterQuery] = useState("");
+  const [rosterFilter, setRosterFilter] = useState<"all" | "expected" | "attending" | "pending">("all");
+  const eventNotesDraft = useLocalDraft(`brotm:event:${id}:notes`, event?.notes ?? "");
 
   const applyDetail = (detail: EventDetailResponse) => {
     setEvent(detail.event);
     setEventPlayers(detail.players);
     setAudits(detail.audits);
+    setLastUpdated(new Date().toISOString());
+    setStale(false);
   };
 
-  const load = async () => {
+  const load = async (silent = false) => {
+    if (!silent) setRefreshing(true);
     try {
       const [detail, players] = await Promise.all([
         api<EventDetailResponse>(`/api/events/${id}`),
@@ -731,18 +778,59 @@ function EventDetailPage() {
       setDirectory(players.players);
       setError(undefined);
     } catch (caught) {
-      setError(caught);
+      setStale(true);
+      if (!silent) setError(caught);
+    } finally {
+      if (!silent) setRefreshing(false);
     }
   };
 
   useEffect(() => {
     void load();
+    const refresh = () => {
+      if (document.visibilityState === "visible") void load(true);
+    };
+    const interval = window.setInterval(refresh, 15_000);
+    document.addEventListener("visibilitychange", refresh);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", refresh);
+    };
   }, [id]);
 
   const availablePlayers = useMemo(
     () => directory.filter((player) => !eventPlayers.some((entry) => entry.playerId === player.id)),
     [directory, eventPlayers],
   );
+
+  const visiblePlayers = useMemo(() => {
+    const query = rosterQuery.trim().toLowerCase();
+    return eventPlayers.filter((player) => {
+      const matchesQuery = !query || player.displayName.toLowerCase().includes(query);
+      const matchesFilter =
+        rosterFilter === "all" ||
+        (rosterFilter === "expected" && ["yes", "maybe"].includes(player.rsvpStatus)) ||
+        (rosterFilter === "attending" && player.attended) ||
+        (rosterFilter === "pending" && player.invitationStatus === "invited" && player.rsvpStatus === "pending");
+      return matchesQuery && matchesFilter;
+    });
+  }, [eventPlayers, rosterFilter, rosterQuery]);
+
+  const expectedCount = eventPlayers.filter((player) => ["yes", "maybe"].includes(player.rsvpStatus)).length;
+  const checkedInCount = eventPlayers.filter((player) => player.attended).length;
+  const pendingCount = eventPlayers.filter(
+    (player) => player.invitationStatus === "invited" && player.rsvpStatus === "pending",
+  ).length;
+  const inviteReadiness = useMemo(() => {
+    const eligible = eventPlayers.filter((player) => player.invitationStatus === "invited");
+    const emailReady = eligible.filter((eventPlayer) => directory.some((player) => player.id === eventPlayer.playerId && Boolean(player.email)));
+    return {
+      eligible: eligible.length,
+      emailReady: emailReady.length,
+      missingEmail: eligible.length - emailReady.length,
+      excluded: eventPlayers.length - eligible.length,
+    };
+  }, [directory, eventPlayers]);
 
   if (error && !event) return <ErrorPanel error={error} />;
   if (!event) return <Loading label="Loading poker night" />;
@@ -774,6 +862,7 @@ function EventDetailPage() {
         }),
       });
       await load();
+      eventNotesDraft.clear();
       setSavedMessage(locked ? "Completed event correction saved and audited." : "Event details saved.");
     } catch (caught) {
       setError(caught);
@@ -900,15 +989,40 @@ function EventDetailPage() {
     }
   }
 
+  async function duplicate() {
+    setSaving(true);
+    setError(undefined);
+    try {
+      const response = await api<{ event: { id: string } }>(`/ops-api/events/${id}/duplicate`, { method: "POST" });
+      navigate(`/events/${response.event.id}`);
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <>
       <PageHeader
         eyebrow="Poker night"
         title={event.title}
-        actions={<StatusBadge status={event.status} />}
+        actions={
+          <>
+            {!locked ? <Button type="button" variant="secondary" disabled={saving} onClick={() => void duplicate()}>Duplicate</Button> : null}
+            <StatusBadge status={event.status} />
+          </>
+        }
       />
       {error ? <ErrorPanel error={error} /> : null}
       {savedMessage ? <SuccessPanel>{savedMessage}</SuccessPanel> : null}
+      <div className={`sync-status ${stale ? "is-stale" : ""}`} role="status">
+        <span>{stale ? "Live data may be out of date." : "Live workspace"}</span>
+        <span>{lastUpdated ? `Updated ${formatDate(lastUpdated)}` : "Connecting…"}</span>
+        <Button type="button" variant="secondary" disabled={refreshing || saving} onClick={() => void load()}>
+          {refreshing ? "Refreshing…" : "Refresh"}
+        </Button>
+      </div>
 
       <section className="event-hero panel">
         <div>
@@ -926,6 +1040,44 @@ function EventDetailPage() {
         <div>
           <span>Attendance</span>
           <strong>{event.attendanceCount}</strong>
+        </div>
+      </section>
+
+      <section className="live-summary-bar" aria-label="Live night summary">
+        <div><strong>{checkedInCount}</strong><span>checked in</span></div>
+        <div><strong>{expectedCount}</strong><span>expected</span></div>
+        <div><strong>{pendingCount}</strong><span>awaiting RSVP</span></div>
+        <div><strong>{eventPlayers.length}</strong><span>rostered</span></div>
+      </section>
+
+      <section className="panel invite-readiness-panel" aria-labelledby="invite-readiness-title">
+        <div>
+          <p className="eyebrow">Invitation workflow</p>
+          <h2 id="invite-readiness-title">{event.status === "draft" ? "Get this night ready to invite" : "Invite the roster"}</h2>
+          <p className="panel-muted">
+            {event.status === "draft"
+              ? "Save the event details, add the players, then open invitations to review the email roster."
+              : "Review the email-ready players, confirm once, and send each person a private RSVP link."}
+          </p>
+        </div>
+        <div className="invite-readiness-stats">
+          <span><strong>{inviteReadiness.eligible}</strong> eligible</span>
+          <span><strong>{inviteReadiness.emailReady}</strong> email-ready</span>
+          <span className={inviteReadiness.missingEmail ? "is-warning" : ""}><strong>{inviteReadiness.missingEmail}</strong> missing email</span>
+          <span><strong>{inviteReadiness.excluded}</strong> excluded</span>
+        </div>
+        <div className="invite-readiness-actions">
+          {event.status === "draft" ? (
+            <Button type="button" disabled={saving} onClick={() => void transition("open")}>
+              Open invitations
+            </Button>
+          ) : null}
+          {event.status === "open" || event.status === "active" ? (
+            <Button type="button" disabled={saving || !inviteReadiness.eligible} onClick={() => navigate(`/events/${id}/rsvp-links?invite=1`)}>
+              Invite roster
+            </Button>
+          ) : null}
+          <Link className="button button-secondary" to={`/events/${id}/rsvp-links`}>Review RSVP setup</Link>
         </div>
       </section>
 
@@ -976,11 +1128,6 @@ function EventDetailPage() {
         </section>
       ) : (
         <section className="workflow-bar" aria-label="Event workflow actions">
-          {event.status === "draft" ? (
-            <Button onClick={() => void transition("open")} disabled={saving}>
-              Open invitations
-            </Button>
-          ) : null}
           {event.status === "open" ? (
             <Button onClick={() => void transition("active")} disabled={saving}>
               Start Live Night
@@ -1059,11 +1206,15 @@ function EventDetailPage() {
             <textarea
               name="notes"
               rows={4}
-              defaultValue={event.notes ?? ""}
+              value={eventNotesDraft.value}
+              onChange={(change) => eventNotesDraft.setValue(change.target.value)}
               maxLength={1200}
               disabled={editDisabled}
             />
           </label>
+          {eventNotesDraft.savedAt ? (
+            <small className="draft-status form-grid-wide">Draft saved locally. It is not synced until you save event details.</small>
+          ) : null}
           <Button className="form-grid-action" disabled={editDisabled}>
             {saving ? "Saving…" : "Save event details"}
           </Button>
@@ -1077,7 +1228,7 @@ function EventDetailPage() {
               <p className="eyebrow">Roster</p>
               <h2>Players and attendance</h2>
             </div>
-            <span>{eventPlayers.length}</span>
+            <span>{visiblePlayers.length} shown</span>
           </div>
 
           <div className="inline-form">
@@ -1104,9 +1255,33 @@ function EventDetailPage() {
             </Button>
           </div>
 
+          <div className="roster-toolbar">
+            <label className="search-field">
+              <span className="sr-only">Search roster</span>
+              <input
+                type="search"
+                placeholder="Search players"
+                value={rosterQuery}
+                onChange={(change) => setRosterQuery(change.target.value)}
+              />
+            </label>
+            <div className="roster-filters" aria-label="Roster filter">
+              {(["all", "expected", "attending", "pending"] as const).map((filter) => (
+                <button
+                  className={`roster-filter ${rosterFilter === filter ? "active" : ""}`}
+                  type="button"
+                  key={filter}
+                  onClick={() => setRosterFilter(filter)}
+                >
+                  {filter === "all" ? "Everyone" : filter === "expected" ? "Expected" : filter === "attending" ? "Checked in" : "Pending"}
+                </button>
+              ))}
+            </div>
+          </div>
+
           <div className="live-roster">
-            {eventPlayers.length ? (
-              eventPlayers.map((player) => (
+            {visiblePlayers.length ? (
+              visiblePlayers.map((player) => (
                 <EventPlayerEditor
                   key={player.id}
                   player={player}
@@ -1117,7 +1292,7 @@ function EventDetailPage() {
                 />
               ))
             ) : (
-              <EmptyState>Add players to build the event roster.</EmptyState>
+              <EmptyState>{eventPlayers.length ? "No roster players match this view." : "Add players to build the event roster."}</EmptyState>
             )}
           </div>
         </section>
@@ -1154,12 +1329,26 @@ function EventDetailPage() {
 function HistoryPage() {
   const [events, setEvents] = useState<PokerEvent[]>();
   const [error, setError] = useState<unknown>();
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     api<{ events: PokerEvent[] }>("/api/events?status=completed")
       .then((response) => setEvents(response.events))
       .catch(setError);
   }, []);
+
+  const visibleEvents = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return events ?? [];
+    return (events ?? []).filter((event) =>
+      [event.title, event.location, event.hostName ?? ""].some((value) =>
+        value.toLowerCase().includes(normalized),
+      ),
+    );
+  }, [events, query]);
+
+  const attendanceTotal = (events ?? []).reduce((total, event) => total + event.attendanceCount, 0);
+  const attendanceAverage = events?.length ? Math.round(attendanceTotal / events.length) : 0;
 
   return (
     <>
@@ -1168,9 +1357,25 @@ function HistoryPage() {
       {!events ? (
         <Loading label="Loading history" />
       ) : events.length ? (
-        <div className="card-list event-grid">
-          {events.map((event) => <EventCard event={event} key={event.id} />)}
-        </div>
+        <>
+          <section className="metric-grid history-summary" aria-label="Attendance history summary">
+            <article className="metric-card"><span>Completed nights</span><strong>{events.length}</strong></article>
+            <article className="metric-card"><span>Total check-ins</span><strong>{attendanceTotal}</strong></article>
+            <article className="metric-card"><span>Average attendance</span><strong>{attendanceAverage}</strong></article>
+          </section>
+          <label className="search-field history-search">
+            <span className="sr-only">Search history</span>
+            <input
+              type="search"
+              placeholder="Search completed nights"
+              value={query}
+              onChange={(change) => setQuery(change.target.value)}
+            />
+          </label>
+          {visibleEvents.length ? <div className="card-list event-grid">
+            {visibleEvents.map((event) => <EventCard event={event} key={event.id} />)}
+          </div> : <EmptyState>No completed nights match that search.</EmptyState>}
+        </>
       ) : (
         <EmptyState>Complete the first poker night to begin history.</EmptyState>
       )}

--- a/src/Rsvp.tsx
+++ b/src/Rsvp.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import type { DeliveryChannel, DeliveryStatus } from "../shared/delivery";
 import type { PublicRsvpStatus, RsvpLocationVisibility } from "../shared/rsvp";
 import { api } from "./api";
 import { BrandMark } from "./BrandMark";
@@ -42,7 +43,16 @@ interface AdminRsvpPlayer {
   displayName: string;
   invitationStatus: "invited" | "not_invited";
   rsvpStatus: "pending" | PublicRsvpStatus;
+  contact: { email: string | null; phone: string | null };
   invite: AdminInviteState;
+  latestDelivery: Record<DeliveryChannel, LatestDelivery | null>;
+}
+
+interface LatestDelivery {
+  status: DeliveryStatus;
+  provider: string | null;
+  at: string | null;
+  errorMessage: string | null;
 }
 
 interface AdminRsvpDetail {
@@ -66,6 +76,54 @@ interface GeneratedInvite {
   url: string;
   inviteText: string;
   expiresAt: string;
+}
+
+interface AdminDelivery {
+  id: string;
+  playerId: string;
+  playerName: string;
+  channel: DeliveryChannel;
+  destination: string;
+  provider: string;
+  status: DeliveryStatus;
+  providerMessageId: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  completedAt: string | null;
+  batchId: string | null;
+  attempt: number;
+  providerStatus: string | null;
+  providerStatusAt: string | null;
+}
+
+interface AdminDeliveryBatch {
+  id: string;
+  policy: "requested_channels" | "preferred_with_fallback";
+  source: "manual" | "scheduled";
+  status: "sending" | "completed" | "partial" | "failed";
+  summary: { requested: number; sent: number; failed: number; skipped: number };
+  createdAt: string;
+  completedAt: string | null;
+}
+
+interface SendInvitesResponse {
+  batchId: string;
+  summary: { requested: number; sent: number; failed: number; skipped: number };
+  results: Array<{
+    deliveryId: string | null;
+    playerId: string;
+    playerName: string;
+    channel: DeliveryChannel;
+    destination: string | null;
+    provider: string | null;
+    status: "sent" | "failed" | "skipped";
+    errorMessage: string | null;
+  }>;
+}
+
+interface PendingSend {
+  playerIds?: string[];
+  targetLabel: string;
 }
 
 function formatDate(value: string): string {
@@ -232,15 +290,27 @@ function inviteStatus(player: AdminRsvpPlayer): string {
 
 export function RsvpAdminPage() {
   const { id = "" } = useParams();
+  const [searchParams] = useSearchParams();
   const [detail, setDetail] = useState<AdminRsvpDetail>();
+  const [deliveries, setDeliveries] = useState<AdminDelivery[]>([]);
+  const [batches, setBatches] = useState<AdminDeliveryBatch[]>([]);
   const [generated, setGenerated] = useState<Record<string, GeneratedInvite>>({});
   const [error, setError] = useState<unknown>();
   const [message, setMessage] = useState<string>();
   const [saving, setSaving] = useState(false);
+  const [pendingSend, setPendingSend] = useState<PendingSend>();
+  const confirmSendButton = useRef<HTMLButtonElement>(null);
+  const didAutoOpenInvite = useRef(false);
 
   const load = async () => {
     try {
-      setDetail(await api<AdminRsvpDetail>(`/rsvp-admin-api/events/${id}`));
+      const [nextDetail, deliveryResponse] = await Promise.all([
+        api<AdminRsvpDetail>(`/rsvp-admin-api/events/${id}`),
+        api<{ deliveries: AdminDelivery[]; batches: AdminDeliveryBatch[] }>(`/rsvp-admin-api/events/${id}/deliveries`),
+      ]);
+      setDetail(nextDetail);
+      setDeliveries(deliveryResponse.deliveries);
+      setBatches(deliveryResponse.batches);
       setError(undefined);
     } catch (caught) {
       setError(caught);
@@ -250,6 +320,15 @@ export function RsvpAdminPage() {
   useEffect(() => {
     void load();
   }, [id]);
+
+  useEffect(() => {
+    if (!detail || didAutoOpenInvite.current || searchParams.get("invite") !== "1") return;
+    didAutoOpenInvite.current = true;
+    if (detail.event.status === "open" || detail.event.status === "active") {
+      const invited = detail.players.filter((player) => player.invitationStatus === "invited");
+      if (invited.length) setPendingSend({ targetLabel: `${invited.length} rostered players` });
+    }
+  }, [detail, searchParams]);
 
   const invitedPlayers = useMemo(
     () => detail?.players.filter((player) => player.invitationStatus === "invited") ?? [],
@@ -289,6 +368,39 @@ export function RsvpAdminPage() {
       setGenerated(next);
       await copyText(response.generated.map((invite) => invite.inviteText).join("\n\n---\n\n"));
       setMessage(`${response.generated.length} personalized invitations were generated and copied.`);
+      await load();
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function requestSendInvites(playerIds?: string[]) {
+    const target = playerIds?.length === 1
+      ? "this player"
+      : `${playerIds?.length ?? invitedPlayers.length} rostered players`;
+    setPendingSend({ playerIds, targetLabel: target });
+  }
+
+  async function sendInvites(playerIds?: string[]) {
+    setPendingSend(undefined);
+    setSaving(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      const response = await api<SendInvitesResponse>(`/rsvp-admin-api/events/${id}/send-invites`, {
+        method: "POST",
+        body: JSON.stringify({
+          channels: ["email"],
+          requestId: crypto.randomUUID(),
+          ...(playerIds ? { playerIds } : {}),
+        }),
+      });
+      const { summary } = response;
+      setMessage(
+        `Batch ${response.batchId.slice(0, 8)} processed: ${summary.sent} sent, ${summary.failed} failed, ${summary.skipped} skipped.`,
+      );
       await load();
     } catch (caught) {
       setError(caught);
@@ -351,13 +463,87 @@ export function RsvpAdminPage() {
     }
   }
 
+  async function retryDelivery(delivery: AdminDelivery) {
+    if (delivery.status !== "failed") return;
+    setSaving(true);
+    setError(undefined);
+    setMessage(undefined);
+    try {
+      const response = await api<SendInvitesResponse>(`/rsvp-admin-api/deliveries/${delivery.id}/retry`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      });
+      setMessage(`Retry processed: ${response.summary.sent} sent, ${response.summary.failed} failed, ${response.summary.skipped} skipped.`);
+      await load();
+    } catch (caught) {
+      setError(caught);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  useEffect(() => {
+    if (pendingSend) confirmSendButton.current?.focus();
+  }, [pendingSend]);
+
   if (error && !detail) return <div className="state-card state-error">{errorMessage(error)}</div>;
   if (!detail) return <div className="state-card">Loading RSVP links…</div>;
 
   const locked = ["completed", "cancelled", "archived"].includes(detail.event.status);
+  const sendable = detail.event.status === "open" || detail.event.status === "active";
+  const contactSummary = {
+    email: invitedPlayers.filter((player) => Boolean(player.contact.email)).length,
+    missing: invitedPlayers.filter((player) => !player.contact.email).length,
+    excluded: (detail?.players.length ?? 0) - invitedPlayers.length,
+  };
 
   return (
     <div className="rsvp-admin-page">
+      {pendingSend ? (
+        <div
+          className="invite-dialog-backdrop"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) setPendingSend(undefined);
+          }}
+        >
+          <section
+            className="invite-dialog panel"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="invite-dialog-title"
+            onKeyDown={(event) => {
+              if (event.key === "Escape") setPendingSend(undefined);
+            }}
+          >
+            <div>
+              <p className="eyebrow">Review invitation</p>
+              <h2 id="invite-dialog-title">Send email invitations?</h2>
+              <p>
+                This will send email to {pendingSend.targetLabel}. Each recipient gets a fresh RSVP link; any previous link for that player will stop working.
+              </p>
+            </div>
+            <div className="invite-dialog-summary">
+              <span><strong>{pendingSend.playerIds?.length ?? invitedPlayers.length}</strong> selected</span>
+              <span><strong>{pendingSend.playerIds ? pendingSend.playerIds.filter((playerId) => invitedPlayers.some((player) => player.playerId === playerId && player.contact.email)).length : contactSummary.email}</strong> email-ready</span>
+              <span className={contactSummary.missing ? "is-warning" : ""}><strong>{pendingSend.playerIds ? pendingSend.playerIds.filter((playerId) => invitedPlayers.some((player) => player.playerId === playerId && !player.contact.email)).length : contactSummary.missing}</strong> skipped without email</span>
+            </div>
+            <div className="invite-dialog-actions">
+              <button className="button button-secondary" type="button" onClick={() => setPendingSend(undefined)}>
+                Cancel
+              </button>
+              <button
+                ref={confirmSendButton}
+                className="button button-primary"
+                type="button"
+                onClick={() => void sendInvites(pendingSend.playerIds)}
+              >
+                Send invitations
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
       <div className="page-header">
         <div>
           <p className="eyebrow">Private self-service RSVP</p>
@@ -365,9 +551,12 @@ export function RsvpAdminPage() {
           <p className="rsvp-admin-subtitle">Generate personalized links without giving players organizer access.</p>
         </div>
         <div className="page-actions">
-          <Link className="button button-secondary" to={`/ops/events/${id}`}>Invite summary</Link>
+          <Link className="button button-secondary" to={`/events/${id}`}>Event setup</Link>
           <button className="button button-primary" type="button" disabled={saving || locked || !invitedPlayers.length} onClick={() => void generateAll()}>
             Generate all and copy
+          </button>
+          <button className="button button-primary" type="button" disabled={saving || !sendable || !invitedPlayers.length} onClick={() => requestSendInvites()}>
+            Invite roster by email
           </button>
         </div>
       </div>
@@ -394,6 +583,23 @@ export function RsvpAdminPage() {
       {locked ? (
         <div className="state-card">This event is locked. Recorded responses remain visible, but links cannot be generated, regenerated, or revoked.</div>
       ) : null}
+      {!locked && !sendable ? (
+        <div className="state-card">Open the event before sending invitations. Draft events can still have links generated for testing.</div>
+      ) : null}
+
+      <section className="panel rsvp-preflight-panel">
+        <div>
+          <p className="eyebrow">Send preflight</p>
+          <h2>Ready to invite</h2>
+          <p>Sending rotates each invited player’s RSVP link. Missing contacts are skipped without stopping the batch.</p>
+        </div>
+        <div className="rsvp-preflight-stats">
+          <span><strong>{invitedPlayers.length}</strong> eligible</span>
+          <span><strong>{contactSummary.email}</strong> with email</span>
+          <span className={contactSummary.missing ? "is-warning" : ""}><strong>{contactSummary.missing}</strong> missing email</span>
+          <span><strong>{contactSummary.excluded}</strong> excluded</span>
+        </div>
+      </section>
 
       <section className="panel">
         <div className="section-heading-row">
@@ -411,13 +617,21 @@ export function RsvpAdminPage() {
                 <div className="rsvp-admin-player">
                   <strong>{player.displayName}</strong>
                   <span>RSVP: {player.rsvpStatus}</span>
+                  <small>Email: {player.contact.email || "not saved"}</small>
+                  <small>Phone: {player.contact.phone || "not saved"}</small>
+                  <small>Email is the active invitation method in this release.</small>
                 </div>
                 <div className="rsvp-admin-metadata">
                   <span className={`rsvp-link-status ${player.invite.active ? "is-active" : ""}`}>{inviteStatus(player)}</span>
                   <small>Last response: {formatShortDate(player.invite.lastResponseAt)}</small>
                   {player.invite.expiresAt ? <small>Expires: {formatShortDate(player.invite.expiresAt)}</small> : null}
+                  <small>Email: {deliverySummary(player.latestDelivery.email)}</small>
+                  <small>Text: {deliverySummary(player.latestDelivery.sms)}</small>
                 </div>
                 <div className="rsvp-admin-actions">
+                  <button className="button button-primary" type="button" disabled={saving || !sendable || !player.contact.email} onClick={() => requestSendInvites([player.playerId])}>
+                    Send email
+                  </button>
                   <button className="button button-primary" type="button" disabled={saving || locked} onClick={() => void generateOne(player)}>
                     {player.invite.exists ? "Regenerate and copy" : "Generate and copy"}
                   </button>
@@ -440,6 +654,67 @@ export function RsvpAdminPage() {
           {!invitedPlayers.length ? <div className="state-card">Mark players as invited on the event roster first.</div> : null}
         </div>
       </section>
+
+      <section className="panel">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Batch history</p><h2>Send summaries</h2></div>
+          <span>{batches.length}</span>
+        </div>
+        {batches.length ? (
+          <div className="rsvp-delivery-history">
+            {batches.map((batch) => (
+              <article className="rsvp-delivery-row" key={batch.id}>
+                <div>
+                  <strong>{batch.source === "scheduled" ? "Scheduled reminder" : "Organizer send"}</strong>
+                  <span>{batch.policy === "preferred_with_fallback" ? "Preferred channel with fallback" : "Requested channels"}</span>
+                </div>
+                <div>
+                  <span className={`rsvp-delivery-status is-${batch.status}`}>{batch.status}</span>
+                  <small>{batch.summary.sent} sent · {batch.summary.failed} failed · {batch.summary.skipped} skipped</small>
+                  <small>{formatShortDate(batch.completedAt || batch.createdAt)}</small>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="state-card">No send batches yet.</div>
+        )}
+      </section>
+
+      <section className="panel">
+        <div className="section-heading-row">
+          <div><p className="eyebrow">Delivery history</p><h2>Recent invitation attempts</h2></div>
+          <span>{deliveries.length}</span>
+        </div>
+        {deliveries.length ? (
+          <div className="rsvp-delivery-history">
+            {deliveries.map((delivery) => (
+              <article className="rsvp-delivery-row" key={delivery.id}>
+                <div>
+                  <strong>{delivery.playerName}</strong>
+                  <span>{delivery.channel === "email" ? "Email" : "Text"} · {delivery.destination}</span>
+                </div>
+                <div>
+                  <span className={`rsvp-delivery-status is-${delivery.status}`}>{delivery.status}</span>
+                  <small>{delivery.provider} · {formatShortDate(delivery.completedAt || delivery.createdAt)}</small>
+                  {delivery.errorMessage ? <small className="state-error-text">{delivery.errorMessage}</small> : null}
+                  <small>Attempt {delivery.attempt}</small>
+                  {delivery.providerStatus ? <small>Provider: {delivery.providerStatus}</small> : null}
+                  {delivery.status === "failed" ? <button className="button button-secondary" type="button" disabled={saving || !sendable} onClick={() => void retryDelivery(delivery)}>Retry</button> : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="state-card">No delivery attempts yet.</div>
+        )}
+      </section>
     </div>
   );
+}
+
+function deliverySummary(delivery: LatestDelivery | null): string {
+  if (!delivery) return "not sent";
+  if (delivery.status === "sent") return `${delivery.provider ?? "provider"} · ${formatShortDate(delivery.at)}`;
+  return `${delivery.status}${delivery.errorMessage ? ` · ${delivery.errorMessage}` : ""}`;
 }

--- a/src/UnifiedApp.tsx
+++ b/src/UnifiedApp.tsx
@@ -14,6 +14,11 @@ import { OperationsApp } from "./Operations";
 import { RsvpAdminPage } from "./Rsvp";
 import type { Organizer } from "./types";
 
+interface InstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Something went wrong.";
 }
@@ -52,6 +57,8 @@ export function UnifiedApp() {
   const [organizer, setOrganizer] = useState<Organizer>();
   const [sessionError, setSessionError] = useState<unknown>();
   const [health, setHealth] = useState<HealthReport>();
+  const [online, setOnline] = useState(() => navigator.onLine);
+  const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent>();
   const eventId = eventIdFromPath(location.pathname);
 
   useEffect(() => {
@@ -78,6 +85,28 @@ export function UnifiedApp() {
       });
   }, []);
 
+  useEffect(() => {
+    const updateOnline = () => setOnline(navigator.onLine);
+    const captureInstall = (event: Event) => {
+      event.preventDefault();
+      setInstallPrompt(event as InstallPromptEvent);
+    };
+    window.addEventListener("online", updateOnline);
+    window.addEventListener("offline", updateOnline);
+    window.addEventListener("beforeinstallprompt", captureInstall);
+    return () => {
+      window.removeEventListener("online", updateOnline);
+      window.removeEventListener("offline", updateOnline);
+      window.removeEventListener("beforeinstallprompt", captureInstall);
+    };
+  }, []);
+
+  async function installApp() {
+    if (!installPrompt) return;
+    await installPrompt.prompt();
+    setInstallPrompt(undefined);
+  }
+
   if (sessionError) {
     const accessMessage =
       sessionError instanceof ApiError && sessionError.status === 403
@@ -98,7 +127,7 @@ export function UnifiedApp() {
   const searchActive = location.pathname.startsWith("/ops/search");
 
   return (
-    <div className="unified-shell">
+    <div className={`unified-shell ${eventId ? "is-event-workspace" : ""}`}>
       <a className="skip-link" href="#unified-main">Skip to content</a>
       <header className="unified-topbar">
         <Link className="brand-lockup" to="/">
@@ -106,6 +135,8 @@ export function UnifiedApp() {
           <strong>BroTM Poker</strong>
         </Link>
         <div className="unified-topbar-actions">
+          {!online ? <span className="connection-badge is-offline">Offline shell</span> : null}
+          {installPrompt ? <ButtonLike onClick={() => void installApp()}>Install app</ButtonLike> : null}
           <Link className="button button-primary unified-plan-button" to="/ops/events/new">Plan night</Link>
           <div className="organizer-chip"><span>{organizer.displayName}</span><small>{organizer.role}</small></div>
         </div>
@@ -130,10 +161,10 @@ export function UnifiedApp() {
 
       {eventId ? (
         <nav className="event-workspace-nav" aria-label="Poker night sections">
-          <Link className={location.pathname === `/events/${eventId}` ? "active" : ""} to={`/events/${eventId}`}>Details & live</Link>
-          <Link className={location.pathname === `/ops/events/${eventId}` ? "active" : ""} to={`/ops/events/${eventId}`}>Invites & RSVP</Link>
-          <Link className={location.pathname === `/events/${eventId}/rsvp-links` ? "active" : ""} to={`/events/${eventId}/rsvp-links`}>RSVP links</Link>
-          <Link className={location.pathname === `/money/events/${eventId}` ? "active" : ""} to={`/money/events/${eventId}`}>Money</Link>
+          <Link className={location.pathname === `/events/${eventId}` ? "active" : ""} to={`/events/${eventId}`}><span aria-hidden="true">◉</span> Live</Link>
+          <Link className={location.pathname === `/events/${eventId}/rsvp-links` ? "active" : ""} to={`/events/${eventId}/rsvp-links`}><span aria-hidden="true">✉</span> RSVP</Link>
+          <Link className={location.pathname === `/money/events/${eventId}` ? "active" : ""} to={`/money/events/${eventId}`}><span aria-hidden="true">$</span> Money</Link>
+          <Link className={location.pathname === `/ops/events/${eventId}` ? "active" : ""} to={`/ops/events/${eventId}`}><span aria-hidden="true">⋯</span> More</Link>
         </nav>
       ) : null}
 
@@ -148,4 +179,8 @@ export function UnifiedApp() {
       </footer>
     </div>
   );
+}
+
+function ButtonLike({ children, onClick }: { children: ReactNode; onClick: () => void }) {
+  return <button className="button button-secondary install-button" type="button" onClick={onClick}>{children}</button>;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,3 +23,9 @@ createRoot(root).render(
     </BrowserRouter>
   </StrictMode>,
 );
+
+if (import.meta.env.PROD && "serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    void navigator.serviceWorker.register("/sw.js").catch(() => undefined);
+  });
+}

--- a/src/rsvp.css
+++ b/src/rsvp.css
@@ -34,8 +34,9 @@
   color: var(--gold);
 }
 
-.public-rsvp-brand span {
-  font-size: 1.5rem;
+.public-rsvp-brand .brand-mark {
+  width: 42px;
+  height: 42px;
 }
 
 .public-rsvp-details {
@@ -81,6 +82,44 @@
 .rsvp-privacy-panel p {
   margin: 0;
   color: var(--muted);
+}
+
+.rsvp-preflight-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 1fr);
+  gap: 1rem;
+  align-items: center;
+}
+
+.rsvp-preflight-panel p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.rsvp-preflight-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.rsvp-preflight-stats span {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 7rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.rsvp-preflight-stats strong {
+  color: var(--text);
+  font-size: 1.25rem;
+}
+
+.rsvp-preflight-stats .is-warning strong {
+  color: var(--gold);
 }
 
 .rsvp-choice-grid {
@@ -139,6 +178,70 @@
   gap: 1rem;
 }
 
+.rsvp-admin-page > .page-header {
+  border-bottom: 1px solid rgba(215, 178, 103, 0.22);
+  padding-bottom: 1rem;
+}
+
+.invite-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.68);
+}
+
+.invite-dialog {
+  width: min(560px, 100%);
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+}
+
+.invite-dialog h2,
+.invite-dialog p {
+  margin-top: 0;
+}
+
+.invite-dialog p:last-child {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.invite-dialog-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.invite-dialog-summary span {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.invite-dialog-summary strong {
+  color: var(--text);
+  font-size: 1.25rem;
+}
+
+.invite-dialog-summary .is-warning strong {
+  color: var(--gold);
+}
+
+.invite-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
 .rsvp-privacy-panel {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(240px, 0.45fr);
@@ -174,8 +277,23 @@
 }
 
 .rsvp-admin-player span,
+.rsvp-admin-player small,
 .rsvp-admin-metadata small {
   color: var(--muted);
+}
+
+.rsvp-preferred-channel {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 0.3rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.rsvp-preferred-channel select {
+  width: 100%;
+  padding: 0.35rem 0.45rem;
+  font: inherit;
 }
 
 .rsvp-link-status {
@@ -196,8 +314,57 @@
 
 .rsvp-admin-actions {
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(0, 0.85fr) minmax(0, 0.7fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.55rem;
+}
+
+.rsvp-delivery-history {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.rsvp-delivery-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.rsvp-delivery-row > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.rsvp-delivery-row > div:last-child {
+  text-align: right;
+}
+
+.rsvp-delivery-row span,
+.rsvp-delivery-row small {
+  color: var(--muted);
+}
+
+.rsvp-delivery-status {
+  font-weight: 850;
+  text-transform: capitalize;
+}
+
+.rsvp-delivery-status.is-sent {
+  color: var(--green);
+}
+
+.rsvp-delivery-status.is-failed {
+  color: var(--red);
+}
+
+.rsvp-delivery-status.is-sending {
+  color: var(--gold);
+}
+
+.state-error-text {
+  color: var(--red) !important;
 }
 
 .rsvp-generated-preview {
@@ -234,8 +401,21 @@
     border-radius: 16px;
   }
 
+  .rsvp-admin-page > .page-header .page-actions {
+    position: sticky;
+    top: 0.5rem;
+    z-index: 25;
+    padding: 0.45rem;
+    border: 1px solid rgba(215, 178, 103, 0.24);
+    border-radius: 12px;
+    background: rgba(9, 11, 8, 0.94);
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.28);
+    backdrop-filter: blur(14px);
+  }
+
   .public-rsvp-details > div,
   .rsvp-privacy-panel,
+  .rsvp-preflight-panel,
   .rsvp-admin-row,
   .rsvp-admin-actions {
     grid-template-columns: 1fr;
@@ -252,10 +432,21 @@
   .rsvp-admin-actions {
     grid-column: auto;
   }
-}
 
+  .invite-dialog-summary {
+    grid-template-columns: 1fr;
+  }
 
-.public-rsvp-brand .brand-mark {
-  width: 42px;
-  height: 42px;
+  .invite-dialog-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .rsvp-delivery-row {
+    display: grid;
+  }
+
+  .rsvp-delivery-row > div:last-child {
+    text-align: left;
+  }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,8 @@
   --green: #96c788;
   --green-dark: #365a31;
   --gold: #d7b267;
+  --gold-bright: #e7c978;
+  --gold-soft: rgba(215, 178, 103, 0.32);
   --red: #e07974;
   --blue: #8abbd8;
   --radius: 14px;
@@ -109,16 +111,15 @@ textarea:focus-visible {
   text-decoration: none;
 }
 
-.brand-lockup > span {
+.brand-lockup > span,
+.brand-mark {
   display: grid;
   width: 34px;
   height: 34px;
   place-items: center;
   border-radius: 9px;
-  background: var(--text);
-  color: var(--bg);
-  font-family: Georgia, serif;
-  font-size: 1.2rem;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px rgba(215, 178, 103, 0.28);
 }
 
 .organizer-chip {
@@ -164,6 +165,7 @@ textarea:focus-visible {
 .primary-nav a.active {
   background: var(--surface-2);
   color: var(--text);
+  box-shadow: inset 0 -2px 0 var(--gold);
 }
 
 .page-container {
@@ -206,6 +208,10 @@ textarea:focus-visible {
   text-transform: uppercase;
 }
 
+.page-header > div > .eyebrow {
+  color: var(--gold);
+}
+
 .page-actions,
 .workflow-bar {
   display: flex;
@@ -244,6 +250,10 @@ textarea:focus-visible {
   color: var(--bg);
 }
 
+.button-primary:hover:not(:disabled) {
+  background: var(--gold-bright);
+}
+
 .button-secondary {
   border-color: var(--line);
   background: var(--surface-2);
@@ -262,6 +272,10 @@ textarea:focus-visible {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: linear-gradient(145deg, var(--surface-2), var(--surface));
+}
+
+.panel {
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
 }
 
 .panel {
@@ -291,6 +305,10 @@ textarea:focus-visible {
   font-size: clamp(2rem, 5vw, 3.2rem);
   line-height: 1;
   text-transform: capitalize;
+}
+
+.metric-card:nth-child(2) {
+  border-top-color: var(--gold-soft);
 }
 
 .content-section {
@@ -334,6 +352,7 @@ textarea:focus-visible {
 .event-card:hover {
   transform: translateY(-2px);
   border-color: rgba(150, 199, 136, 0.55);
+  box-shadow: 0 12px 26px rgba(215, 178, 103, 0.08);
 }
 
 .event-card strong {
@@ -373,6 +392,7 @@ textarea:focus-visible {
 .status-open,
 .status-active {
   color: var(--green);
+  border: 1px solid var(--gold-soft);
 }
 
 .status-completed {
@@ -466,6 +486,22 @@ textarea {
   color: var(--muted);
 }
 
+.contact-chip {
+  display: inline-flex;
+  margin-right: 0.35rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--green);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.directory-search,
+.history-search {
+  margin: 0 0 1rem;
+}
+
 .avatar {
   flex: 0 0 auto;
   display: grid;
@@ -497,6 +533,7 @@ textarea {
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1rem;
   margin-bottom: 1rem;
+  border-color: rgba(215, 178, 103, 0.22);
 }
 
 .event-hero > div {
@@ -514,6 +551,178 @@ textarea {
 
 .workflow-bar {
   padding: 0.9rem 0;
+}
+
+.sync-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: -0.75rem 0 1rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.sync-status span:first-child {
+  color: var(--green);
+  font-weight: 800;
+}
+
+.sync-status.is-stale span:first-child,
+.connection-badge.is-offline {
+  color: var(--red);
+}
+
+.sync-status .button {
+  min-height: 36px;
+  margin-left: auto;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.live-summary-bar {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.live-summary-bar > div {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.live-summary-bar > div:first-child {
+  border-color: var(--gold-soft);
+}
+
+.live-summary-bar strong {
+  font-size: 1.45rem;
+}
+
+.live-summary-bar span,
+.draft-status {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.invite-readiness-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 1fr);
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-color: var(--gold-soft);
+}
+
+.invite-readiness-panel h2,
+.invite-readiness-panel p {
+  margin-top: 0;
+}
+
+.panel-muted {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.invite-readiness-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.invite-readiness-stats span {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 7rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.invite-readiness-stats strong {
+  color: var(--text);
+  font-size: 1.25rem;
+}
+
+.invite-readiness-stats .is-warning strong {
+  color: var(--gold);
+}
+
+.invite-readiness-actions {
+  display: flex;
+  flex-wrap: wrap;
+  grid-column: 1 / -1;
+  gap: 0.6rem;
+}
+
+.roster-toolbar {
+  display: grid;
+  gap: 0.65rem;
+  margin-bottom: 0.9rem;
+}
+
+.roster-filters {
+  display: flex;
+  gap: 0.4rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.roster-filters::-webkit-scrollbar {
+  display: none;
+}
+
+.roster-filter {
+  min-height: 38px;
+  flex: 0 0 auto;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.roster-filter.active {
+  border-color: rgba(150, 199, 136, 0.55);
+  background: rgba(150, 199, 136, 0.12);
+  color: var(--green);
+}
+
+.search-field input {
+  width: 100%;
+}
+
+.connection-badge {
+  color: var(--green);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.install-button {
+  min-height: 36px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.78rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .inline-form {
@@ -601,6 +810,14 @@ textarea {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .invite-readiness-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .invite-readiness-actions {
+    grid-column: auto;
+  }
+
   .page-header {
     align-items: start;
     flex-direction: column;
@@ -660,7 +877,21 @@ textarea {
   }
 
   .event-hero {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .live-summary-bar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sync-status {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .sync-status .button {
+    width: 100%;
+    margin-left: 0;
   }
 }
 
@@ -671,13 +902,4 @@ textarea {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }
-}
-
-
-.brand-mark {
-  display: block;
-  width: 34px;
-  height: 34px;
-  border-radius: 9px;
-  object-fit: cover;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Player {
   displayName: string;
   email: string | null;
   phone: string | null;
+  preferredChannel: "email" | "sms";
   notes: string | null;
   status: "active" | "archived";
   createdAt: string;
@@ -42,6 +43,7 @@ export interface EventPlayer {
   eventId: string;
   playerId: string;
   displayName: string;
+  contact: { email: string | null; phone: string | null };
   invitationStatus: InvitationStatus;
   rsvpStatus: RsvpStatus;
   attended: boolean;

--- a/src/unified.css
+++ b/src/unified.css
@@ -12,7 +12,7 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 0.75rem max(1rem, calc((100vw - 1180px) / 2));
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid rgba(215, 178, 103, 0.28);
   background: rgba(9, 11, 8, 0.96);
 }
 
@@ -93,10 +93,20 @@
   text-decoration: none;
 }
 
+.event-workspace-nav a span {
+  margin-right: 0.35rem;
+  color: var(--green);
+  font-size: 0.95rem;
+}
+
 .event-workspace-nav a:hover,
 .event-workspace-nav a.active {
   background: var(--surface-strong, #1b2119);
   color: var(--text);
+}
+
+.event-workspace-nav a.active {
+  box-shadow: inset 0 -2px 0 var(--gold);
 }
 
 .deployment-warning {
@@ -170,6 +180,10 @@
     border-bottom: 0;
   }
 
+  .unified-shell.is-event-workspace .unified-nav {
+    display: none;
+  }
+
   .unified-nav a {
     min-width: 0;
     min-height: 50px;
@@ -188,6 +202,34 @@
   .deployment-warning,
   .unified-footer {
     width: min(100% - 1rem, 1180px);
+  }
+
+  .unified-shell.is-event-workspace .event-workspace-nav {
+    position: fixed;
+    inset: auto 0 0;
+    z-index: 80;
+    width: 100%;
+    margin: 0;
+    padding: 0.35rem max(0.35rem, env(safe-area-inset-left)) calc(0.35rem + env(safe-area-inset-bottom)) max(0.35rem, env(safe-area-inset-right));
+    border: 0;
+    border-top: 1px solid var(--line);
+    border-radius: 0;
+    background: rgba(9, 11, 8, 0.97);
+    backdrop-filter: blur(16px);
+  }
+
+  .event-workspace-nav a {
+    min-height: 54px;
+    flex: 1 1 0;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.45rem 0.25rem;
+    font-size: 0.68rem;
+  }
+
+  .event-workspace-nav a span {
+    margin: 0;
+    font-size: 1rem;
   }
 
   .deployment-warning {
@@ -216,6 +258,10 @@
   }
 
   .unified-footer {
+    padding-bottom: 6.5rem;
+  }
+
+  .unified-shell.is-event-workspace .unified-footer {
     padding-bottom: 6.5rem;
   }
 }

--- a/src/useLocalDraft.ts
+++ b/src/useLocalDraft.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+
+interface DraftEnvelope<T> {
+  savedAt: string;
+  value: T;
+}
+
+export function useLocalDraft<T>(key: string, initialValue: T) {
+  const [draft, setDraft] = useState({
+    key,
+    value: initialValue,
+    savedAt: null as string | null,
+    hydrated: false,
+  });
+  const skipSaveRef = useRef(false);
+
+  useEffect(() => {
+    let value = initialValue;
+    let savedAt: string | null = null;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw) {
+        const envelope = JSON.parse(raw) as DraftEnvelope<T>;
+        value = envelope.value;
+        savedAt = envelope.savedAt;
+      }
+    } catch {
+      // Drafts are an enhancement; storage failures must not block the app.
+    } finally {
+      setDraft({ key, value, savedAt, hydrated: true });
+    }
+  }, [initialValue, key]);
+
+  useEffect(() => {
+    if (!draft.hydrated || draft.key !== key) return;
+    if (skipSaveRef.current) {
+      skipSaveRef.current = false;
+      return;
+    }
+    try {
+      const nextSavedAt = new Date().toISOString();
+      window.localStorage.setItem(key, JSON.stringify({ savedAt: nextSavedAt, value: draft.value }));
+    } catch {
+      // Ignore quota/private-mode failures and keep the in-memory value.
+    }
+  }, [draft.hydrated, draft.key, draft.value, key]);
+
+  function clear() {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // Ignore storage failures.
+    }
+    skipSaveRef.current = true;
+    setDraft((current) => ({ ...current, savedAt: null, value: initialValue }));
+  }
+
+  return {
+    value: draft.value,
+    setValue: (next: T | ((current: T) => T)) =>
+      setDraft((current) => ({ ...current, value: typeof next === "function" ? (next as (current: T) => T)(current.value) : next })),
+    savedAt: draft.savedAt,
+    hydrated: draft.hydrated && draft.key === key,
+    clear,
+  };
+}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveOrganizer } from "../functions/lib/auth";
+import type { Env } from "../functions/lib/types";
+
+function testDatabase() {
+  return {
+    prepare: () => ({
+      bind: () => ({
+        first: async () => ({
+          id: "organizer-id",
+          email: "dev@example.com",
+          display_name: "Dev Organizer",
+          role: "admin" as const,
+        }),
+      }),
+    }),
+  } as unknown as D1Database;
+}
+
+describe("organizer test access", () => {
+  it("resolves the configured organizer without an Access token in public mode", async () => {
+    const env = {
+      DB: testDatabase(),
+      AUTH_MODE: "public",
+      DEV_ORGANIZER_EMAIL: "dev@example.com",
+    } as Env;
+
+    await expect(resolveOrganizer(new Request("https://example.test/api/session"), env)).resolves.toMatchObject({
+      id: "organizer-id",
+      email: "dev@example.com",
+      role: "admin",
+    });
+  });
+
+  it("does not silently fall back to public access when access mode is selected", async () => {
+    const env = {
+      DB: testDatabase(),
+      AUTH_MODE: "access",
+      DEV_ORGANIZER_EMAIL: "dev@example.com",
+    } as Env;
+
+    await expect(resolveOrganizer(new Request("https://example.test/api/session"), env)).rejects.toThrow(
+      "Authentication required",
+    );
+  });
+});

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { providerName, sendDelivery } from "../functions/lib/delivery";
+import type { Env } from "../functions/lib/types";
+import { sendInvitesSchema, type DeliveryMessage } from "../shared/delivery";
+import {
+  buildPersonalizedInviteEmail,
+  buildPersonalizedInviteSms,
+} from "../shared/rsvp";
+
+const invite = {
+  playerName: "Ryan",
+  title: "Friday Poker Night",
+  startsAt: "2026-07-24T19:00:00-06:00",
+  hostName: "Sterling",
+  location: "123 Private Street",
+  locationVisibility: "always" as const,
+  gameNotes: "Dealer's choice",
+  stakesNotes: "$10 buy-in",
+  rsvpUrl: "https://poker.skpfam.com/rsvp/example-token",
+};
+
+describe("invite delivery contracts", () => {
+  it("uses the development sink without provider credentials", async () => {
+    const env = { DELIVERY_MODE: "log" } as Env;
+    const message: DeliveryMessage = {
+      channel: "email",
+      destination: "dev@example.com",
+      subject: "Test invite",
+      text: "Test invite body",
+      idempotencyKey: "delivery-test",
+    };
+    expect(providerName("email", env)).toBe("development");
+    await expect(sendDelivery(env, message)).resolves.toMatchObject({ provider: "development" });
+  });
+
+  it("accepts one or both delivery channels without duplicates", () => {
+    expect(sendInvitesSchema.parse({ channels: ["email"] })).toEqual({
+      channels: ["email"],
+      policy: "requested_channels",
+    });
+    expect(sendInvitesSchema.parse({ channels: ["email", "sms"] })).toEqual({
+      channels: ["email", "sms"],
+      policy: "requested_channels",
+    });
+    expect(() => sendInvitesSchema.parse({ channels: ["email", "email"] })).toThrow();
+  });
+
+  it("supports preferred-channel fallback requests", () => {
+    expect(sendInvitesSchema.parse({ channels: ["email", "sms"], policy: "preferred_with_fallback" }).policy).toBe(
+      "preferred_with_fallback",
+    );
+  });
+
+  it("builds an HTML and plain-text email with the RSVP link", () => {
+    const message = buildPersonalizedInviteEmail(invite);
+    expect(message.subject).toContain("Friday Poker Night");
+    expect(message.text).toContain(invite.rsvpUrl);
+    expect(message.html).toContain(`href="${invite.rsvpUrl}"`);
+  });
+
+  it("escapes player and event content in the HTML email", () => {
+    const message = buildPersonalizedInviteEmail({
+      ...invite,
+      playerName: "A <Player>",
+      title: "Friday & Saturday",
+    });
+    expect(message.html).toContain("A &lt;Player&gt;");
+    expect(message.html).toContain("Friday &amp; Saturday");
+    expect(message.html).not.toContain("A <Player>");
+  });
+
+  it("keeps SMS concise while preserving the RSVP link", () => {
+    const message = buildPersonalizedInviteSms({
+      ...invite,
+      gameNotes: "A very long game note ".repeat(100),
+      stakesNotes: "A very long stakes note ".repeat(100),
+    });
+    expect(message).toContain(invite.rsvpUrl);
+    expect(message.length).toBeLessThanOrEqual(480);
+  });
+});


### PR DESCRIPTION
## What changed

- Add email-first organizer invitations through Resend or the development delivery sink.
- Add invite delivery and batch/result migrations 0005 and 0006.
- Add personalized plain-text and HTML RSVP emails with fresh token rotation.
- Add one-click event-page Invite roster flow with confirmation, delivery history, retries, and mobile-friendly layout.
- Preserve existing branding and add the current mobile/PWA polish.
- Keep scheduled reminders, migration 0007, and SMS automation out of this release.

## Validation

- `npm.cmd run check`
- Formatting, lint, TypeScript, 36 tests, and production build all pass.
- Local public-auth and D1 delivery smoke tests passed in the source worktree.

## Deployment follow-up

- Production D1 must have migrations 0005 and 0006 applied.
- Pages Production variables must use `DELIVERY_MODE=live`, the verified `EMAIL_FROM`, `RESEND_API_KEY`, and `PUBLIC_APP_ORIGIN=https://poker.skpfam.com`.
- Run the first live send only to the organizer's own email.