### PR TITLE
Fix blank app caused by stale service worker

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -21,5 +21,8 @@
 /manifest.webmanifest
   Cache-Control: public, max-age=3600
 
+/sw.js
+  Cache-Control: no-cache
+
 /api/*
   Cache-Control: no-store

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,7 @@
-const CACHE = "brotm-shell-v1";
-const SHELL = ["/", "/index.html", "/manifest.webmanifest", "/icon.svg", "/icon-1024.png", "/apple-touch-icon.png"];
+// Change the cache name whenever the HTML shell or its icon assets change.
+// This prevents an installed shortcut from keeping an old bundle reference.
+const CACHE = "brotm-shell-v3";
+const SHELL = ["/", "/index.html", "/manifest.webmanifest", "/icon.svg", "/apple-touch-icon-v3.png"];
 const API_PREFIXES = ["/api/", "/rsvp-api/", "/rsvp-admin-api/", "/ops-api/", "/money-api/"];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Root cause

Production was serving the old sw.js cache rotm-shell-v1, whose precache list referenced a nonexistent /icon-1024.png. Installed shortcuts could keep a stale index shell and blank after the deployment changed JavaScript bundle names.

## Fix

- Bump the service-worker cache to rotm-shell-v3.
- Remove the missing icon from the precache list and use /apple-touch-icon-v3.png.
- Mark /sw.js as 
o-cache so Cloudflare and installed browsers can activate the repair promptly.

## Validation

- npm run check (41 tests passing)

After deployment, reload the site. If the Home Screen shortcut remains blank, delete it and add it again.