### PR TITLE
Upgrade BroTime Poker invitation emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ The Production environment needs one D1 binding named `DB`, pointing to `brotm-p
 - [`docs/FIRST_SLICE_WORK_ORDER.md`](docs/FIRST_SLICE_WORK_ORDER.md): implementation scope and acceptance criteria
 - [`docs/DECISION_LOG.md`](docs/DECISION_LOG.md): durable product and architecture decisions
 - [`docs/MOBILE_FIRST_ROADMAP.md`](docs/MOBILE_FIRST_ROADMAP.md): phone-first features, automation, and follow-on work
+- [`docs/EMAIL_TEMPLATE.md`](docs/EMAIL_TEMPLATE.md): branded invitation email implementation and standalone preview
 - [`wrangler.worker.jsonc`](wrangler.worker.jsonc): reminder Worker and Cron Trigger configuration

--- a/docs/EMAIL_TEMPLATE.md
+++ b/docs/EMAIL_TEMPLATE.md
@@ -1,0 +1,11 @@
+# BroTime Poker email template
+
+The reusable renderer lives in [`shared/rsvp.ts`](../shared/rsvp.ts), in `buildPersonalizedInviteEmail`, `buildPersonalizedReminderEmail`, and `buildPersonalizedUpdateEmail`. It emits a table-based, inline-styled HTML email capped at 600px plus a readable plain-text fallback.
+
+Email sends pass the absolute public URL for `public/apple-touch-icon.png`. The existing 180px PNG is displayed at 84px for retina-friendly email rendering. The SVG remains the web/PWA asset but is intentionally not required by the email because SVG support is inconsistent in Outlook and some webmail clients.
+
+The RSVP, calendar, and directions links remain ordinary absolute URLs. Resend can rewrite them for click tracking on the configured tracking domain; the application does not hardcode or proxy the tracking host.
+
+The template accepts an optional `unsubscribeUrl`. When present, it renders a visible unsubscribe link and sends `List-Unsubscribe` and `List-Unsubscribe-Post` headers through Resend. The current product has no unsubscribe endpoint yet, so current sends use the organizer-contact fallback. Add the future endpoint URL to the input when that backend is implemented.
+
+Standalone preview: [`brotm-invite-email-preview.html`](./brotm-invite-email-preview.html).

--- a/docs/brotm-invite-email-preview.html
+++ b/docs/brotm-invite-email-preview.html
@@ -16,7 +16,7 @@
     <tr><td align="center">
       <table role="presentation" class="email-shell" width="600" cellpadding="0" cellspacing="0" border="0">
         <tr><td align="center" style="padding:28px 20px 24px;background:#075b3b;border:1px solid #d7b267;border-bottom:0;">
-          <img src="https://poker.skpfam.com/apple-touch-icon.png?v=2" width="84" height="84" alt="BroTime Poker spade logo" style="display:block;width:84px;height:84px;margin:0 auto 10px;border:0;">
+          <img src="https://poker.skpfam.com/apple-touch-icon.png" width="84" height="84" alt="BroTime Poker spade logo" style="display:block;width:84px;height:84px;margin:0 auto 10px;border:0;">
           <div style="color:#fffdf6;font-size:12px;line-height:16px;letter-spacing:3px;font-weight:bold;">BROTIME</div>
           <div style="margin-top:3px;color:#d7b267;font:700 20px/26px Georgia,'Times New Roman',serif;">Poker Night</div>
         </td></tr>

--- a/docs/brotm-invite-email-preview.html
+++ b/docs/brotm-invite-email-preview.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BroTime Poker Night email preview</title>
+  <style>
+    body { margin: 0; padding: 24px 10px; background: #063c29; color: #1d2a22; font-family: Arial, Helvetica, sans-serif; }
+    .email-shell { width: 100%; max-width: 600px; margin: 0 auto; }
+    @media only screen and (max-width: 620px) { .email-pad { padding-left: 20px !important; padding-right: 20px !important; } }
+  </style>
+</head>
+<body>
+  <div style="display:none!important;max-height:0;overflow:hidden;opacity:0;color:transparent;">You’re invited to Friday Poker Night. Let the host know if you can make it.</div>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;background:#063c29;">
+    <tr><td align="center">
+      <table role="presentation" class="email-shell" width="600" cellpadding="0" cellspacing="0" border="0">
+        <tr><td align="center" style="padding:28px 20px 24px;background:#075b3b;border:1px solid #d7b267;border-bottom:0;">
+          <img src="https://poker.skpfam.com/apple-touch-icon.png?v=2" width="84" height="84" alt="BroTime Poker spade logo" style="display:block;width:84px;height:84px;margin:0 auto 10px;border:0;">
+          <div style="color:#fffdf6;font-size:12px;line-height:16px;letter-spacing:3px;font-weight:bold;">BROTIME</div>
+          <div style="margin-top:3px;color:#d7b267;font:700 20px/26px Georgia,'Times New Roman',serif;">Poker Night</div>
+        </td></tr>
+        <tr><td class="email-pad" style="padding:34px 42px 30px;background:#fffdf6;border:1px solid #d7b267;border-top:4px solid #d7b267;">
+          <div style="padding-bottom:10px;color:#8b6b28;font-size:12px;line-height:16px;letter-spacing:1.5px;text-transform:uppercase;font-weight:bold;">BroTime Poker Night</div>
+          <div style="padding-bottom:12px;color:#075b3b;font:700 30px/37px Georgia,'Times New Roman',serif;">You’re invited</div>
+          <div style="padding-bottom:24px;color:#455249;font-size:16px;line-height:25px;">A seat may be waiting for you at the table.</div>
+          <div style="padding-bottom:6px;color:#1d2a22;font-size:17px;line-height:24px;font-weight:bold;">Hi Ryan,</div>
+          <div style="padding-bottom:20px;color:#455249;font-size:15px;line-height:23px;">You’re invited to <strong style="color:#075b3b;">Friday Poker Night</strong>.</div>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="padding:12px 18px;background:#fffaf0;border:1px solid #ead9ad;">
+            <tr><td style="padding:8px 12px 8px 0;color:#6c746e;font-size:13px;vertical-align:top;white-space:nowrap;">When</td><td style="padding:8px 0;color:#1d2a22;font-size:15px;font-weight:600;">Friday, August 7, 2026 at 7:00 PM</td></tr>
+            <tr><td style="padding:8px 12px 8px 0;color:#6c746e;font-size:13px;vertical-align:top;white-space:nowrap;">Host</td><td style="padding:8px 0;color:#1d2a22;font-size:15px;font-weight:600;">Sterling</td></tr>
+            <tr><td style="padding:8px 12px 8px 0;color:#6c746e;font-size:13px;vertical-align:top;white-space:nowrap;">Location</td><td style="padding:8px 0;color:#1d2a22;font-size:15px;font-weight:600;">123 Main Street</td></tr>
+            <tr><td style="padding:8px 12px 8px 0;color:#6c746e;font-size:13px;vertical-align:top;white-space:nowrap;">Game</td><td style="padding:8px 0;color:#1d2a22;font-size:15px;font-weight:600;">Dealer’s choice</td></tr>
+            <tr><td style="padding:8px 12px 8px 0;color:#6c746e;font-size:13px;vertical-align:top;white-space:nowrap;">Stakes</td><td style="padding:8px 0;color:#1d2a22;font-size:15px;font-weight:600;">$10 buy-in</td></tr>
+          </table>
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:28px auto 14px;"><tr><td bgcolor="#075b3b" style="border-radius:4px;background:#075b3b;box-shadow:inset 0 -2px 0 #063c29;"><a href="https://poker.skpfam.com/rsvp/example-token" style="display:inline-block;padding:15px 24px;color:#fffdf6;font-size:16px;line-height:20px;font-weight:bold;text-decoration:none;">View Invitation &amp; RSVP</a></td></tr></table>
+          <div style="padding-bottom:22px;color:#6c746e;font-size:12px;line-height:18px;text-align:center;word-break:break-all;">Or open this private link:<br><a href="https://poker.skpfam.com/rsvp/example-token" style="color:#075b3b;text-decoration:underline;">https://poker.skpfam.com/rsvp/example-token</a></div>
+          <div style="padding-bottom:24px;color:#075b3b;font-size:14px;line-height:20px;text-align:center;"><a href="https://poker.skpfam.com/rsvp-api/example-token/calendar.ics" style="color:#075b3b;text-decoration:underline;">Add to calendar</a>&nbsp;&nbsp;·&nbsp;&nbsp;<a href="https://www.google.com/maps/search/?api=1&amp;query=123%20Main%20Street" style="color:#075b3b;text-decoration:underline;">Get directions</a></div>
+          <div style="padding-top:17px;border-top:1px solid #ead9ad;color:#6c746e;font-size:12px;line-height:19px;">This RSVP link is unique to you. Please do not forward it.</div>
+        </td></tr>
+        <tr><td align="center" style="padding:20px 24px 22px;background:#075b3b;border:1px solid #d7b267;border-top:0;">
+          <div style="color:#fffdf6;font:700 18px/24px Georgia,'Times New Roman',serif;">BroTime</div>
+          <div style="margin-top:5px;color:#c9d4c9;font-size:12px;line-height:18px;">You’re receiving this because you were invited to a BroTime Poker Night event.</div>
+          <div style="margin-top:10px;color:#e8eadf;font-size:12px;line-height:18px;">Need to change future invitations? Contact the event organizer.</div>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/functions/lib/delivery.ts
+++ b/functions/lib/delivery.ts
@@ -45,6 +45,7 @@ async function sendEmail(env: Env, message: DeliveryMessage): Promise<ProviderDe
       subject: message.subject,
       text: message.text,
       html: message.html,
+      ...(message.headers ? { headers: message.headers } : {}),
     }),
   });
 

--- a/functions/lib/scheduled-delivery.ts
+++ b/functions/lib/scheduled-delivery.ts
@@ -269,10 +269,19 @@ async function processRow(db: D1Database, env: Env, row: NotificationRow, origin
     rsvpUrl,
     calendarUrl: calendarUrl(origin, token),
     directionsUrl: row.location ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(row.location)}` : null,
