### PR TITLE
Polish invitee RSVP and add opt-in email automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ npm run dev
 
 Create `.dev.vars` and seed a local organizer before starting the application. See [`docs/CLOUDFLARE_V2_SETUP.md`](docs/CLOUDFLARE_V2_SETUP.md).
 
-Local and preview construction use `AUTH_MODE=public` and `DELIVERY_MODE=log`, so organizer login and provider credentials do not block testing. The current delivery milestone sends manual email invitations through Resend; scheduled reminders and SMS remain follow-on work using the same delivery records and token behavior.
+Local and preview construction use `AUTH_MODE=public` and `DELIVERY_MODE=log`, so organizer login and provider credentials do not block testing. The application supports manual email invitations through Resend plus an opt-in 24-hour reminder and event-update worker. SMS remains a follow-on channel using the same delivery records and token behavior.
 
-The reminder worker is retained as follow-on work and is not required for the email-first release. If you are specifically developing that extension, run it locally with:
+The reminder/update worker is optional for the Pages application and runs separately. To develop it locally, run:
 
 ```bash
 npm run dev:worker

--- a/docs/CLOUDFLARE_V2_SETUP.md
+++ b/docs/CLOUDFLARE_V2_SETUP.md
@@ -89,8 +89,9 @@ Add these as encrypted Pages secrets for live delivery:
 
 - `RESEND_API_KEY`
 - `EMAIL_FROM`
+- `RSVP_TOKEN_ENCRYPTION_KEY` — a long random secret shared by the Pages Functions and reminder Worker. It lets automated messages reuse the current RSVP link without rotating it.
 
-SMS provider secrets and the reminder Worker are intentionally not required for the email-first invitation release. They remain follow-on work and should not block the first live email test.
+The optional reminder Worker also needs `RESEND_API_KEY`, `EMAIL_FROM`, `PUBLIC_APP_ORIGIN`, and `RSVP_TOKEN_ENCRYPTION_KEY` as Worker variables/secrets, plus the same production D1 binding. Deploy it from `wrangler.worker.jsonc` after replacing the example database ID. Its 15-minute Cron Trigger sends only for events with **Automate invitee emails** enabled.
 
 Keep the application and Resend tracking DNS records separate. The application hostname `poker.skpfam.com` must continue pointing to the Cloudflare Pages project. If Resend tracking is enabled, use the separate `clicks-poker.skpfam.com` hostname for the Resend tracking CNAME; never replace the application `poker` record with the Resend tracking target.
 
@@ -142,3 +143,5 @@ npm run dev
 - The email-first Invite roster action creates a delivery record containing a working RSVP link.
 - A manual email batch returns a batch summary and can be retried without deleting the original attempt.
 - The development sink can exercise the full workflow without Resend credentials.
+- An invitee can add the night to a calendar, open directions, and submit RSVP without an account.
+- An enabled event queues one 24-hour reminder for pending RSVPs and update emails when material details change.

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -43,3 +43,10 @@ Sterling approved the following direction:
 - A development delivery sink allows local and preview testing without provider credentials.
 - Delivery is synchronous and organizer-triggered for initial invitations; scheduled reminders are now implemented as a follow-on Cron Worker workflow.
 - Build and preview environments may use `AUTH_MODE=public` with `DEV_ORGANIZER_EMAIL` so login setup does not block construction.
+
+## 2026-08-03: Invitee follow-up experience
+
+- Invitees use a private RSVP link without an account and can add the event to a calendar or open Google Maps directions.
+- Automated follow-up is opt-in per event and email-only: one reminder 24 hours before the start for pending RSVPs, plus update emails after material event-detail changes.
+- Automated messages reuse the existing RSVP token. Pages Functions store an encrypted token copy using `RSVP_TOKEN_ENCRYPTION_KEY`; the public RSVP API continues to validate the hash.
+- SMS remains a later channel; the worker does not send text messages in this phase.

--- a/docs/INVITEE_AUTOMATION_ROLLOUT.md
+++ b/docs/INVITEE_AUTOMATION_ROLLOUT.md
@@ -1,0 +1,41 @@
+# Invitee experience and automation rollout
+
+This release improves the player-facing RSVP page and adds opt-in email follow-up.
+
+## Database
+
+Apply migrations `0007_delivery_automation.sql` and `0008_invitee_automation.sql` to the same D1 database used by Pages. Confirm `/api/health` reports schema version 8 and `ok: true`.
+
+Migration 0008 adds the event automation flag, encrypted RSVP-token storage, the delivery notification type, and the event-update queue.
+
+## Pages configuration
+
+Keep the existing production values and add:
+
+```text
+RSVP_TOKEN_ENCRYPTION_KEY=<long random secret>
+```
+
+The value must be identical for Pages Functions and the Worker. Never commit it. Existing invites created before this release do not have an encrypted token copy; resend those invitations once after deployment before expecting automated follow-up for them.
+
+## Worker deployment
+
+1. Copy the production D1 `database_id` into `wrangler.worker.jsonc`.
+2. Deploy the Worker with `npm run deploy:worker`.
+3. Add Worker secrets for `RESEND_API_KEY`, `EMAIL_FROM`, and `RSVP_TOKEN_ENCRYPTION_KEY`.
+4. Set `PUBLIC_APP_ORIGIN=https://poker.skpfam.com` and `DELIVERY_MODE=live` in the Worker production environment.
+5. Confirm the Cron Trigger is present and run the Worker once manually if a smoke test is needed.
+
+The Worker runs every 15 minutes. It sends only email. Pending players receive one reminder 24 hours before an enabled event. Material event changes queue update messages for invited players. Provider failures are persisted and retried up to three times.
+
+## Organizer smoke test
+
+1. Create or open a future event and add only the organizer’s own player record.
+2. Enable **Automate invitee emails** on the event setup page.
+3. Send one invitation and confirm the received RSVP link works.
+4. Use **Add to calendar** and confirm the `.ics` file opens with the four-hour default duration.
+5. Submit an RSVP and confirm the organizer roster updates while attendance remains unchecked.
+6. Change the location or start time and confirm a queued event-update batch appears after the Worker runs.
+7. For a reminder test, use an event whose start is 24 hours away and leave the RSVP pending.
+
+If an automated row says the player needs a fresh invitation, resend the organizer invitation. That creates the encrypted token copy needed to reuse the same link safely.

--- a/docs/PRIVATE_RSVP_ROLLOUT.md
+++ b/docs/PRIVATE_RSVP_ROLLOUT.md
@@ -79,7 +79,7 @@ Use an incognito window that is not logged into Cloudflare Access.
 
 For local and preview testing, set `DELIVERY_MODE=log` and `AUTH_MODE=public`. The organizer identity is resolved from `DEV_ORGANIZER_EMAIL`, so no Access login is required.
 
-For the email-first release, set `DELIVERY_MODE=live`, configure `RESEND_API_KEY` and `EMAIL_FROM` as Pages secrets, open an event, choose **Invite roster by email**, review the recipient summary, and confirm the send. SMS and scheduled reminders remain follow-on work; their shared provider and batch contracts are retained for the next delivery milestone.
+For live email delivery, set `DELIVERY_MODE=live`, configure `RESEND_API_KEY`, `EMAIL_FROM`, and `RSVP_TOKEN_ENCRYPTION_KEY` as Pages secrets, open an event, choose **Invite roster by email**, review the recipient summary, and confirm the send. The event setup page can opt into automated 24-hour reminders for pending RSVPs and update emails when details change. The separate Worker must be deployed for those automated messages.
 
 ## Security properties
 

--- a/docs/PRODUCT_PHASES.md
+++ b/docs/PRODUCT_PHASES.md
@@ -29,7 +29,7 @@
 - delivery batches, idempotency, and failed-send retry
 - private RSVP token rotation and response tracking
 
-SMS delivery, preferred-channel fallback, and scheduled reminders remain the next delivery extensions using the same batch and token contracts.
+SMS delivery remains the next delivery extension using the same batch and token contracts. The current phase also includes invitee calendar/directions actions, opt-in 24-hour email reminders, and automatic event-detail update emails.
 
 Recurring campaigns and general-purpose bulk messaging remain later features. Automated invitation delivery is now part of the active product roadmap rather than a deferred non-goal.
 