+    brandAssetUrl: `${origin.replace(/\/+$/u, "")}/apple-touch-icon.png?v=2`,
   };
   const email = isReminder ? buildPersonalizedReminderEmail(input) : buildPersonalizedUpdateEmail(input, fields);
   const provider = providerName("email", env);
-  const message = { channel: "email" as const, destination: destination.destination, subject: email.subject, text: email.text, html: email.html, idempotencyKey: `${batchId}:${deliveryId}` };
+  const message = {
+    channel: "email" as const,
+    destination: destination.destination,
+    subject: email.subject,
+    text: email.text,
+    html: email.html,
+    headers: email.headers,
+    idempotencyKey: `${batchId}:${deliveryId}`,
+  };
 
   await db.batch([
     db.prepare(

--- a/functions/lib/scheduled-delivery.ts
+++ b/functions/lib/scheduled-delivery.ts
@@ -269,7 +269,7 @@ async function processRow(db: D1Database, env: Env, row: NotificationRow, origin
     rsvpUrl,
     calendarUrl: calendarUrl(origin, token),
     directionsUrl: row.location ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(row.location)}` : null,
-    brandAssetUrl: `${origin.replace(/\/+$/u, "")}/apple-touch-icon.png?v=2`,
+    brandAssetUrl: `${origin.replace(/\/+$/u, "")}/apple-touch-icon.png`,
   };
   const email = isReminder ? buildPersonalizedReminderEmail(input) : buildPersonalizedUpdateEmail(input, fields);
   const provider = providerName("email", env);

--- a/functions/rsvp-admin-api/[[path]].ts
+++ b/functions/rsvp-admin-api/[[path]].ts
@@ -473,6 +473,7 @@ function deliveryMessage(
   destination: string,
   url: string,
   deliveryId: string,
+  origin: string,
 ) {
   const input = {
     playerName: player.display_name,
@@ -484,6 +485,7 @@ function deliveryMessage(
     gameNotes: event.game_notes,
     stakesNotes: event.stakes_notes,
     rsvpUrl: url,
+    brandAssetUrl: `${origin.replace(/\/+$/u, "")}/apple-touch-icon.png?v=2`,
     calendarUrl: `${origin.replace(/\/+$/u, "")}/rsvp-api/${encodeURIComponent(url.split("/rsvp/").pop() ?? "")}/calendar.ics`,
     directionsUrl: event.location
       ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`
@@ -497,6 +499,7 @@ function deliveryMessage(
       subject: email.subject,
       text: email.text,
       html: email.html,
+      headers: email.headers,
       idempotencyKey: deliveryId,
     };
   }
@@ -1000,7 +1003,7 @@ async function sendInvites(
         deliveryId,
         resultId,
         resultIndex: results.length - 1,
-        message: deliveryMessage(event, player, channel, destinationValue, prepared.generated.url, deliveryId),
+        message: deliveryMessage(event, player, channel, destinationValue, prepared.generated.url, deliveryId, origin),
         player,
         provider,
       });

--- a/functions/rsvp-admin-api/[[path]].ts
+++ b/functions/rsvp-admin-api/[[path]].ts
@@ -485,7 +485,7 @@ function deliveryMessage(
     gameNotes: event.game_notes,
     stakesNotes: event.stakes_notes,
     rsvpUrl: url,
-    brandAssetUrl: `${origin.replace(/\/+$/u, "")}/apple-touch-icon.png?v=2`,
+    brandAssetUrl: `${origin.replace(/\/+$/u, "")}/apple-touch-icon.png`,
     calendarUrl: `${origin.replace(/\/+$/u, "")}/rsvp-api/${encodeURIComponent(url.split("/rsvp/").pop() ?? "")}/calendar.ics`,
     directionsUrl: event.location
       ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`

--- a/index.html
+++ b/index.html
@@ -8,9 +8,12 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2" />
+    <!-- Safari uses these explicit PNG declarations for Add to Home Screen. Keep the URL stable. -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="icon" href="/icon.svg?v=2" type="image/svg+xml" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/apple-touch-icon.png" type="image/png" sizes="180x180" />
     <title>BroTM Poker</title>
   </head>
   <body>

--- a/public/_headers
+++ b/public/_headers
@@ -9,5 +9,14 @@
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
+/apple-touch-icon.png
+  Cache-Control: public, max-age=86400
+
+/icon.svg
+  Cache-Control: public, max-age=86400
+
+/manifest.webmanifest
+  Cache-Control: public, max-age=3600
+
 /api/*
   Cache-Control: no-store

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -8,7 +8,7 @@
   "background_color": "#075b3b",
   "theme_color": "#075b3b",
   "icons": [
-    { "src": "/apple-touch-icon.png?v=2", "sizes": "180x180", "type": "image/png", "purpose": "any" },
-    { "src": "/icon.svg?v=2", "sizes": "any", "type": "image/svg+xml", "purpose": "any" }
+    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png", "purpose": "any" },
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any" }
   ]
 }

--- a/shared/delivery.ts
+++ b/shared/delivery.ts
@@ -59,6 +59,7 @@ export interface DeliveryMessage {
   subject?: string;
   text: string;
   html?: string;
+  headers?: Record<string, string>;
   idempotencyKey: string;
 }
 

--- a/shared/rsvp.ts
+++ b/shared/rsvp.ts
@@ -26,6 +26,9 @@ export interface PersonalizedInviteInput {
   rsvpUrl: string;
   calendarUrl?: string;
   directionsUrl?: string | null;
+  brandAssetUrl?: string;
+  unsubscribeUrl?: string | null;
+  preheader?: string;
 }
 
 export function invitationExpiresAt(startsAt: string): string {
@@ -33,11 +36,15 @@ export function invitationExpiresAt(startsAt: string): string {
   return new Date(starts.getTime() + 36 * 60 * 60 * 1000).toISOString();
 }
 
-export function buildPersonalizedInviteText(input: PersonalizedInviteInput, locale = "en-US"): string {
-  const when = new Intl.DateTimeFormat(locale, {
+function formattedInviteTime(startsAt: string, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
     dateStyle: "full",
     timeStyle: "short",
-  }).format(new Date(input.startsAt));
+  }).format(new Date(startsAt));
+}
+
+export function buildPersonalizedInviteText(input: PersonalizedInviteInput, locale = "en-US"): string {
+  const when = formattedInviteTime(input.startsAt, locale);
   const lines = [`${input.playerName}, you are invited to ${input.title}.`, when];
   if (input.hostName) lines.push(`Host: ${input.hostName}`);
   if (input.locationVisibility === "always" && input.location) {
@@ -62,56 +69,219 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
-function formattedInviteTime(startsAt: string, locale: string): string {
-  return new Intl.DateTimeFormat(locale, {
-    dateStyle: "full",
-    timeStyle: "short",
-  }).format(new Date(startsAt));
+function escapeAttribute(value: string): string {
+  return escapeHtml(value);
 }
 
-export function buildPersonalizedInviteEmail(
-  input: PersonalizedInviteInput,
-  locale = "en-US",
-): { subject: string; text: string; html: string } {
-  const text = buildPersonalizedInviteText(input, locale);
-  const lines = text.split("\n");
-  const escapedLines = lines.map((line) => `<p>${escapeHtml(line)}</p>`).join("");
-  const subject = `BroTM Poker: ${input.title} — RSVP`;
-  const html = [
-    escapedLines,
-    `<p><a href="${escapeHtml(input.rsvpUrl)}">RSVP yes, maybe, or no</a></p>`,
-    input.calendarUrl ? `<p><a href="${escapeHtml(input.calendarUrl)}">Add to calendar</a></p>` : "",
-    input.directionsUrl ? `<p><a href="${escapeHtml(input.directionsUrl)}">Get directions</a></p>` : "",
-  ].join("");
-  return { subject, text, html };
+function absoluteLink(url: string | null | undefined, label: string): string {
+  if (!url) return "";
+  return `<a href="${escapeAttribute(url)}" style="color:#075b3b;text-decoration:underline;">${escapeHtml(label)}</a>`;
 }
 
-export function buildPersonalizedReminderEmail(
+function detailRow(label: string, value: string): string {
+  return `<tr>
+    <td style="padding:8px 12px 8px 0;color:#6c746e;font-size:13px;line-height:20px;vertical-align:top;white-space:nowrap;">${escapeHtml(label)}</td>
+    <td style="padding:8px 0;color:#1d2a22;font-size:15px;line-height:20px;font-weight:600;">${escapeHtml(value)}</td>
+  </tr>`;
+}
+
+function emailText(
   input: PersonalizedInviteInput,
+  intro: string,
+  unsubscribeLine: string,
+  locale: string,
+): string {
+  const lines = [
+    intro,
+    "",
+    buildPersonalizedInviteText(input, locale),
+    "",
+    `View Invitation & RSVP: ${input.rsvpUrl}`,
+  ];
+  if (input.calendarUrl) lines.push(`Add to calendar: ${input.calendarUrl}`);
+  if (input.directionsUrl) lines.push(`Get directions: ${input.directionsUrl}`);
+  lines.push("", "This RSVP link is unique to you. Please do not forward it.", unsubscribeLine);
+  return lines.join("\n");
+}
+
+function emailHtml(
+  input: PersonalizedInviteInput,
+  heading: string,
+  intro: string,
+  locale: string,
+  changedFields: string[] = [],
+): string {
+  const when = formattedInviteTime(input.startsAt, locale);
+  const logoUrl = input.brandAssetUrl ? escapeAttribute(input.brandAssetUrl) : "";
+  const preheader = escapeHtml(input.preheader ?? intro);
+  const location = input.locationVisibility === "always" && input.location
+    ? detailRow("Location", input.location)
+    : input.locationVisibility === "after_yes"
+      ? detailRow("Location", "Shown after you RSVP yes")
+      : "";
+  const changes = changedFields.length
+    ? `<tr><td colspan="2" style="padding:0 0 18px;color:#075b3b;font-size:14px;line-height:21px;"><strong>Updated details:</strong> ${escapeHtml(changedFields.join(", "))}</td></tr>`
+    : "";
+  const calendar = input.calendarUrl
+    ? `<a href="${escapeAttribute(input.calendarUrl)}" style="color:#075b3b;text-decoration:underline;">Add to calendar</a>`
+    : "";
+  const directions = input.directionsUrl
+    ? `<a href="${escapeAttribute(input.directionsUrl)}" style="color:#075b3b;text-decoration:underline;">Get directions</a>`
+    : "";
+  const links = [calendar, directions].filter(Boolean).join("&nbsp;&nbsp;·&nbsp;&nbsp;");
+  const unsubscribe = input.unsubscribeUrl
+    ? `<a href="${escapeAttribute(input.unsubscribeUrl)}" style="color:#d7b267;text-decoration:underline;">Unsubscribe from BroTime Poker emails</a>`
+    : "Need to change future invitations? Contact the event organizer.";
+  const footerHeaders = input.unsubscribeUrl
+    ? `<p style="margin:10px 0 0;font-size:12px;line-height:18px;color:#e8eadf;">${unsubscribe}</p>`
+    : `<p style="margin:10px 0 0;font-size:12px;line-height:18px;color:#e8eadf;">${unsubscribe}</p>`;
+  const image = logoUrl
+    ? `<img src="${logoUrl}" width="84" height="84" alt="BroTime Poker spade logo" style="display:block;width:84px;height:84px;margin:0 auto 10px;border:0;outline:none;text-decoration:none;">`
+    : "";
+  const unsubscribeLine = input.unsubscribeUrl
+    ? `Unsubscribe: ${input.unsubscribeUrl}`
+    : "To change future invitations, contact the event organizer.";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="x-apple-disable-message-reformatting">
+  <title>${escapeHtml(heading)}</title>
+  <style>
+    @media only screen and (max-width:620px) {
+      .email-shell { width:100% !important; }
+      .email-pad { padding-left:20px !important; padding-right:20px !important; }
+      .email-heading { font-size:25px !important; line-height:32px !important; }
+      .email-button { width:100% !important; }
+      .email-button a { display:block !important; }
+    }
+  </style>
+</head>
+<body style="margin:0;padding:0;background-color:#063c29;color:#1d2a22;font-family:Arial,Helvetica,sans-serif;">
+  <div style="display:none!important;max-height:0;overflow:hidden;opacity:0;color:transparent;">${preheader}</div>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;margin:0;padding:0;background-color:#063c29;">
+    <tr>
+      <td align="center" style="padding:24px 10px;">
+        <table role="presentation" class="email-shell" width="600" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;margin:0 auto;">
+          <tr>
+            <td align="center" style="padding:28px 20px 24px;background-color:#075b3b;border:1px solid #d7b267;border-bottom:0;">
+              ${image}
+              <div style="color:#fffdf6;font-size:12px;line-height:16px;letter-spacing:3px;font-weight:bold;">BROTIME</div>
+              <div style="margin-top:3px;color:#d7b267;font-size:20px;line-height:26px;font-family:Georgia,'Times New Roman',serif;font-weight:bold;">Poker Night</div>
+            </td>
+          </tr>
+          <tr>
+            <td class="email-pad" style="padding:34px 42px 30px;background-color:#fffdf6;border:1px solid #d7b267;border-top:4px solid #d7b267;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr><td style="padding:0 0 10px;color:#8b6b28;font-size:12px;line-height:16px;letter-spacing:1.5px;text-transform:uppercase;font-weight:bold;">BroTime Poker Night</td></tr>
+                <tr><td class="email-heading" style="padding:0 0 12px;color:#075b3b;font-family:Georgia,'Times New Roman',serif;font-size:30px;line-height:37px;font-weight:bold;">${escapeHtml(heading)}</td></tr>
+                <tr><td style="padding:0 0 24px;color:#455249;font-size:16px;line-height:25px;">${escapeHtml(intro)}</td></tr>
+                ${changes}
+                <tr><td style="padding:0 0 6px;color:#1d2a22;font-size:17px;line-height:24px;font-weight:bold;">Hi ${escapeHtml(input.playerName)},</td></tr>
+                <tr><td style="padding:0 0 20px;color:#455249;font-size:15px;line-height:23px;">You’re invited to <strong style="color:#075b3b;">${escapeHtml(input.title)}</strong>.</td></tr>
+                <tr><td style="padding:18px 18px 12px;border:1px solid #ead9ad;background-color:#fffaf0;">
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                    ${detailRow("When", when)}
+                    ${input.hostName ? detailRow("Host", input.hostName) : ""}
+                    ${location}
+                    ${input.gameNotes ? detailRow("Game", input.gameNotes) : ""}
+                    ${input.stakesNotes ? detailRow("Stakes", input.stakesNotes) : ""}
+                  </table>
+                </td></tr>
+                <tr><td align="center" style="padding:28px 0 14px;">
+                  <table role="presentation" class="email-button" cellpadding="0" cellspacing="0" border="0">
+                    <tr><td align="center" bgcolor="#075b3b" style="border-radius:4px;background-color:#075b3b;box-shadow:inset 0 -2px 0 #063c29;">
+                      <a href="${escapeAttribute(input.rsvpUrl)}" style="display:inline-block;padding:15px 24px;color:#fffdf6;font-size:16px;line-height:20px;font-weight:bold;text-decoration:none;">View Invitation &amp; RSVP</a>
+                    </td></tr>
+                  </table>
+                </td></tr>
+                <tr><td align="center" style="padding:0 0 22px;color:#6c746e;font-size:12px;line-height:18px;word-break:break-all;">Or open this private link:<br><a href="${escapeAttribute(input.rsvpUrl)}" style="color:#075b3b;text-decoration:underline;">${escapeHtml(input.rsvpUrl)}</a></td></tr>
+                ${links ? `<tr><td align="center" style="padding:0 0 24px;color:#075b3b;font-size:14px;line-height:20px;">${links}</td></tr>` : ""}
+                <tr><td style="padding:17px 0 0;border-top:1px solid #ead9ad;color:#6c746e;font-size:12px;line-height:19px;">This RSVP link is unique to you. Please do not forward it.</td></tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding:20px 24px 22px;background-color:#075b3b;border:1px solid #d7b267;border-top:0;">
+              <div style="color:#fffdf6;font-family:Georgia,'Times New Roman',serif;font-size:18px;line-height:24px;font-weight:bold;">BroTime</div>
+              <div style="margin-top:5px;color:#c9d4c9;font-size:12px;line-height:18px;">You’re receiving this because you were invited to a BroTime Poker Night event.</div>
+              ${footerHeaders}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+interface EmailBuildResult {
+  subject: string;
+  text: string;
+  html: string;
+  headers?: Record<string, string>;
+}
+
+function buildEventEmail(
+  input: PersonalizedInviteInput,
+  variant: "invite" | "reminder" | "update",
+  changedFields: string[] = [],
   locale = "en-US",
-): { subject: string; text: string; html: string } {
-  const invite = buildPersonalizedInviteEmail(input, locale);
+): EmailBuildResult {
+  const unsubscribeLine = input.unsubscribeUrl
+    ? `Unsubscribe: ${input.unsubscribeUrl}`
+    : "To change future invitations, contact the event organizer.";
+  const config = variant === "reminder"
+    ? {
+        subject: `Reminder: ${input.title}`,
+        heading: "A quick RSVP reminder",
+        intro: "The poker night is coming up. Let the host know if you can make it.",
+      }
+    : variant === "update"
+      ? {
+          subject: `Update: ${input.title}`,
+          heading: "Poker night details changed",
+          intro: "The host updated this poker night. Review the details and update your RSVP if needed.",
+        }
+      : {
+          subject: `BroTM Poker: ${input.title} - RSVP`,
+          heading: "You’re invited",
+          intro: "A seat may be waiting for you at the table.",
+        };
+  const text = variant === "update" && changedFields.length
+    ? emailText(input, `${config.intro}\nUpdated details: ${changedFields.join(", ")}.`, unsubscribeLine, locale)
+    : emailText(input, config.intro, unsubscribeLine, locale);
+  const headers = input.unsubscribeUrl
+    ? {
+        "List-Unsubscribe": `<${input.unsubscribeUrl}>`,
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      }
+    : undefined;
   return {
-    subject: `Reminder: ${invite.subject}`,
-    text: `Friendly reminder: please let the host know if you can make it.\n\n${invite.text}`,
-    html: `<p>Friendly reminder: please let the host know if you can make it.</p>${invite.html}`,
+    subject: config.subject,
+    text: text.trim(),
+    html: emailHtml(input, config.heading, config.intro, locale, changedFields),
+    headers,
   };
+}
+
+export function buildPersonalizedInviteEmail(input: PersonalizedInviteInput, locale = "en-US"): EmailBuildResult {
+  return buildEventEmail(input, "invite", [], locale);
+}
+
+export function buildPersonalizedReminderEmail(input: PersonalizedInviteInput, locale = "en-US"): EmailBuildResult {
+  return buildEventEmail(input, "reminder", [], locale);
 }
 
 export function buildPersonalizedUpdateEmail(
   input: PersonalizedInviteInput,
   changedFields: string[],
   locale = "en-US",
-): { subject: string; text: string; html: string } {
-  const invite = buildPersonalizedInviteEmail(input, locale);
-  const changes = changedFields.length
-    ? `Updated details: ${changedFields.join(", ")}.`
-    : "The poker night details were updated.";
-  return {
-    subject: `Update: ${input.title}`,
-    text: `${changes}\n\n${invite.text}`,
-    html: `<p>${escapeHtml(changes)}</p>${invite.html}`,
-  };
+): EmailBuildResult {
+  return buildEventEmail(input, "update", changedFields, locale);
 }
 
 function escapeIcs(value: string): string {

--- a/src/BrandMark.tsx
+++ b/src/BrandMark.tsx
@@ -1,3 +1,3 @@
 export function BrandMark({ className = "" }: { className?: string }) {
-  return <img className={`brand-mark ${className}`} src="/apple-touch-icon.png?v=2" alt="" aria-hidden="true" />;
+  return <img className={`brand-mark ${className}`} src="/apple-touch-icon.png" alt="" aria-hidden="true" />;
 }

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -17,7 +17,7 @@ const invite = {
   gameNotes: "Dealer's choice",
   stakesNotes: "$10 buy-in",
   rsvpUrl: "https://poker.skpfam.com/rsvp/example-token",
-  brandAssetUrl: "https://poker.skpfam.com/apple-touch-icon.png?v=2",
+  brandAssetUrl: "https://poker.skpfam.com/apple-touch-icon.png",
 };
 
 describe("invite delivery contracts", () => {

--- a/tests/delivery.test.ts
+++ b/tests/delivery.test.ts
@@ -17,6 +17,7 @@ const invite = {
   gameNotes: "Dealer's choice",
   stakesNotes: "$10 buy-in",
   rsvpUrl: "https://poker.skpfam.com/rsvp/example-token",
+  brandAssetUrl: "https://poker.skpfam.com/apple-touch-icon.png?v=2",
 };
 
 describe("invite delivery contracts", () => {
@@ -56,6 +57,11 @@ describe("invite delivery contracts", () => {
     expect(message.subject).toContain("Friday Poker Night");
     expect(message.text).toContain(invite.rsvpUrl);
     expect(message.html).toContain(`href="${invite.rsvpUrl}"`);
+    expect(message.html).toContain("max-width:600px");
+    expect(message.html).toContain("role=\"presentation\"");
+    expect(message.html).toContain("apple-touch-icon");
+    expect(message.html).toContain("BroTime Poker Night");
+    expect(message.html).toContain("You’re receiving this because you were invited");
   });
 
   it("includes calendar and directions links when supplied", () => {
@@ -77,6 +83,19 @@ describe("invite delivery contracts", () => {
     expect(message.html).toContain("A &lt;Player&gt;");
     expect(message.html).toContain("Friday &amp; Saturday");
     expect(message.html).not.toContain("A <Player>");
+  });
+
+  it("supports future unsubscribe links and one-click headers", () => {
+    const message = buildPersonalizedInviteEmail({
+      ...invite,
+      unsubscribeUrl: "https://poker.skpfam.com/unsubscribe/example",
+    });
+    expect(message.html).toContain("Unsubscribe from BroTime Poker emails");
+    expect(message.text).toContain("Unsubscribe: https://poker.skpfam.com/unsubscribe/example");
+    expect(message.headers).toEqual({
+      "List-Unsubscribe": "<https://poker.skpfam.com/unsubscribe/example>",
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    });
   });
 
   it("keeps SMS concise while preserving the RSVP link", () => {


### PR DESCRIPTION
## What changed

- Replace plain RSVP email paragraphs with a branded, table-based HTML email capped at 600px.
- Add green felt and gold treatment, existing BroTime PNG logo, responsive mobile styles, bulletproof CTA, event details, calendar, directions, and private-link copy.
- Keep the matching plain-text fallback.
- Apply the same visual template to reminder and event-update emails.
- Add optional unsubscribe URL support with List-Unsubscribe and one-click headers.
- Add a standalone preview at docs/brotm-invite-email-preview.html and implementation notes at docs/EMAIL_TEMPLATE.md.

## Validation

- npm run check (41 tests passing)

## Follow-up

The email references /apple-touch-icon.png as an absolute HTTPS asset URL. Resend click tracking can rewrite the normal RSVP, calendar, and directions links; no tracking domain is hardcoded. A true unsubscribe endpoint is not yet implemented, so current sends use the organizer-contact fallback.