--- a/functions/api/[[path]].ts
+++ b/functions/api/[[path]].ts
@@ -13,6 +13,7 @@ import {
   type EventStatus,
 } from "../../shared/domain";
 import { apiError, json, readJson, validationError } from "../lib/http";
+import { queueEventUpdateNotifications } from "../lib/automation";
 import type { AppPagesFunction, OrganizerIdentity } from "../lib/types";
 
 interface PlayerRow {
@@ -38,6 +39,7 @@ interface EventRow {
   location: string;
   game_notes: string | null;
   notes: string | null;
+  invite_automation_enabled: number;
   status: EventStatus;
   created_at: string;
   updated_at: string;
@@ -94,6 +96,7 @@ function eventJson(row: EventRow) {
     location: row.location,
     gameNotes: row.game_notes,
     notes: row.notes,
+    inviteAutomationEnabled: Boolean(row.invite_automation_enabled),
     status: row.status,
     attendanceCount: Number(row.attendance_count ?? 0),
     playerCount: Number(row.player_count ?? 0),
@@ -458,6 +461,14 @@ async function patchEvent(
     setField("gameNotes", "game_notes", current.game_notes, input.gameNotes || null);
   }
   if (input.notes !== undefined) setField("notes", "notes", current.notes, input.notes || null);
+  if (input.inviteAutomationEnabled !== undefined) {
+    setField(
+      "inviteAutomationEnabled",
+      "invite_automation_enabled",
+      Boolean(current.invite_automation_enabled),
+      input.inviteAutomationEnabled ? 1 : 0,
+    );
+  }
   if (input.status !== undefined) setField("status", "status", current.status, input.status);
 
   const now = new Date().toISOString();
@@ -484,6 +495,18 @@ async function patchEvent(
   }
 
   const event = await getEvent(db, id);
+  if (!correction && Object.keys(changesBetween(before, after)).some((field) =>
+    ["title", "startsAt", "hostPlayerId", "location", "gameNotes", "notes"].includes(field),
+  )) {
+    await queueEventUpdateNotifications(
+      db,
+      id,
+      Object.keys(changesBetween(before, after)).filter((field) =>
+        ["title", "startsAt", "hostPlayerId", "location", "gameNotes", "notes"].includes(field),
+      ),
+      new Date().toISOString(),
+    );
+  }
   return json({ event: eventJson(event as EventRow) });
 }
 

--- a/functions/api/health.ts
+++ b/functions/api/health.ts
@@ -19,6 +19,8 @@ const requiredTables = [
   "invite_deliveries",
   "delivery_batches",
   "invite_delivery_results",
+  "delivery_schedules",
+  "event_update_notifications",
   "d1_migrations",
 ];
 
@@ -50,6 +52,7 @@ export const onRequestGet: AppPagesFunction = async (context) => {
       eventColumns.has("capacity") ? "" : "events.capacity",
       eventColumns.has("rsvp_location_visibility") ? "" : "events.rsvp_location_visibility",
       playersColumns.has("preferred_channel") ? "" : "players.preferred_channel",
+      eventColumns.has("invite_automation_enabled") ? "" : "events.invite_automation_enabled",
     ].filter(Boolean);
 
     const migrationRow = tables.has("d1_migrations")

--- a/functions/lib/automation.ts
+++ b/functions/lib/automation.ts
@@ -1,0 +1,46 @@
+export async function queueEventUpdateNotifications(
+  db: D1Database,
+  eventId: string,
+  changedFields: string[],
+  now: string,
+): Promise<void> {
+  const event = await db
+    .prepare("SELECT status, invite_automation_enabled FROM events WHERE id = ?1")
+    .bind(eventId)
+    .first<{ status: string; invite_automation_enabled: number }>();
+  if (!event || !event.invite_automation_enabled || !["open", "active"].includes(event.status)) return;
+
+  const players = await db
+    .prepare(
+      `SELECT ep.id
+       FROM event_players ep
+       WHERE ep.event_id = ?1 AND ep.invitation_status = 'invited'`,
+    )
+    .bind(eventId)
+    .all<{ id: string }>();
+  if (!players.results.length) return;
+
+  const notificationKey = JSON.stringify({ id: crypto.randomUUID(), changedFields });
+  await db.batch(
+    players.results.map((player) =>
+      db
+        .prepare(
+          `INSERT INTO event_update_notifications
+           (id, event_id, event_player_id, notification_key, status, created_at, updated_at)
+           VALUES (?1, ?2, ?3, ?4, 'pending', ?5, ?5)`,
+        )
+        .bind(crypto.randomUUID(), eventId, player.id, notificationKey, now),
+    ),
+  );
+}
+
+export function notificationFields(notificationKey: string): string[] {
+  try {
+    const parsed = JSON.parse(notificationKey) as { changedFields?: unknown };
+    return Array.isArray(parsed.changedFields)
+      ? parsed.changedFields.filter((field): field is string => typeof field === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}

--- a/functions/lib/scheduled-delivery.ts
+++ b/functions/lib/scheduled-delivery.ts
@@ -1,0 +1,338 @@
+import {
+  buildPersonalizedReminderEmail,
+  buildPersonalizedUpdateEmail,
+  hashRsvpToken,
+  type RsvpLocationVisibility,
+} from "../../shared/rsvp";
+import { DeliveryProviderError, providerName, sendDelivery } from "./delivery";
+import { decryptRsvpToken } from "./token-vault";
+import { notificationFields } from "./automation";
+import type { Env } from "./types";
+
+type ReminderType = "twenty_four_hours";
+type EventStatus = "open" | "active" | "completed" | "cancelled" | "archived" | "draft";
+
+interface ReminderRow {
+  id: string;
+  event_id: string;
+  event_player_id: string;
+  reminder_type: ReminderType;
+  scheduled_for: string;
+  attempt_count: number;
+  event_title: string;
+  starts_at: string;
+  host_name: string | null;
+  location: string;
+  game_notes: string | null;
+  stakes_notes: string | null;
+  location_visibility: RsvpLocationVisibility;
+  event_status: EventStatus;
+  organizer_id: string;
+  player_id: string;
+  display_name: string;
+  email: string | null;
+  rsvp_status: "pending" | "yes" | "maybe" | "no";
+  invitation_status: "invited" | "not_invited";
+  invite_id: string | null;
+  token_hash: string | null;
+  token_ciphertext: string | null;
+}
+
+interface UpdateRow {
+  id: string;
+  event_id: string;
+  event_player_id: string;
+  notification_key: string;
+  attempt_count: number;
+  event_title: string;
+  starts_at: string;
+  host_name: string | null;
+  location: string;
+  game_notes: string | null;
+  stakes_notes: string | null;
+  location_visibility: RsvpLocationVisibility;
+  event_status: EventStatus;
+  organizer_id: string;
+  player_id: string;
+  display_name: string;
+  email: string | null;
+  invitation_status: "invited" | "not_invited";
+  invite_id: string | null;
+  token_hash: string | null;
+  token_ciphertext: string | null;
+}
+
+type NotificationRow = ReminderRow | UpdateRow;
+
+function destinationFor(email: string | null): { destination: string | null; error: string | null; skipped: boolean } {
+  const destination = email?.trim() ?? "";
+  if (!destination) return { destination: null, error: "No email address is saved.", skipped: true };
+  if (!/^\S+@\S+\.\S+$/u.test(destination)) {
+    return { destination, error: "The saved email address is invalid.", skipped: false };
+  }
+  return { destination, error: null, skipped: false };
+}
+
+export function reminderTime(startsAt: string, _type: ReminderType = "twenty_four_hours"): string {
+  return new Date(new Date(startsAt).getTime() - 24 * 60 * 60 * 1000).toISOString();
+}
+
+function auditStatement(
+  db: D1Database,
+  row: NotificationRow,
+  action: string,
+  details: Record<string, unknown>,
+  now: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO event_audit_log
+       (id, event_id, organizer_id, action, details_json, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+    )
+    .bind(crypto.randomUUID(), row.event_id, row.organizer_id, action, JSON.stringify(details), now);
+}
+
+async function scheduleUpcoming(db: D1Database, now: string): Promise<void> {
+  const events = await db
+    .prepare(
+      `SELECT id, starts_at
+       FROM events
+       WHERE status IN ('open', 'active')
+         AND invite_automation_enabled = 1
+         AND datetime(starts_at) > datetime(?1)
+       ORDER BY starts_at ASC LIMIT 50`,
+    )
+    .bind(now)
+    .all<{ id: string; starts_at: string }>();
+
+  for (const event of events.results) {
+    const players = await db
+      .prepare(
+        `SELECT id FROM event_players
+         WHERE event_id = ?1 AND invitation_status = 'invited'`,
+      )
+      .bind(event.id)
+      .all<{ id: string }>();
+    const scheduledFor = reminderTime(event.starts_at);
+    if (new Date(scheduledFor).getTime() <= Date.now()) continue;
+    const statements = players.results.map((player) =>
+      db
+        .prepare(
+          `INSERT INTO delivery_schedules
+           (id, event_id, event_player_id, reminder_type, scheduled_for, created_at, updated_at)
+           VALUES (?1, ?2, ?3, 'twenty_four_hours', ?4, ?5, ?5)
+           ON CONFLICT(event_id, event_player_id, reminder_type) DO UPDATE SET
+             scheduled_for = CASE WHEN delivery_schedules.status = 'pending' THEN excluded.scheduled_for ELSE delivery_schedules.scheduled_for END,
+             updated_at = excluded.updated_at`,
+        )
+        .bind(crypto.randomUUID(), event.id, player.id, scheduledFor, now),
+    );
+    if (statements.length) await db.batch(statements);
+  }
+}
+
+async function dueReminders(db: D1Database, now: string): Promise<ReminderRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT s.id, s.event_id, s.event_player_id, s.reminder_type, s.scheduled_for, s.attempt_count,
+              e.title AS event_title, e.starts_at, e.location, e.game_notes, e.stakes_notes,
+              e.status AS event_status, e.rsvp_location_visibility AS location_visibility,
+              host.display_name AS host_name, e.created_by_organizer_id AS organizer_id,
+              ep.player_id, ep.rsvp_status, ep.invitation_status,
+              p.display_name, p.email, ei.id AS invite_id, ei.token_hash, ei.token_ciphertext
+       FROM delivery_schedules s
+       JOIN events e ON e.id = s.event_id
+       JOIN event_players ep ON ep.id = s.event_player_id
+       JOIN players p ON p.id = ep.player_id
+       LEFT JOIN players host ON host.id = e.host_player_id
+       LEFT JOIN event_invites ei ON ei.event_player_id = ep.id
+       WHERE s.status IN ('pending', 'failed') AND s.attempt_count < 3
+         AND e.invite_automation_enabled = 1
+         AND datetime(s.scheduled_for) <= datetime(?1)
+       ORDER BY s.scheduled_for LIMIT 25`,
+    )
+    .bind(now)
+    .all<ReminderRow>();
+  return rows.results;
+}
+
+async function dueUpdates(db: D1Database, now: string): Promise<UpdateRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT n.id, n.event_id, n.event_player_id, n.notification_key, n.attempt_count,
+              e.title AS event_title, e.starts_at, e.location, e.game_notes, e.stakes_notes,
+              e.status AS event_status, e.rsvp_location_visibility AS location_visibility,
+              host.display_name AS host_name, e.created_by_organizer_id AS organizer_id,
+              ep.player_id, ep.invitation_status, p.display_name, p.email,
+              ei.id AS invite_id, ei.token_hash, ei.token_ciphertext
+       FROM event_update_notifications n
+       JOIN events e ON e.id = n.event_id
+       JOIN event_players ep ON ep.id = n.event_player_id
+       JOIN players p ON p.id = ep.player_id
+       LEFT JOIN players host ON host.id = e.host_player_id
+       LEFT JOIN event_invites ei ON ei.event_player_id = ep.id
+       WHERE n.status IN ('pending', 'failed') AND n.attempt_count < 3
+         AND e.invite_automation_enabled = 1
+         AND datetime(n.created_at) <= datetime(?1)
+       ORDER BY n.created_at LIMIT 25`,
+    )
+    .bind(now)
+    .all<UpdateRow>();
+  return rows.results;
+}
+
+async function claim(db: D1Database, row: NotificationRow, now: string): Promise<boolean> {
+  const table = "reminder_type" in row ? "delivery_schedules" : "event_update_notifications";
+  const result = await db
+    .prepare(
+      `UPDATE ${table}
+       SET status = 'claimed', claimed_at = ?1, attempt_count = attempt_count + 1, updated_at = ?1
+       WHERE id = ?2 AND status IN ('pending', 'failed') AND attempt_count < 3`,
+    )
+    .bind(now, row.id)
+    .run();
+  return result.meta.changes === 1;
+}
+
+async function finish(db: D1Database, row: NotificationRow, status: "sent" | "skipped" | "failed" | "cancelled", error: string | null, now: string): Promise<void> {
+  if ("reminder_type" in row) {
+    await db
+      .prepare(
+        `UPDATE delivery_schedules SET status = ?1, last_error = ?2,
+         scheduled_for = CASE WHEN ?1 = 'failed' THEN datetime(?3, '+15 minutes') ELSE scheduled_for END,
+         completed_at = CASE WHEN ?1 = 'failed' THEN NULL ELSE ?3 END, updated_at = ?3 WHERE id = ?4`,
+      )
+      .bind(status, error, now, row.id)
+      .run();
+  } else {
+    await db
+      .prepare(
+        `UPDATE event_update_notifications SET status = ?1, last_error = ?2,
+         completed_at = CASE WHEN ?1 = 'failed' THEN NULL ELSE ?3 END, updated_at = ?3 WHERE id = ?4`,
+      )
+      .bind(status, error, now, row.id)
+      .run();
+  }
+}
+
+function calendarUrl(origin: string, token: string): string {
+  return `${origin.replace(/\/+$/u, "")}/rsvp-api/${encodeURIComponent(token)}/calendar.ics`;
+}
+
+async function processRow(db: D1Database, env: Env, row: NotificationRow, origin: string): Promise<void> {
+  const now = new Date().toISOString();
+  const isReminder = "reminder_type" in row;
+  const eligible = row.event_status === "open" || row.event_status === "active";
+  const reminderEligible = !isReminder || row.rsvp_status === "pending";
+  if (!eligible || row.invitation_status !== "invited" || !reminderEligible) {
+    await finish(db, row, row.event_status === "cancelled" ? "cancelled" : "skipped", "Player is no longer eligible for this message.", now);
+    await db.batch([auditStatement(db, row, isReminder ? "scheduled_reminder_skipped" : "event_update_skipped", {}, now)]);
+    return;
+  }
+
+  const destination = destinationFor(row.email);
+  if (destination.error || !destination.destination) {
+    await finish(db, row, destination.skipped ? "skipped" : "failed", destination.error, now);
+    await db.batch([auditStatement(db, row, isReminder ? "scheduled_reminder_skipped" : "event_update_skipped", { reason: destination.error }, now)]);
+    return;
+  }
+
+  if (!row.invite_id || !row.token_ciphertext || !row.token_hash) {
+    const error = "This player needs a fresh invitation before automated email can be sent.";
+    await finish(db, row, "skipped", error, now);
+    await db.batch([auditStatement(db, row, isReminder ? "scheduled_reminder_skipped" : "event_update_skipped", { reason: error }, now)]);
+    return;
+  }
+  const token = await decryptRsvpToken(row.token_ciphertext, env.RSVP_TOKEN_ENCRYPTION_KEY ?? "development-rsvp-token-key");
+  if (!token) {
+    const error = "The RSVP token could not be opened. Send a fresh invitation.";
+    await finish(db, row, "failed", error, now);
+    return;
+  }
+
+  const batchId = crypto.randomUUID();
+  const deliveryId = crypto.randomUUID();
+  const resultId = crypto.randomUUID();
+  const notificationType = isReminder ? "reminder" : "event_update";
+  const fields = isReminder ? [] : notificationFields(row.notification_key);
+  const rsvpUrl = `${origin.replace(/\/+$/u, "")}/rsvp/${token}`;
+  const input = {
+    playerName: row.display_name,
+    title: row.event_title,
+    startsAt: row.starts_at,
+    hostName: row.host_name,
+    location: row.location,
+    locationVisibility: row.location_visibility,
+    gameNotes: row.game_notes,
+    stakesNotes: row.stakes_notes,
+    rsvpUrl,
+    calendarUrl: calendarUrl(origin, token),
+    directionsUrl: row.location ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(row.location)}` : null,
+  };
+  const email = isReminder ? buildPersonalizedReminderEmail(input) : buildPersonalizedUpdateEmail(input, fields);
+  const provider = providerName("email", env);
+  const message = { channel: "email" as const, destination: destination.destination, subject: email.subject, text: email.text, html: email.html, idempotencyKey: `${batchId}:${deliveryId}` };
+
+  await db.batch([
+    db.prepare(
+      `INSERT INTO delivery_batches
+       (id, event_id, requested_by_organizer_id, requested_channels_json, policy, source, notification_type, status, requested_count, created_at)
+       VALUES (?1, ?2, ?3, '["email"]', 'requested_channels', 'scheduled', ?4, 'sending', 1, ?5)`,
+    ).bind(batchId, row.event_id, row.organizer_id, notificationType, now),
+    db.prepare(
+      `INSERT INTO invite_deliveries
+       (id, event_invite_id, channel, destination, provider, status, provider_message_id, error_message, token_hash,
+        requested_by_organizer_id, created_at, completed_at, updated_at, batch_id, attempt, idempotency_key)
+       VALUES (?1, ?2, 'email', ?3, ?4, 'sending', NULL, NULL, ?5, ?6, ?7, NULL, ?7, ?8, 1, ?9)`,
+    ).bind(deliveryId, row.invite_id, destination.destination, provider, row.token_hash, row.organizer_id, now, batchId, message.idempotencyKey),
+    db.prepare(
+      `INSERT INTO invite_delivery_results
+       (id, batch_id, event_player_id, channel, destination, status, delivery_id, error_message, token_hash, created_at, updated_at)
+       VALUES (?1, ?2, ?3, 'email', ?4, 'failed', ?5, NULL, ?6, ?7, ?7)`,
+    ).bind(resultId, batchId, row.event_player_id, destination.destination, deliveryId, row.token_hash, now),
+    auditStatement(db, row, isReminder ? "scheduled_reminder_requested" : "event_update_requested", { provider }, now),
+  ]);
+
+  try {
+    const sent = await sendDelivery(env, message);
+    await db.batch([
+      db.prepare("UPDATE invite_deliveries SET status = 'sent', provider_message_id = ?1, completed_at = ?2, updated_at = ?2 WHERE id = ?3").bind(sent.providerMessageId, now, deliveryId),
+      db.prepare("UPDATE invite_delivery_results SET status = 'sent', error_message = NULL, updated_at = ?1 WHERE id = ?2").bind(now, resultId),
+      db.prepare("UPDATE delivery_batches SET status = 'completed', sent_count = 1, completed_at = ?1 WHERE id = ?2").bind(now, batchId),
+      finishStatement(db, row, "sent", null, now),
+      auditStatement(db, row, isReminder ? "scheduled_reminder_sent" : "event_update_sent", { provider: sent.provider }, now),
+    ]);
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : "The delivery provider failed.";
+    const failedProvider = error instanceof DeliveryProviderError ? error.provider : provider;
+    await db.batch([
+      db.prepare("UPDATE invite_deliveries SET status = 'failed', provider = ?1, error_message = ?2, completed_at = ?3, updated_at = ?3 WHERE id = ?4").bind(failedProvider, messageText, now, deliveryId),
+      db.prepare("UPDATE invite_delivery_results SET status = 'failed', error_message = ?1, updated_at = ?2 WHERE id = ?3").bind(messageText, now, resultId),
+      db.prepare("UPDATE delivery_batches SET status = 'failed', failed_count = 1, completed_at = ?1 WHERE id = ?2").bind(now, batchId),
+      finishStatement(db, row, "failed", messageText, now),
+      auditStatement(db, row, isReminder ? "scheduled_reminder_failed" : "event_update_failed", { provider: failedProvider, reason: messageText }, now),
+    ]);
+  }
+}
+
+function finishStatement(db: D1Database, row: NotificationRow, status: "sent" | "skipped" | "failed" | "cancelled", error: string | null, now: string): D1PreparedStatement {
+  const table = "reminder_type" in row ? "delivery_schedules" : "event_update_notifications";
+  return db.prepare(`UPDATE ${table} SET status = ?1, last_error = ?2, completed_at = CASE WHEN ?1 = 'failed' THEN NULL ELSE ?3 END, updated_at = ?3 WHERE id = ?4`).bind(status, error, now, row.id);
+}
+
+export async function runScheduledReminders(env: Env): Promise<{ scheduled: number; processed: number }> {
+  const now = new Date().toISOString();
+  await scheduleUpcoming(env.DB, now);
+  const [reminders, updates] = await Promise.all([dueReminders(env.DB, now), dueUpdates(env.DB, now)]);
+  const rows: NotificationRow[] = [...reminders, ...updates];
+  const origin = env.PUBLIC_APP_ORIGIN?.trim() || "http://localhost:8788";
+  let processed = 0;
+  for (const row of rows) {
+    if (await claim(env.DB, row, now)) {
+      await processRow(env.DB, env, row, origin);
+      processed += 1;
+    }
+  }
+  return { scheduled: rows.length, processed };
+}

--- a/functions/lib/token-vault.ts
+++ b/functions/lib/token-vault.ts
@@ -1,0 +1,46 @@
+function base64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+}
+
+async function vaultKey(secret: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", digest, "AES-GCM", false, ["encrypt", "decrypt"]);
+}
+
+export async function encryptRsvpToken(token: string, secret: string): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    await vaultKey(secret),
+    new TextEncoder().encode(token),
+  );
+  const combined = new Uint8Array(iv.length + encrypted.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(encrypted), iv.length);
+  return base64Url(combined);
+}
+
+export async function decryptRsvpToken(ciphertext: string, secret: string): Promise<string | null> {
+  try {
+    const combined = fromBase64Url(ciphertext);
+    const iv = combined.slice(0, 12);
+    const encrypted = combined.slice(12);
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv },
+      await vaultKey(secret),
+      encrypted,
+    );
+    return new TextDecoder().decode(decrypted);
+  } catch {
+    return null;
+  }
+}

--- a/functions/lib/types.ts
+++ b/functions/lib/types.ts
@@ -16,6 +16,7 @@ export interface Env {
   PUBLIC_APP_ORIGIN?: string;
   RESEND_API_KEY?: string;
   EMAIL_FROM?: string;
+  RSVP_TOKEN_ENCRYPTION_KEY?: string;
   TWILIO_ACCOUNT_SID?: string;
   TWILIO_AUTH_TOKEN?: string;
   TWILIO_FROM_NUMBER?: string;

--- a/functions/rsvp-admin-api/[[path]].ts
+++ b/functions/rsvp-admin-api/[[path]].ts
@@ -16,6 +16,8 @@ import {
 } from "../../shared/rsvp";
 import { DeliveryProviderError, providerName, sendDelivery } from "../lib/delivery";
 import { apiError, json, readJson, validationError } from "../lib/http";
+import { queueEventUpdateNotifications } from "../lib/automation";
+import { encryptRsvpToken } from "../lib/token-vault";
 import type { AppPagesFunction, Env, OrganizerIdentity } from "../lib/types";
 
 interface RsvpEventRow {
@@ -28,6 +30,7 @@ interface RsvpEventRow {
   stakes_notes: string | null;
   status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
   rsvp_location_visibility: RsvpLocationVisibility;
+  invite_automation_enabled: number;
 }
 
 interface RsvpPlayerRow {
@@ -114,7 +117,7 @@ async function getEvent(db: D1Database, eventId: string): Promise<RsvpEventRow |
     .prepare(
       `SELECT e.id, e.title, e.starts_at, host.display_name AS host_name,
               e.location, e.game_notes, e.stakes_notes, e.status,
-              e.rsvp_location_visibility
+              e.rsvp_location_visibility, e.invite_automation_enabled
        FROM events e
        LEFT JOIN players host ON host.id = e.host_player_id
        WHERE e.id = ?1`,
@@ -264,6 +267,7 @@ async function detail(db: D1Database, eventId: string): Promise<Response> {
       stakesNotes: event.stakes_notes,
       status: event.status,
       locationVisibility: event.rsvp_location_visibility,
+      inviteAutomationEnabled: Boolean(event.invite_automation_enabled),
     },
     players: players.map(playerJson),
   });
@@ -286,13 +290,16 @@ async function prepareInvite(
   event: RsvpEventRow,
   player: RsvpPlayerRow,
   origin: string,
-): Promise<{ generated: GeneratedInvite; tokenHash: string; inviteId: string }> {
+  tokenSecret: string,
+): Promise<{ generated: GeneratedInvite; tokenHash: string; tokenCiphertext: string; inviteId: string }> {
   const token = createRsvpToken();
   const tokenHash = await hashRsvpToken(token);
+  const tokenCiphertext = await encryptRsvpToken(token, tokenSecret);
   const expiresAt = invitationExpiresAt(event.starts_at);
   const url = `${origin.replace(/\/+$/u, "")}/rsvp/${token}`;
   return {
     tokenHash,
+    tokenCiphertext,
     inviteId: player.invite_id ?? crypto.randomUUID(),
     generated: {
       playerId: player.player_id,
@@ -320,6 +327,7 @@ function upsertInviteStatement(
   inviteId: string,
   organizer: OrganizerIdentity,
   tokenHash: string,
+  tokenCiphertext: string,
   expiresAt: string,
   now: string,
 ): D1PreparedStatement {
@@ -327,14 +335,15 @@ function upsertInviteStatement(
     .prepare(
       `INSERT INTO event_invites
        (id, event_player_id, token_hash, expires_at, revoked_at,
-        last_response_at, response_count, created_by_organizer_id, created_at, updated_at)
-       VALUES (?1, ?2, ?3, ?4, NULL, NULL, 0, ?5, ?6, ?6)
+        last_response_at, response_count, created_by_organizer_id, created_at, updated_at, token_ciphertext)
+       VALUES (?1, ?2, ?3, ?4, NULL, NULL, 0, ?5, ?6, ?6, ?7)
        ON CONFLICT(event_player_id) DO UPDATE SET
          token_hash = excluded.token_hash,
          expires_at = excluded.expires_at,
          revoked_at = NULL,
          created_by_organizer_id = excluded.created_by_organizer_id,
          created_at = excluded.created_at,
+         token_ciphertext = excluded.token_ciphertext,
          updated_at = excluded.updated_at`,
     )
     .bind(
@@ -344,6 +353,7 @@ function upsertInviteStatement(
       expiresAt,
       organizer.id,
       now,
+      tokenCiphertext,
     );
 }
 
@@ -354,11 +364,12 @@ async function generateOne(
   playerId: string,
   organizer: OrganizerIdentity,
   origin: string,
+  tokenSecret: string,
 ): Promise<Response> {
   const event = await requireEvent(db, eventId);
   requireMutableEvent(event);
   const player = await requireInvitedPlayer(db, eventId, playerId);
-  const prepared = await prepareInvite(event, player, origin);
+  const prepared = await prepareInvite(event, player, origin, tokenSecret);
   const now = new Date().toISOString();
   await db.batch([
     upsertInviteStatement(
@@ -367,6 +378,7 @@ async function generateOne(
       prepared.inviteId,
       organizer,
       prepared.tokenHash,
+      prepared.tokenCiphertext,
       prepared.generated.expiresAt,
       now,
     ),
@@ -387,6 +399,7 @@ async function generateAll(
   eventId: string,
   organizer: OrganizerIdentity,
   origin: string,
+  tokenSecret: string,
 ): Promise<Response> {
   const event = await requireEvent(db, eventId);
   requireMutableEvent(event);
@@ -394,7 +407,7 @@ async function generateAll(
   if (!players.length) return apiError(409, "NO_INVITEES", "Add invited players before generating links.");
 
   const prepared = await Promise.all(
-    players.map((player) => prepareInvite(event, player, origin)),
+    players.map((player) => prepareInvite(event, player, origin, tokenSecret)),
   );
   const now = new Date().toISOString();
   const statements: D1PreparedStatement[] = [];
@@ -408,6 +421,7 @@ async function generateAll(
         invite.inviteId,
         organizer,
         invite.tokenHash,
+        invite.tokenCiphertext,
         invite.generated.expiresAt,
         now,
       ),
@@ -470,6 +484,10 @@ function deliveryMessage(
     gameNotes: event.game_notes,
     stakesNotes: event.stakes_notes,
     rsvpUrl: url,
+    calendarUrl: `${origin.replace(/\/+$/u, "")}/rsvp-api/${encodeURIComponent(url.split("/rsvp/").pop() ?? "")}/calendar.ics`,
+    directionsUrl: event.location
+      ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`
+      : null,
   };
   if (channel === "email") {
     const email = buildPersonalizedInviteEmail(input);
@@ -626,7 +644,7 @@ async function deliveries(db: D1Database, eventId: string): Promise<Response> {
       .all<DeliveryRow>(),
     db
       .prepare(
-        `SELECT id, policy, source, status, requested_count, sent_count,
+        `SELECT id, policy, source, notification_type, status, requested_count, sent_count,
                 failed_count, skipped_count, created_at, completed_at
          FROM delivery_batches
          WHERE event_id = ?1
@@ -658,6 +676,7 @@ async function deliveries(db: D1Database, eventId: string): Promise<Response> {
       id: batch.id,
       policy: batch.policy,
       source: batch.source,
+      notificationType: batch.notification_type,
       status: batch.status,
       summary: {
         requested: Number(batch.requested_count),
@@ -676,6 +695,7 @@ interface DeliveryBatchRow {
   requested_channels_json: string;
   policy: "requested_channels" | "preferred_with_fallback";
   source: "manual" | "scheduled";
+  notification_type: "invite" | "reminder" | "event_update";
   status: "sending" | "completed" | "partial" | "failed";
   requested_count: number;
   sent_count: number;
@@ -720,6 +740,7 @@ async function batchResponse(db: D1Database, batchId: string): Promise<Response>
     batchId: batch.id,
     policy: batch.policy,
     source: batch.source,
+    notificationType: batch.notification_type,
     summary: {
       requested: Number(batch.requested_count),
       sent: Number(batch.sent_count),
@@ -810,7 +831,7 @@ async function sendInvites(
   );
 
   for (const player of selectedPlayers) {
-    const prepared = await prepareInvite(event, player, origin);
+    const prepared = await prepareInvite(event, player, origin, env.RSVP_TOKEN_ENCRYPTION_KEY ?? "development-rsvp-token-key");
     setupStatements.push(
       upsertInviteStatement(
         db,
@@ -818,6 +839,7 @@ async function sendInvites(
         prepared.inviteId,
         organizer,
         prepared.tokenHash,
+        prepared.tokenCiphertext,
         prepared.generated.expiresAt,
         now,
       ),
@@ -1073,16 +1095,46 @@ async function retryDelivery(
 ): Promise<Response> {
   const row = await db
     .prepare(
-      `SELECT d.status, d.channel, ep.event_id, ep.player_id
+      `SELECT d.status, d.channel, ep.event_id, ep.player_id, d.event_invite_id,
+              b.notification_type
        FROM invite_deliveries d
        JOIN event_invites ei ON ei.id = d.event_invite_id
        JOIN event_players ep ON ep.id = ei.event_player_id
+       LEFT JOIN delivery_batches b ON b.id = d.batch_id
        WHERE d.id = ?1`,
     )
     .bind(deliveryId)
-    .first<{ status: DeliveryStatus; channel: DeliveryChannel; event_id: string; player_id: string }>();
+    .first<{
+      status: DeliveryStatus;
+      channel: DeliveryChannel;
+      event_id: string;
+      player_id: string;
+      notification_type: "invite" | "reminder" | "event_update" | null;
+    }>();
   if (!row) return apiError(404, "DELIVERY_NOT_FOUND", "Delivery attempt not found.");
   if (row.status !== "failed") return apiError(409, "DELIVERY_NOT_FAILED", "Only failed deliveries can be retried.");
+
+  if (row.notification_type === "reminder" || row.notification_type === "event_update") {
+    const now = new Date().toISOString();
+    if (row.notification_type === "reminder") {
+      await db
+        .prepare(
+          `UPDATE delivery_schedules SET status = 'pending', scheduled_for = ?1, last_error = NULL, updated_at = ?1
+           WHERE event_player_id = ?2 AND status = 'failed'`,
+        )
+        .bind(now, row.player_id)
+        .run();
+    } else {
+      await db
+        .prepare(
+          `UPDATE event_update_notifications SET status = 'pending', last_error = NULL, updated_at = ?1
+           WHERE event_player_id = ?2 AND status = 'failed'`,
+        )
+        .bind(now, row.player_id)
+        .run();
+    }
+    return json({ queued: true, notificationType: row.notification_type });
+  }
 
   const retryRequest = new Request(request.url, {
     method: "POST",
@@ -1150,6 +1202,7 @@ async function patchEvent(
       now,
     ),
   ]);
+  await queueEventUpdateNotifications(db, eventId, ["locationVisibility"], now);
   return detail(db, eventId);
 }
 
@@ -1204,6 +1257,7 @@ export const onRequest: AppPagesFunction = async (context) => {
         parts[1],
         context.data.organizer,
         publicOrigin(request, context.env),
+        context.env.RSVP_TOKEN_ENCRYPTION_KEY ?? "development-rsvp-token-key",
       );
     }
     if (
@@ -1222,6 +1276,7 @@ export const onRequest: AppPagesFunction = async (context) => {
         parts[3],
         context.data.organizer,
         publicOrigin(request, context.env),
+        context.env.RSVP_TOKEN_ENCRYPTION_KEY ?? "development-rsvp-token-key",
       );
     }
     if (

--- a/functions/rsvp-api/[[path]].ts
+++ b/functions/rsvp-api/[[path]].ts
@@ -1,5 +1,6 @@
 import { ZodError } from "zod";
 import {
+  buildCalendarFile,
   hashRsvpToken,
   isPlausibleRsvpToken,
   publicRsvpResponseSchema,
@@ -59,7 +60,7 @@ function isExpired(invite: PublicInviteRow): boolean {
   return new Date(invite.expires_at).getTime() <= Date.now();
 }
 
-function publicJson(invite: PublicInviteRow) {
+function publicJson(invite: PublicInviteRow, token: string) {
   const expired = isExpired(invite);
   const revoked = Boolean(invite.revoked_at);
   const eventAllowsResponse = invite.event_status === "open" || invite.event_status === "active";
@@ -96,6 +97,13 @@ function publicJson(invite: PublicInviteRow) {
     expiresAt: invite.expires_at,
     lastResponseAt: invite.last_response_at,
     stateMessage,
+    links: {
+      calendar: `/rsvp-api/${encodeURIComponent(token)}/calendar.ics`,
+      directions:
+        locationVisible && invite.location
+          ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(invite.location)}`
+          : null,
+    },
   };
 }
 
@@ -106,7 +114,7 @@ function invalidInvite(): Response {
 async function getPublicInvite(db: D1Database, token: string): Promise<Response> {
   const invite = await findInvite(db, token);
   if (!invite || invite.revoked_at || isExpired(invite)) return invalidInvite();
-  return json(publicJson(invite));
+  return json(publicJson(invite, token));
 }
 
 async function respond(request: Request, db: D1Database, token: string): Promise<Response> {
@@ -166,7 +174,42 @@ async function respond(request: Request, db: D1Database, token: string): Promise
 
   const updated = await findInvite(db, token);
   if (!updated) return invalidInvite();
-  return json(publicJson(updated));
+  return json(publicJson(updated, token));
+}
+
+async function calendar(
+  request: Request,
+  db: D1Database,
+  token: string,
+): Promise<Response> {
+  const invite = await findInvite(db, token);
+  if (!invite || invite.revoked_at || isExpired(invite)) return invalidInvite();
+  const locationVisible = invite.rsvp_location_visibility === "always" || invite.rsvp_status === "yes";
+  const rsvpUrl = new URL(`/rsvp/${token}`, request.url).toString();
+  const description = [
+    invite.host_name ? `Host: ${invite.host_name}` : "",
+    invite.game_notes ? `Game: ${invite.game_notes}` : "",
+    invite.stakes_notes ? `Stakes: ${invite.stakes_notes}` : "",
+    `RSVP: ${rsvpUrl}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  const body = buildCalendarFile({
+    uid: `${invite.invite_id}@poker.skpfam.com`,
+    title: invite.title,
+    startsAt: invite.starts_at,
+    location: locationVisible ? invite.location : null,
+    description,
+    url: rsvpUrl,
+    cancelled: invite.event_status === "cancelled",
+  });
+  return new Response(body, {
+    headers: {
+      "content-type": "text/calendar; charset=utf-8",
+      "content-disposition": `attachment; filename="brotm-poker-${invite.event_id}.ics"`,
+      "cache-control": "no-store",
+    },
+  });
 }
 
 export const onRequest: AppPagesFunction = async (context) => {
@@ -177,7 +220,9 @@ export const onRequest: AppPagesFunction = async (context) => {
   const token = parts[0];
 
   try {
-    if (!token || parts.length !== 1) return invalidInvite();
+    if (!token || parts.length < 1 || parts.length > 2) return invalidInvite();
+    if (method === "GET" && parts[1] === "calendar.ics") return calendar(request, context.env.DB, token);
+    if (parts.length !== 1) return invalidInvite();
     if (method === "GET") return getPublicInvite(context.env.DB, token);
     if (method === "POST") return respond(request, context.env.DB, token);
     return apiError(405, "METHOD_NOT_ALLOWED", "This RSVP action is not supported.");

--- a/migrations/0007_delivery_automation.sql
+++ b/migrations/0007_delivery_automation.sql
@@ -1,0 +1,24 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE delivery_schedules (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  event_player_id TEXT NOT NULL REFERENCES event_players(id) ON DELETE CASCADE,
+  reminder_type TEXT NOT NULL CHECK (reminder_type IN ('twenty_four_hours')),
+  scheduled_for TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'claimed', 'sent', 'skipped', 'failed', 'cancelled')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  claimed_at TEXT,
+  completed_at TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(event_id, event_player_id, reminder_type)
+);
+
+CREATE INDEX delivery_schedules_due_idx
+ON delivery_schedules(status, scheduled_for);
+
+CREATE INDEX delivery_schedules_event_idx
+ON delivery_schedules(event_id, reminder_type, scheduled_for);

--- a/migrations/0008_invitee_automation.sql
+++ b/migrations/0008_invitee_automation.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE events
+ADD COLUMN invite_automation_enabled INTEGER NOT NULL DEFAULT 0
+CHECK (invite_automation_enabled IN (0, 1));
+
+ALTER TABLE event_invites
+ADD COLUMN token_ciphertext TEXT;
+
+ALTER TABLE delivery_batches
+ADD COLUMN notification_type TEXT NOT NULL DEFAULT 'invite'
+CHECK (notification_type IN ('invite', 'reminder', 'event_update'));
+
+CREATE TABLE event_update_notifications (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  event_player_id TEXT NOT NULL REFERENCES event_players(id) ON DELETE CASCADE,
+  notification_key TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'claimed', 'sent', 'skipped', 'failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  claimed_at TEXT,
+  completed_at TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(event_id, event_player_id, notification_key)
+);
+
+CREATE INDEX event_update_notifications_due_idx
+ON event_update_notifications(status, created_at);
+
+CREATE INDEX event_update_notifications_event_idx
+ON event_update_notifications(event_id, created_at DESC);

--- a/shared/app-shell.ts
+++ b/shared/app-shell.ts
@@ -1,5 +1,5 @@
-export const APP_VERSION = "2.4.0";
-export const REQUIRED_SCHEMA_VERSION = 6;
+export const APP_VERSION = "2.5.0";
+export const REQUIRED_SCHEMA_VERSION = 8;
 
 export interface HealthReport {
   ok: boolean;

--- a/shared/domain.ts
+++ b/shared/domain.ts
@@ -62,6 +62,7 @@ export const eventPatchSchema = z
     location: z.string().trim().max(240).optional(),
     gameNotes: z.string().trim().max(1200).nullable().optional(),
     notes: z.string().trim().max(1200).nullable().optional(),
+    inviteAutomationEnabled: z.boolean().optional(),
     status: z.enum(eventStatuses).optional(),
     correctionNote,
   })

--- a/shared/rsvp.ts
+++ b/shared/rsvp.ts
@@ -24,6 +24,8 @@ export interface PersonalizedInviteInput {
   gameNotes: string | null;
   stakesNotes: string | null;
   rsvpUrl: string;
+  calendarUrl?: string;
+  directionsUrl?: string | null;
 }
 
 export function invitationExpiresAt(startsAt: string): string {
@@ -46,6 +48,8 @@ export function buildPersonalizedInviteText(input: PersonalizedInviteInput, loca
   if (input.gameNotes) lines.push(`Game: ${input.gameNotes}`);
   if (input.stakesNotes) lines.push(`Stakes: ${input.stakesNotes}`);
   lines.push(`RSVP yes, maybe, or no: ${input.rsvpUrl}`);
+  if (input.calendarUrl) lines.push(`Add to calendar: ${input.calendarUrl}`);
+  if (input.directionsUrl) lines.push(`Get directions: ${input.directionsUrl}`);
   return lines.join("\n");
 }
 
@@ -73,8 +77,85 @@ export function buildPersonalizedInviteEmail(
   const lines = text.split("\n");
   const escapedLines = lines.map((line) => `<p>${escapeHtml(line)}</p>`).join("");
   const subject = `BroTM Poker: ${input.title} — RSVP`;
-  const html = `${escapedLines}<p><a href="${escapeHtml(input.rsvpUrl)}">RSVP yes, maybe, or no</a></p>`;
+  const html = [
+    escapedLines,
+    `<p><a href="${escapeHtml(input.rsvpUrl)}">RSVP yes, maybe, or no</a></p>`,
+    input.calendarUrl ? `<p><a href="${escapeHtml(input.calendarUrl)}">Add to calendar</a></p>` : "",
+    input.directionsUrl ? `<p><a href="${escapeHtml(input.directionsUrl)}">Get directions</a></p>` : "",
+  ].join("");
   return { subject, text, html };
+}
+
+export function buildPersonalizedReminderEmail(
+  input: PersonalizedInviteInput,
+  locale = "en-US",
+): { subject: string; text: string; html: string } {
+  const invite = buildPersonalizedInviteEmail(input, locale);
+  return {
+    subject: `Reminder: ${invite.subject}`,
+    text: `Friendly reminder: please let the host know if you can make it.\n\n${invite.text}`,
+    html: `<p>Friendly reminder: please let the host know if you can make it.</p>${invite.html}`,
+  };
+}
+
+export function buildPersonalizedUpdateEmail(
+  input: PersonalizedInviteInput,
+  changedFields: string[],
+  locale = "en-US",
+): { subject: string; text: string; html: string } {
+  const invite = buildPersonalizedInviteEmail(input, locale);
+  const changes = changedFields.length
+    ? `Updated details: ${changedFields.join(", ")}.`
+    : "The poker night details were updated.";
+  return {
+    subject: `Update: ${input.title}`,
+    text: `${changes}\n\n${invite.text}`,
+    html: `<p>${escapeHtml(changes)}</p>${invite.html}`,
+  };
+}
+
+function escapeIcs(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll(";", "\\;")
+    .replaceAll(",", "\\,")
+    .replaceAll(/\r?\n/gu, "\\n");
+}
+
+function icsDate(value: string): string {
+  return new Date(value).toISOString().replaceAll(/[-:]/gu, "").replace(/\.\d{3}Z$/u, "Z");
+}
+
+export function buildCalendarFile(input: {
+  uid: string;
+  title: string;
+  startsAt: string;
+  location?: string | null;
+  description?: string | null;
+  url: string;
+  cancelled?: boolean;
+}): string {
+  const startsAt = new Date(input.startsAt);
+  const endsAt = new Date(startsAt.getTime() + 4 * 60 * 60 * 1000);
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//BroTM Poker//RSVP//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${escapeIcs(input.uid)}`,
+    `DTSTAMP:${icsDate(new Date().toISOString())}`,
+    `DTSTART:${icsDate(startsAt.toISOString())}`,
+    `DTEND:${icsDate(endsAt.toISOString())}`,
+    `SUMMARY:${escapeIcs(input.title)}`,
+    `URL:${escapeIcs(input.url)}`,
+    `STATUS:${input.cancelled ? "CANCELLED" : "CONFIRMED"}`,
+  ];
+  if (input.location) lines.push(`LOCATION:${escapeIcs(input.location)}`);
+  if (input.description) lines.push(`DESCRIPTION:${escapeIcs(input.description)}`);
+  lines.push("END:VEVENT", "END:VCALENDAR");
+  return `${lines.join("\r\n")}\r\n`;
 }
 
 export function buildPersonalizedInviteSms(input: PersonalizedInviteInput, locale = "en-US"): string {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -858,6 +858,7 @@ function EventDetailPage() {
           location: formValue(fields, "location"),
           gameNotes: formValue(fields, "gameNotes") || null,
           notes: formValue(fields, "notes") || null,
+          inviteAutomationEnabled: fields.get("inviteAutomationEnabled") === "on",
           ...correctionFields,
         }),
       });
@@ -1190,6 +1191,18 @@ function EventDetailPage() {
               maxLength={240}
               disabled={editDisabled}
             />
+          </label>
+          <label className="checkbox-field form-grid-wide">
+            <input
+              name="inviteAutomationEnabled"
+              type="checkbox"
+              defaultChecked={event.inviteAutomationEnabled}
+              disabled={editDisabled}
+            />
+            <span>
+              <strong>Automate invitee emails</strong>
+              <small>Send a 24-hour reminder to pending RSVPs and email invited players when event details change.</small>
+            </span>
           </label>
           <label className="form-grid-wide">
             Game and house-rule notes

--- a/src/Rsvp.tsx
+++ b/src/Rsvp.tsx
@@ -23,6 +23,7 @@ interface PublicRsvpDetail {
   expiresAt: string;
   lastResponseAt: string | null;
   stateMessage: string;
+  links: { calendar: string; directions: string | null };
 }
 
 interface AdminInviteState {
@@ -66,6 +67,7 @@ interface AdminRsvpDetail {
     stakesNotes: string | null;
     status: "draft" | "open" | "active" | "completed" | "cancelled" | "archived";
     locationVisibility: RsvpLocationVisibility;
+    inviteAutomationEnabled: boolean;
   };
   players: AdminRsvpPlayer[];
 }
@@ -100,6 +102,7 @@ interface AdminDeliveryBatch {
   id: string;
   policy: "requested_channels" | "preferred_with_fallback";
   source: "manual" | "scheduled";
+  notificationType: "invite" | "reminder" | "event_update";
   status: "sending" | "completed" | "partial" | "failed";
   summary: { requested: number; sent: number; failed: number; skipped: number };
   createdAt: string;
@@ -107,6 +110,8 @@ interface AdminDeliveryBatch {
 }
 
 interface SendInvitesResponse {
+  queued?: boolean;
+  notificationType?: "reminder" | "event_update";
   batchId: string;
   summary: { requested: number; sent: number; failed: number; skipped: number };
   results: Array<{
@@ -238,6 +243,9 @@ export function PublicRsvpPage() {
         <div className="public-rsvp-brand"><BrandMark /><strong>BroTM Poker</strong></div>
         <p className="eyebrow">Private invitation for {detail.player.displayName}</p>
         <h1>{detail.event.title}</h1>
+        <p className="public-rsvp-lede">
+          Let the host know if you’re coming. You can change your answer from this link before responses close.
+        </p>
         <div className="public-rsvp-details">
           <div><span>When</span><strong>{formatDate(detail.event.startsAt)}</strong></div>
           {detail.event.hostName ? <div><span>Host</span><strong>{detail.event.hostName}</strong></div> : null}
@@ -272,6 +280,21 @@ export function PublicRsvpPage() {
             />
           ))}
         </div>
+        <div className="public-rsvp-actions" aria-label="Event actions">
+          <a className="button button-primary" href={detail.links.calendar} download>
+            Add to calendar
+          </a>
+          {detail.links.directions ? (
+            <a className="button button-secondary" href={detail.links.directions} target="_blank" rel="noreferrer">
+              Get directions
+            </a>
+          ) : null}
+        </div>
+        {detail.rsvpStatus === "yes" && detail.event.locationHiddenUntilYes && detail.event.location ? (
+          <p className="public-rsvp-location-revealed" role="status">
+            The address is now visible above because you RSVP’d yes.
+          </p>
+        ) : null}
         <p className="public-rsvp-footnote">
           This private link expires after the poker night. Do not forward it to another person.
         </p>
@@ -473,7 +496,9 @@ export function RsvpAdminPage() {
         method: "POST",
         body: JSON.stringify({}),
       });
-      setMessage(`Retry processed: ${response.summary.sent} sent, ${response.summary.failed} failed, ${response.summary.skipped} skipped.`);
+      setMessage(response.queued
+        ? "Automated message queued for the next reminder Worker run."
+        : `Retry processed: ${response.summary.sent} sent, ${response.summary.failed} failed, ${response.summary.skipped} skipped.`);
       await load();
     } catch (caught) {
       setError(caught);
@@ -580,6 +605,15 @@ export function RsvpAdminPage() {
         </select>
       </section>
 
+      <section className="panel rsvp-privacy-panel">
+        <div>
+          <p className="eyebrow">Invitee follow-up</p>
+          <h2>{detail.event.inviteAutomationEnabled ? "Automatic emails are on" : "Automatic emails are off"}</h2>
+          <p>When enabled on the event setup page, pending players receive one email reminder 24 hours before the poker night and invited players receive updates when details change.</p>
+        </div>
+        <Link className="button button-secondary" to={`/events/${id}`}>Manage on event setup</Link>
+      </section>
+
       {locked ? (
         <div className="state-card">This event is locked. Recorded responses remain visible, but links cannot be generated, regenerated, or revoked.</div>
       ) : null}
@@ -665,7 +699,7 @@ export function RsvpAdminPage() {
             {batches.map((batch) => (
               <article className="rsvp-delivery-row" key={batch.id}>
                 <div>
-                  <strong>{batch.source === "scheduled" ? "Scheduled reminder" : "Organizer send"}</strong>
+                  <strong>{batch.notificationType === "event_update" ? "Event update" : batch.notificationType === "reminder" ? "24-hour reminder" : "Organizer invitation"}</strong>
                   <span>{batch.policy === "preferred_with_fallback" ? "Preferred channel with fallback" : "Requested channels"}</span>
                 </div>
                 <div>

--- a/src/rsvp.css
+++ b/src/rsvp.css
@@ -27,6 +27,14 @@
   letter-spacing: -0.045em;
 }
 
+.public-rsvp-lede {
+  max-width: 48ch;
+  margin: -0.5rem 0 0;
+  color: var(--muted);
+  font-size: 1.03rem;
+  line-height: 1.6;
+}
+
 .public-rsvp-brand {
   display: inline-flex;
   align-items: center;
@@ -162,6 +170,23 @@
 .rsvp-choice:disabled {
   cursor: not-allowed;
   opacity: 0.62;
+}
+
+.public-rsvp-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.public-rsvp-actions .button {
+  flex: 1 1 180px;
+}
+
+.public-rsvp-location-revealed {
+  margin: -0.5rem 0 0;
+  color: var(--green);
+  font-size: 0.9rem;
+  font-weight: 700;
 }
 
 .public-rsvp-footnote {
@@ -427,6 +452,10 @@
 
   .rsvp-choice {
     min-height: 58px;
+  }
+
+  .public-rsvp-actions {
+    display: grid;
   }
 
   .rsvp-admin-actions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface PokerEvent {
   location: string;
   gameNotes: string | null;
   notes: string | null;
+  inviteAutomationEnabled: boolean;
   status: EventStatus;
   attendanceCount: number;
   playerCount: number;

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -58,6 +58,16 @@ describe("invite delivery contracts", () => {
     expect(message.html).toContain(`href="${invite.rsvpUrl}"`);
   });
 
+  it("includes calendar and directions links when supplied", () => {
+    const message = buildPersonalizedInviteEmail({
+      ...invite,
+      calendarUrl: "https://poker.skpfam.com/rsvp-api/example-token/calendar.ics",
+      directionsUrl: "https://www.google.com/maps/search/?api=1&query=123%20Main%20Street",
+    });
+    expect(message.text).toContain("calendar.ics");
+    expect(message.html).toContain("Get directions");
+  });
+
   it("escapes player and event content in the HTML email", () => {
     const message = buildPersonalizedInviteEmail({
       ...invite,

--- a/tests/rsvp.test.ts
+++ b/tests/rsvp.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPersonalizedInviteText,
+  buildCalendarFile,
   hashRsvpToken,
   invitationExpiresAt,
   isPlausibleRsvpToken,
@@ -40,5 +41,20 @@ describe("private RSVP invitation helpers", () => {
     expect(isPlausibleRsvpToken(token)).toBe(true);
     expect(isPlausibleRsvpToken("too-short")).toBe(false);
     expect(await hashRsvpToken(token)).toBe(await hashRsvpToken(token));
+  });
+
+  it("builds a four-hour calendar event with the RSVP link", () => {
+    const calendar = buildCalendarFile({
+      uid: "invite-123",
+      title: "Friday Poker Night",
+      startsAt: "2026-07-24T19:00:00-06:00",
+      location: "123 Main Street",
+      url: "https://poker.skpfam.com/rsvp/example-token",
+    });
+    expect(calendar).toContain("SUMMARY:Friday Poker Night");
+    expect(calendar).toContain("DTSTART:20260725T010000Z");
+    expect(calendar).toContain("DTEND:20260725T050000Z");
+    expect(calendar).toContain("URL:https://poker.skpfam.com/rsvp/example-token");
+    expect(calendar).toContain("LOCATION:123 Main Street");
   });
 });

--- a/tests/scheduled-delivery.test.ts
+++ b/tests/scheduled-delivery.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { reminderTime } from "../functions/lib/scheduled-delivery";
+import { decryptRsvpToken, encryptRsvpToken } from "../functions/lib/token-vault";
+import { createRsvpToken } from "../shared/rsvp";
+
+describe("scheduled reminder timing", () => {
+  it("schedules the response reminder 24 hours before the event", () => {
+    expect(reminderTime("2026-08-08T19:00:00-06:00", "twenty_four_hours")).toBe("2026-08-08T01:00:00.000Z");
+  });
+
+  it("round-trips an RSVP token for automated messages without changing it", async () => {
+    const token = createRsvpToken();
+    const ciphertext = await encryptRsvpToken(token, "test-secret");
+    expect(ciphertext).not.toContain(token);
+    await expect(decryptRsvpToken(ciphertext, "test-secret")).resolves.toBe(token);
+    await expect(decryptRsvpToken(ciphertext, "wrong-secret")).resolves.toBeNull();
+  });
+});

--- a/worker.ts
+++ b/worker.ts
@@ -1,0 +1,8 @@
+import { runScheduledReminders } from "./functions/lib/scheduled-delivery";
+import type { Env } from "./functions/lib/types";
+
+export default {
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(runScheduledReminders(env));
+  },
+};

--- a/wrangler.worker.jsonc
+++ b/wrangler.worker.jsonc
@@ -1,0 +1,21 @@
+{
+  "name": "brotm-poker-reminders",
+  "main": "worker.ts",
+  "compatibility_date": "2026-07-21",
+  "triggers": {
+    "crons": ["*/15 * * * *"]
+  },
+  "vars": {
+    "ENVIRONMENT": "development",
+    "DELIVERY_MODE": "log",
+    "PUBLIC_APP_ORIGIN": "http://localhost:8788"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "brotm-poker",
+      "database_id": "local-brotm-poker",
+      "migrations_dir": "./migrations"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Add a mobile-first public RSVP experience with calendar download and Google Maps directions.
- Add per-event opt-in 24-hour reminder emails for pending RSVPs.
- Queue email update notifications when material event details change.
- Preserve the existing RSVP link for automated messages using encrypted token storage.
- Add delivery history labels, safe automated retry queueing, migrations 0007-0008, tests, and rollout documentation.

## Validation

- npm run typecheck
- npm run test (40 passing)
- npm run format:check
- npm run lint
- npm run build

## Deployment notes

Apply migrations 0007 and 0008 to production D1. Configure RSVP_TOKEN_ENCRYPTION_KEY on Pages and the Worker. Deploy the separate Worker from wrangler.worker.jsonc with the production D1 binding and live Resend secrets. Existing invites should be resent once after deployment so they receive encrypted token copies for automated follow-up.